### PR TITLE
feat(airbyte-cdk): update datamodel_code_generator to `0.26.3`

### DIFF
--- a/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
+++ b/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
@@ -4,10 +4,9 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 
 from pydantic.v1 import BaseModel, Extra, Field
-from typing_extensions import Literal
 
 
 class AuthFlowType(Enum):
@@ -632,6 +631,7 @@ class HttpResponseFilter(BaseModel):
         description="Match the response if its HTTP code is included in this list.",
         examples=[[420, 429], [500]],
         title="HTTP Codes",
+        unique_items=True,
     )
     predicate: Optional[str] = Field(
         None,

--- a/bin/generate_component_manifest_files.py
+++ b/bin/generate_component_manifest_files.py
@@ -13,7 +13,7 @@ LOCAL_OUTPUT_DIR_PATH = "airbyte_cdk/sources/declarative/models"
 
 
 PIP_DEPENDENCIES = [
-    "datamodel_code_generator==0.11.19",
+    "datamodel_code_generator==0.26.3",
 ]
 
 
@@ -73,6 +73,8 @@ async def main():
                     "--enum-field-as-literal",
                     "one",
                     "--set-default-enum-member",
+                    "--use-double-quotes",
+                    "--remove-special-field-name-prefix",
                 ],
                 use_entrypoint=True,
             )


### PR DESCRIPTION
# What

use double-quotes during generation to align with linting rules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced type safety in data models with the addition of `Literal` types.
	- New `unique_items` attribute in `HttpResponseFilter` to enforce uniqueness of HTTP codes.
	- Added command-line options for improved output formatting in code generation.

- **Bug Fixes**
	- Refined formatting in generated Python files by removing underscores from parameter names.

- **Chores**
	- Updated `datamodel_code_generator` dependency to the latest version for improved functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->