### PR TITLE
CI: Follow-up PR for SDM workflow

### DIFF
--- a/.github/workflows/publish_sdm_connector.yml
+++ b/.github/workflows/publish_sdm_connector.yml
@@ -78,11 +78,11 @@ jobs:
           fetch-depth: 0
 
       - uses: hynek/build-and-inspect-python-package@v2
-        name: Build package with version ref '${{ env.VERSION }}'
+        name: Build package with version ref '${{ env.VERSION || '0.0.0dev0' }}'
         env:
           # Pass in the evaluated version from the previous step
           # More info: https://github.com/mtkennerly/poetry-dynamic-versioning#user-content-environment-variables
-          POETRY_DYNAMIC_VERSIONING_BYPASS: ${{ env.VERSION }}
+          POETRY_DYNAMIC_VERSIONING_BYPASS: ${{ env.VERSION || '0.0.0dev0'}}
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/publish_sdm_connector.yml
+++ b/.github/workflows/publish_sdm_connector.yml
@@ -44,7 +44,7 @@ jobs:
           # Exit with success if both detected and input versions are empty
           if [ -z "${DETECTED_VERSION:-}" ] && [ -z "${INPUT_VERSION:-}" ]; then
             echo "No version detected or input. Will publish to SHA tag instead."
-            echo 'VERSION=""' >> $GITHUB_ENV
+            echo 'VERSION=' >> $GITHUB_ENV
             exit 0
           fi
           # Remove the 'v' prefix if it exists


### PR DESCRIPTION
Creating this PR to fix any issues and follow-up from:

- #83

Manual tests confirmed:

- [x] Triggering with 'dry_run' checked correctly validates and prints versions, then builds the package but _does not_ publish to DockerHub: https://github.com/airbytehq/airbyte-python-cdk/actions/runs/11979788484/job/33402736539
- [x] Triggering from an already-created release tag and no other inputs successfully detects version and publishes the image: https://github.com/airbytehq/airbyte-python-cdk/actions/runs/11979864474/job/33402936116
  - [x] When triggered from pre-release release tag, the "latest" tag is not pushed to dockerhub.
- [x] Triggering workflow on a branch (not a release tag) and with an explicit version input tag: successfully publishes the requested tag to DockerHub: https://github.com/airbytehq/airbyte-python-cdk/actions/runs/11979951523/job/33403248419

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced version handling for the Source-Declarative-Manifest (SDM) connector during DockerHub publishing.
	- Introduced default versioning to streamline the build process.

- **Bug Fixes**
	- Improved validation logic for version settings to ensure successful workflow exits under specific conditions.

- **Chores**
	- Updated conditions for checking existing tags and building Docker images to enhance reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->