### PR TITLE
ci: replace faker with hardcoded source

### DIFF
--- a/.github/workflows/connector-tests.yml
+++ b/.github/workflows/connector-tests.yml
@@ -70,8 +70,6 @@ jobs:
         include:
           - connector: source-hardcoded-records
             cdk_extra: n/a
-          - connector: source-faker
-            cdk_extra: n/a
           - connector: source-shopify
             cdk_extra: n/a
           # Currently not passing CI (unrelated)

--- a/.github/workflows/connector-tests.yml
+++ b/.github/workflows/connector-tests.yml
@@ -141,14 +141,16 @@ jobs:
           json_output_file=$(find airbyte/airbyte-ci/connectors/pipelines/pipeline_reports -name 'output.json' -print -quit)
           job_output=$(cat ${json_output_file})
           success=$(echo ${job_output} | jq -r '.success')
-          failed_jobs=$(echo ${job_output} | jq -r '.failed_steps')
+          failed_step=$(echo ${job_output} | jq -r '.failed_steps | select(length > 0) | .[0] // "None"')
           run_duration=$(echo ${job_output} | jq -r '.run_duration')
           echo "## Job Output for ${{matrix.connector}}" >> $GITHUB_STEP_SUMMARY
           echo "- Success: ${success}" >> $GITHUB_STEP_SUMMARY
           echo "- Test Duration: $(printf "%.0f" ${run_duration})s" >> $GITHUB_STEP_SUMMARY
-          echo "- Failed Checks: ${failed_jobs}" >> $GITHUB_STEP_SUMMARY
+          if [ "${success}" != "true" ]; then
+            echo "- Failed Step: ${failed_step}" >> $GITHUB_STEP_SUMMARY
+          fi
           echo -e "\n[Download Job Output](${{steps.upload_job_output.outputs.artifact-url}})" >> $GITHUB_STEP_SUMMARY
           if [ "${success}" != "true" ]; then
-            # Throw failure if tests failed
+            echo "::error::Test failed for connector '${{ matrix.connector }}' on step '${failed_step}'. Check the logs for more details."
             exit 1
           fi

--- a/.github/workflows/connector-tests.yml
+++ b/.github/workflows/connector-tests.yml
@@ -70,6 +70,8 @@ jobs:
         include:
           - connector: source-hardcoded-records
             cdk_extra: n/a
+          - connector: source-faker
+            cdk_extra: n/a
           - connector: source-shopify
             cdk_extra: n/a
           # Currently not passing CI (unrelated)

--- a/.github/workflows/connector-tests.yml
+++ b/.github/workflows/connector-tests.yml
@@ -68,7 +68,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - connector: source-faker
+          - connector: source-hardcoded-records
             cdk_extra: n/a
           - connector: source-shopify
             cdk_extra: n/a


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated the connector being tested in CI from `source-faker` to `source-hardcoded-records`.
	- Refined conditions for executing CI jobs based on detected changes in the Airbyte project.
	- Simplified output reporting by focusing on the first failed step in CI job results.
	- Maintained concurrency settings and job permissions for efficient CI processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->