### PR TITLE
CI: Fix mypy script reference to main branch

### DIFF
--- a/bin/run-mypy-on-modified-files.sh
+++ b/bin/run-mypy-on-modified-files.sh
@@ -9,5 +9,5 @@ cd "$(dirname "${0}")/.." || exit 1
 {
   git diff --name-only --diff-filter=d --relative ':(exclude)unit_tests'
   git diff --name-only --diff-filter=d --staged --relative ':(exclude)unit_tests'
-  git diff --name-only --diff-filter=d master... --relative ':(exclude)unit_tests'
+  git diff --name-only --diff-filter=d main... --relative ':(exclude)unit_tests'
 } | grep -E '\.py$' | sort | uniq | xargs mypy --config-file mypy.ini --install-types --non-interactive


### PR DESCRIPTION
Update the mypy script to reference the main branch instead of master for consistency with the repository's branch naming.