### PR TITLE
Feat: destination vector db add option for embedding without field names

### DIFF
--- a/airbyte_cdk/destinations/vector_db_based/config.py
+++ b/airbyte_cdk/destinations/vector_db_based/config.py
@@ -108,6 +108,12 @@ class ProcessingConfigModel(BaseModel):
         always_show=True,
         examples=["text", "user.name", "users.*.name"],
     )
+    omit_field_names_from_embeddings: bool = Field(
+        default=False,
+        title="Omit field names from embeddings",
+        description="Do not include the field names in the text that gets embedded. By default field names are embedded e.g 'user: name, user.email: email@email.com'. If set to true, only the values are embedded e.g. 'name, email@email.com'.",
+        always_show=True,
+    )
     metadata_fields: Optional[List[str]] = Field(
         default=[],
         title="Fields to store as metadata",

--- a/airbyte_cdk/destinations/vector_db_based/document_processor.py
+++ b/airbyte_cdk/destinations/vector_db_based/document_processor.py
@@ -125,6 +125,7 @@ class DocumentProcessor:
         self.text_fields = config.text_fields
         self.metadata_fields = config.metadata_fields
         self.field_name_mappings = config.field_name_mappings
+        self.omit_field_names_from_embeddings = config.omit_field_names_from_embeddings
         self.logger = logging.getLogger("airbyte.document_processor")
 
     def process(self, record: AirbyteRecordMessage) -> Tuple[List[Chunk], Optional[str]]:
@@ -162,7 +163,12 @@ class DocumentProcessor:
         relevant_fields = self._extract_relevant_fields(record, self.text_fields)
         if len(relevant_fields) == 0:
             return None
-        text = stringify_dict(relevant_fields)
+        if self.omit_field_names_from_embeddings == False:
+            text = stringify_dict(relevant_fields)
+        else:
+            text = ""
+            for key, value in relevant_fields.items():
+                text += f"{value}\n"
         metadata = self._extract_metadata(record)
         return Document(page_content=text, metadata=metadata)
 

--- a/airbyte_cdk/destinations/vector_db_based/document_processor.py
+++ b/airbyte_cdk/destinations/vector_db_based/document_processor.py
@@ -166,11 +166,17 @@ class DocumentProcessor:
         if self.omit_field_names_from_embeddings == False:
             text = stringify_dict(relevant_fields)
         else:
-            text = ""
-            for key, value in relevant_fields.items():
-                text += f"{value}\n"
+            text = self._extract_values_from_dict(relevant_fields)
         metadata = self._extract_metadata(record)
         return Document(page_content=text, metadata=metadata)
+
+    def _extract_values_from_dict(self, data):
+        if isinstance(data, dict):
+            return "\n".join(self._extract_values_from_dict(value) for value in data.values())
+        elif isinstance(data, list):
+            return "\n".join(self._extract_values_from_dict(item) for item in data)
+        else:
+            return str(data)
 
     def _extract_relevant_fields(
         self, record: AirbyteRecordMessage, fields: Optional[List[str]]

--- a/unit_tests/destinations/vector_db_based/config_test.py
+++ b/unit_tests/destinations/vector_db_based/config_test.py
@@ -242,6 +242,13 @@ def test_json_schema_generation():
                         "type": "array",
                         "items": {"type": "string"},
                     },
+                    "omit_field_names_from_embeddings": {
+                        "title": "Omit field names from embeddings",
+                        "description": "Do not include the field names in the text that gets embedded. By default field names are embedded e.g 'user: name, user.email: email@email.com'. If set to true, only the values are embedded e.g. 'name, email@email.com'.",
+                        "default": False,
+                        "always_show": True,
+                        "type": "boolean",
+                    },
                     "metadata_fields": {
                         "title": "Fields to store as metadata",
                         "description": "List of fields in the record that should be stored as metadata. The field list is applied to all streams in the same way and non-existing fields are ignored. If none are defined, all fields are considered metadata fields. When specifying text fields, you can access nested fields in the record by using dot notation, e.g. `user.name` will access the `name` field in the `user` object. It's also possible to use wildcards to access all fields in an object, e.g. `users.*.name` will access all `names` fields in all entries of the `users` array. When specifying nested paths, all matching values are flattened into an array set to a field named by the path.",


### PR DESCRIPTION
### Description
Responding to issue [#48627](https://github.com/airbytehq/airbyte/issues/48627#issue-2684912914)

Including field names when embedding text changes the semantic meaning of a vector, so it is useful to have the option of embedding only the text without the field names.

This is my first contribution, so please let me know what else is needed!

### Changes
Adds an additional config to allow user to choose whether or not to embed field names with a vector db destination.