### PR TITLE
ci: fix version ref in github publish action

### DIFF
--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -41,7 +41,7 @@ jobs:
           file_glob: true
 
       - name: Publish to PyPI (${{vars.PYPI_PUBLISH_URL}})
-        uses: pypa/gh-action-pypi-publish@v1
+        uses: pypa/gh-action-pypi-publish@v1.12.2
         with:
           # Can be toggled at the repository level between `https://upload.pypi.org/legacy/` and `https://test.pypi.org/legacy/`
           repository-url: ${{vars.PYPI_PUBLISH_URL}}


### PR DESCRIPTION
Resolves a problem created by dependabot here:

- https://github.com/airbytehq/airbyte-python-cdk/pull/4