### PR TITLE
ci: disable SDM publish step

### DIFF
--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -60,80 +60,80 @@ jobs:
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@v1.10.3
 
-  publish_sdm:
-    name: Publish SDM to DockerHub
-    if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
-    needs: [publish]
-    environment:
-      name: DockerHub
-      url: https://hub.docker.com/r/airbyte/source-declarative-manifest/tags
+  # publish_sdm:
+  #   name: Publish SDM to DockerHub
+  #   if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
+  #   runs-on: ubuntu-latest
+  #   needs: [publish]
+  #   environment:
+  #     name: DockerHub
+  #     url: https://hub.docker.com/r/airbyte/source-declarative-manifest/tags
 
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #       with:
+  #         fetch-depth: 0
 
-      - name: Set Version (workflow_dispatch)
-        if: github.event_name == 'workflow_dispatch'
-        run: |
-          VERSION=${{ github.event.inputs.version }}
-          echo "Version input set to '${VERSION}'"
-          # Remove the 'v' prefix if it exists
-          VERSION=${VERSION#v}
-          echo "Setting version to '$VERSION'"
-          echo "VERSION=${VERSION}" >> $GITHUB_ENV
+  #     - name: Set Version (workflow_dispatch)
+  #       if: github.event_name == 'workflow_dispatch'
+  #       run: |
+  #         VERSION=${{ github.event.inputs.version }}
+  #         echo "Version input set to '${VERSION}'"
+  #         # Remove the 'v' prefix if it exists
+  #         VERSION=${VERSION#v}
+  #         echo "Setting version to '$VERSION'"
+  #         echo "VERSION=${VERSION}" >> $GITHUB_ENV
 
-      - name: Set Version (tag)
-        if: startsWith(github.ref, 'refs/tags/v')
-        run: |
-          VERSION=${{ github.ref_name }}
-          echo "Version ref set to '${VERSION}'"
-          # Remove the 'v' prefix if it exists
-          VERSION=${VERSION#v}
-          echo "Setting version to '$VERSION'"
-          echo "VERSION=${VERSION}" >> $GITHUB_ENV
+  #     - name: Set Version (tag)
+  #       if: startsWith(github.ref, 'refs/tags/v')
+  #       run: |
+  #         VERSION=${{ github.ref_name }}
+  #         echo "Version ref set to '${VERSION}'"
+  #         # Remove the 'v' prefix if it exists
+  #         VERSION=${VERSION#v}
+  #         echo "Setting version to '$VERSION'"
+  #         echo "VERSION=${VERSION}" >> $GITHUB_ENV
 
-      # We need to download the build artifact again because the previous job was on a different runner
-      - name: Download Build Artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: Packages-${{ github.run_id }}
-          path: dist
+  #     # We need to download the build artifact again because the previous job was on a different runner
+  #     - name: Download Build Artifact
+  #       uses: actions/download-artifact@v4
+  #       with:
+  #         name: Packages-${{ github.run_id }}
+  #         path: dist
 
-      - name: Set up QEMU for multi-platform builds
-        uses: docker/setup-qemu-action@v3
+  #     - name: Set up QEMU for multi-platform builds
+  #       uses: docker/setup-qemu-action@v3
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+  #     - name: Set up Docker Buildx
+  #       uses: docker/setup-buildx-action@v3
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v3
+  #       with:
+  #         username: ${{ secrets.DOCKER_HUB_USERNAME }}
+  #         password: ${{ secrets.DOCKER_HUB_PASSWORD }}
 
-      - name: Check for existing tag
-        run: |
-          tag="airbyte/source-declarative-manifest:${{ env.VERSION }}"
-          if [ -z "$tag" ]; then
-            echo "Error: VERSION is not set. Ensure the tag follows the format 'refs/tags/vX.Y.Z'."
-            exit 1
-          fi
-          echo "Checking if tag '$tag' exists on DockerHub..."
-          if DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect "$tag" > /dev/null 2>&1; then
-            echo "The tag '$tag' already exists on DockerHub. Skipping publish to prevent overwrite."
-            exit 1
-          fi
-          echo "No existing tag '$tag' found. Proceeding with publish."
+  #     - name: Check for existing tag
+  #       run: |
+  #         tag="airbyte/source-declarative-manifest:${{ env.VERSION }}"
+  #         if [ -z "$tag" ]; then
+  #           echo "Error: VERSION is not set. Ensure the tag follows the format 'refs/tags/vX.Y.Z'."
+  #           exit 1
+  #         fi
+  #         echo "Checking if tag '$tag' exists on DockerHub..."
+  #         if DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect "$tag" > /dev/null 2>&1; then
+  #           echo "The tag '$tag' already exists on DockerHub. Skipping publish to prevent overwrite."
+  #           exit 1
+  #         fi
+  #         echo "No existing tag '$tag' found. Proceeding with publish."
 
-      - name: Build and push
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: |
-            airbyte/source-declarative-manifest:latest
-            airbyte/source-declarative-manifest:${{ env.VERSION }}
-            airbyte/source-declarative-manifest:${{ github.sha }}
+  #     - name: Build and push
+  #       uses: docker/build-push-action@v5
+  #       with:
+  #         context: .
+  #         platforms: linux/amd64,linux/arm64
+  #         push: true
+  #         tags: |
+  #           airbyte/source-declarative-manifest:latest
+  #           airbyte/source-declarative-manifest:${{ env.VERSION }}
+  #           airbyte/source-declarative-manifest:${{ github.sha }}


### PR DESCRIPTION
The SDM image published from this repo was automatically picked up and run in production. It caused an outage of Builder-created connectors. This PR disables auto-publish until we can diagnose the issue and until we have sufficient tests to ensure stability.

Related:

- TBD: Shouldn't Builder wait for this signal before picking up new versions of the CDK?: https://github.com/airbytehq/airbyte-python-cdk/issues/79

Regarding tests needed:
- https://github.com/airbytehq/airbyte-python-cdk/issues/66
- https://github.com/airbytehq/airbyte-python-cdk/issues/64