### PR TITLE
fix(concurrent cursor): Ensure than when start and state are provided, sequential state value…

### DIFF
--- a/airbyte_cdk/sources/streams/concurrent/state_converters/datetime_stream_state_converter.py
+++ b/airbyte_cdk/sources/streams/concurrent/state_converters/datetime_stream_state_converter.py
@@ -82,7 +82,11 @@ class DateTimeStreamStateConverter(AbstractStreamStateConverter):
         # The start and end are the same to avoid confusion as to whether the records for this slice
         # were actually synced
         slices = [
-            {self.START_KEY: start if start is not None else sync_start, self.END_KEY: sync_start, self.MOST_RECENT_RECORD_KEY: sync_start}
+            {
+                self.START_KEY: start if start is not None else sync_start,
+                self.END_KEY: sync_start,
+                self.MOST_RECENT_RECORD_KEY: sync_start,
+            }
         ]
 
         return sync_start, {

--- a/airbyte_cdk/sources/streams/concurrent/state_converters/datetime_stream_state_converter.py
+++ b/airbyte_cdk/sources/streams/concurrent/state_converters/datetime_stream_state_converter.py
@@ -82,7 +82,7 @@ class DateTimeStreamStateConverter(AbstractStreamStateConverter):
         # The start and end are the same to avoid confusion as to whether the records for this slice
         # were actually synced
         slices = [
-            {self.START_KEY: start if start is not None else sync_start, self.END_KEY: sync_start}
+            {self.START_KEY: start if start is not None else sync_start, self.END_KEY: sync_start, self.MOST_RECENT_RECORD_KEY: sync_start}
         ]
 
         return sync_start, {

--- a/unit_tests/sources/declarative/parsers/test_model_to_component_factory.py
+++ b/unit_tests/sources/declarative/parsers/test_model_to_component_factory.py
@@ -3017,6 +3017,7 @@ def test_create_concurrent_cursor_from_datetime_based_cursor_all_fields(
                 {
                     "start": pendulum.parse(config["start_time"]),
                     "end": pendulum.parse(stream_state["updated_at"]),
+                    "most_recent_cursor_value": pendulum.parse(stream_state["updated_at"]),
                 },
             ],
             "state_type": "date-range",
@@ -3028,6 +3029,7 @@ def test_create_concurrent_cursor_from_datetime_based_cursor_all_fields(
                 {
                     "start": pendulum.parse(config["start_time"]),
                     "end": pendulum.parse(config["start_time"]),
+                    "most_recent_cursor_value": pendulum.parse(config["start_time"]),
                 },
             ],
             "state_type": "date-range",
@@ -3261,6 +3263,7 @@ def test_create_concurrent_cursor_uses_min_max_datetime_format_if_defined():
             {
                 "start": expected_start,
                 "end": expected_start,
+                "most_recent_cursor_value": expected_start,
             },
         ],
         "state_type": "date-range",

--- a/unit_tests/sources/streams/concurrent/test_cursor.py
+++ b/unit_tests/sources/streams/concurrent/test_cursor.py
@@ -64,7 +64,9 @@ class ConcurrentCursorStateTest(TestCase):
         self._message_repository = Mock(spec=MessageRepository)
         self._state_manager = Mock(spec=ConnectorStateManager)
 
-    def _cursor_with_slice_boundary_fields(self, is_sequential_state: bool = True) -> ConcurrentCursor:
+    def _cursor_with_slice_boundary_fields(
+        self, is_sequential_state: bool = True
+    ) -> ConcurrentCursor:
         return ConcurrentCursor(
             _A_STREAM_NAME,
             _A_STREAM_NAMESPACE,
@@ -128,7 +130,10 @@ class ConcurrentCursorStateTest(TestCase):
             _A_STREAM_NAME,
             _A_STREAM_NAMESPACE,
             {
-                "slices": [{"end": 0, "most_recent_cursor_value": 0, "start": 0}, {"end": 30, "start": 12}],
+                "slices": [
+                    {"end": 0, "most_recent_cursor_value": 0, "start": 0},
+                    {"end": 30, "start": 12},
+                ],
                 "state_type": "date-range",
             },
         )

--- a/unit_tests/sources/streams/concurrent/test_cursor.py
+++ b/unit_tests/sources/streams/concurrent/test_cursor.py
@@ -64,7 +64,7 @@ class ConcurrentCursorStateTest(TestCase):
         self._message_repository = Mock(spec=MessageRepository)
         self._state_manager = Mock(spec=ConnectorStateManager)
 
-    def _cursor_with_slice_boundary_fields(self, is_sequential_state=True) -> ConcurrentCursor:
+    def _cursor_with_slice_boundary_fields(self, is_sequential_state: bool = True) -> ConcurrentCursor:
         return ConcurrentCursor(
             _A_STREAM_NAME,
             _A_STREAM_NAMESPACE,
@@ -128,7 +128,7 @@ class ConcurrentCursorStateTest(TestCase):
             _A_STREAM_NAME,
             _A_STREAM_NAMESPACE,
             {
-                "slices": [{"end": 0, "start": 0}, {"end": 30, "start": 12}],
+                "slices": [{"end": 0, "most_recent_cursor_value": 0, "start": 0}, {"end": 30, "start": 12}],
                 "state_type": "date-range",
             },
         )
@@ -719,6 +719,39 @@ class ConcurrentCursorStateTest(TestCase):
         assert slices == [
             (datetime.fromtimestamp(0, timezone.utc), datetime.fromtimestamp(10, timezone.utc))
         ]
+
+    @freezegun.freeze_time(time_to_freeze=datetime.fromtimestamp(50, timezone.utc))
+    def test_given_initial_state_is_sequential_and_start_provided_when_generate_slices_then_state_emitted_is_initial_state(
+        self,
+    ) -> None:
+        cursor = ConcurrentCursor(
+            _A_STREAM_NAME,
+            _A_STREAM_NAMESPACE,
+            {_A_CURSOR_FIELD_KEY: 10},
+            self._message_repository,
+            self._state_manager,
+            EpochValueConcurrentStreamStateConverter(is_sequential_state=True),
+            CursorField(_A_CURSOR_FIELD_KEY),
+            _SLICE_BOUNDARY_FIELDS,
+            datetime.fromtimestamp(0, timezone.utc),
+            EpochValueConcurrentStreamStateConverter.get_end_provider(),
+            _NO_LOOKBACK_WINDOW,
+        )
+
+        # simulate the case where at least the first slice fails but others succeed
+        cursor.close_partition(
+            _partition(
+                {_LOWER_SLICE_BOUNDARY_FIELD: 40, _UPPER_SLICE_BOUNDARY_FIELD: 50},
+            )
+        )
+
+        self._state_manager.update_state_for_stream.assert_called_once_with(
+            _A_STREAM_NAME,
+            _A_STREAM_NAMESPACE,
+            {
+                _A_CURSOR_FIELD_KEY: 10
+            },  # State message is updated to the legacy format before being emitted
+        )
 
 
 @freezegun.freeze_time(time_to_freeze=datetime(2024, 4, 1, 0, 0, 0, 0, tzinfo=timezone.utc))


### PR DESCRIPTION
… is initial state if first slice is not closed

## What

In an attempt to make source-klaviyo concurrent, we have seen the state revert to the start of the stream.

Most reasonable hypothesis: there is a bug in our state migration logic from single value state to partitioned state that was introduced when we added the `most_recent_cursor_value` and the connector still hadn’t sync the first slice. Note that I’ll provide a fix for that shortly.

Why this is the most reasonable hypothesis: I can reproduce locally and will provide a fix for the case I can reproduce

Why I’m doubting just a smidge: It would mean that the first slice in October 2023 was still not processed. This is surprising because this is the first slice being produced and hence the first slice being allocated to a thread. Sure after that, the thread pool can decide never to pick this thread back up but it would be unlucky to say the least. This would also mean that all the previous attempt didn’t close a since slice as the issue mentioned above was present in other versions and [the state was never updated in the previous attempts](https://airbyte.metabaseapp.com/question?connection_ids=1b276f7d-358a-4fe3-a437-6747fd780eed#eyJkYXRhc2V0X3F1ZXJ5Ijp7Im5hdGl2ZSI6eyJ0ZW1wbGF0ZS10YWdzIjp7ImNvbm5lY3Rpb25faWRzIjp7ImlkIjoiZDExNmMxOTctYzkwNy1iNWZkLTI4ZGEtNTMzMGUyNmE1YmU2IiwibmFtZSI6ImNvbm5lY3Rpb25faWRzIiwiZGlzcGxheS1uYW1lIjoiQ29ubmVjdGlvbiIsInR5cGUiOiJkaW1lbnNpb24iLCJkaW1lbnNpb24iOlsiZmllbGQiLDIwNDQyNyxudWxsXSwid2lkZ2V0LXR5cGUiOiJzdHJpbmcvPSIsInJlcXVpcmVkIjp0cnVlLCJkZWZhdWx0IjpbIjZmY2FiM2M0LTM5YmItNDljNy04ZGM1LTYwMmI2N2U0OWRjYSIsImIzOGIzOWFhLWU5MjgtNDhmYS05MTZjLTY2ZTJjMjc1MzBjZiIsImNhZTk2ZGQ3LWRmYjQtNGQ2ZC1iNDY0LWM1ZmY3MzQ2YzcyMSJdfX0sInF1ZXJ5IjoiXG5zZWxlY3QgYXR0ZW1wdHMuY3JlYXRlZF9hdCxcbiAgam9icy5zY29wZSBhcyBjb25uZWN0aW9uX2lkLFxuICBhdHRlbXB0X3N5bmNfY29uZmlnIC0-ICdzdGF0ZScgLT4gJ3N0YXRlJyBhcyBzdGF0ZVxuZnJvbSBhdHRlbXB0c1xuaW5uZXIgam9pbiBqb2JzIG9uIGpvYnMuaWQgPSBhdHRlbXB0cy5qb2JfaWRcbndoZXJlXG4gIHt7Y29ubmVjdGlvbl9pZHN9fVxub3JkZXIgYnkgam9icy5zY29wZSwgYXR0ZW1wdHMuY3JlYXRlZF9hdCBkZXNjIn0sImRhdGFiYXNlIjo3MiwidHlwZSI6Im5hdGl2ZSJ9LCJkaXNwbGF5IjoidGFibGUiLCJkaXNwbGF5SXNMb2NrZWQiOnRydWUsInBhcmFtZXRlcnMiOlt7ImlkIjoiZDExNmMxOTctYzkwNy1iNWZkLTI4ZGEtNTMzMGUyNmE1YmU2IiwidHlwZSI6InN0cmluZy89IiwidGFyZ2V0IjpbImRpbWVuc2lvbiIsWyJ0ZW1wbGF0ZS10YWciLCJjb25uZWN0aW9uX2lkcyJdXSwibmFtZSI6IkNvbm5lY3Rpb24iLCJzbHVnIjoiY29ubmVjdGlvbl9pZHMiLCJkZWZhdWx0IjpbIjZmY2FiM2M0LTM5YmItNDljNy04ZGM1LTYwMmI2N2U0OWRjYSIsImIzOGIzOWFhLWU5MjgtNDhmYS05MTZjLTY2ZTJjMjc1MzBjZiIsImNhZTk2ZGQ3LWRmYjQtNGQ2ZC1iNDY0LWM1ZmY3MzQ2YzcyMSJdLCJyZXF1aXJlZCI6dHJ1ZX1dLCJ2aXN1YWxpemF0aW9uX3NldHRpbmdzIjp7InRhYmxlLnBpdm90X2NvbHVtbiI6ImNvbm5lY3Rpb25faWQiLCJ0YWJsZS5jZWxsX2NvbHVtbiI6ImNyZWF0ZWRfYXQiLCJ0YWJsZS5jb2x1bW5fd2lkdGhzIjpbbnVsbCxudWxsLDE1NzZdfSwib3JpZ2luYWxfY2FyZF9pZCI6NzE4OCwidHlwZSI6InF1ZXN0aW9uIn0=)). I’ve tested locally that the first slice is closed with at least one record emitted and this case is behaving fine.

For more information: https://airbytehq-team.slack.com/archives/C07V1RTCRV2/p1731595468942439?thread_ts=1730912193.745319&cid=C07V1RTCRV2

## How

By ensuring that if there is a `start` that is different from the `end` when creating a cursor, that we set the `most_recent_cursor_value` to the same value as `end`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced state management for cursors by including the most recent record's timestamp in state messages.
	- Improved error handling and configuration validation in the test suite for various components.

- **Bug Fixes**
	- Updated tests to ensure correct behavior of cursors and state management under different configurations.

- **Tests**
	- Added multiple new test cases to validate the behavior of components and their interactions with state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->