### PR TITLE
feat(concurrent): [ISSUE #10550] do not raise when record does not have cursor value in…

### DIFF
--- a/airbyte_cdk/sources/streams/concurrent/cursor.py
+++ b/airbyte_cdk/sources/streams/concurrent/cursor.py
@@ -186,7 +186,9 @@ class ConcurrentCursor(Cursor):
         self.start, self._concurrent_state = self._get_concurrent_state(stream_state)
         self._lookback_window = lookback_window
         self._slice_range = slice_range
-        self._most_recent_cursor_value_per_partition: MutableMapping[Union[StreamSlice, Mapping[str, Any], None], Any] = {}
+        self._most_recent_cursor_value_per_partition: MutableMapping[
+            Union[StreamSlice, Mapping[str, Any], None], Any
+        ] = {}
         self._has_closed_at_least_one_slice = False
         self._cursor_granularity = cursor_granularity
         # Flag to track if the logger has been triggered (per stream)

--- a/airbyte_cdk/sources/streams/concurrent/cursor.py
+++ b/airbyte_cdk/sources/streams/concurrent/cursor.py
@@ -5,7 +5,18 @@
 import functools
 import logging
 from abc import ABC, abstractmethod
-from typing import Any, Callable, Iterable, List, Mapping, MutableMapping, Optional, Protocol, Tuple
+from typing import (
+    Any,
+    Callable,
+    Iterable,
+    List,
+    Mapping,
+    MutableMapping,
+    Optional,
+    Protocol,
+    Tuple,
+    Union,
+)
 
 from airbyte_cdk.sources.connector_state_manager import ConnectorStateManager
 from airbyte_cdk.sources.message import MessageRepository
@@ -175,7 +186,7 @@ class ConcurrentCursor(Cursor):
         self.start, self._concurrent_state = self._get_concurrent_state(stream_state)
         self._lookback_window = lookback_window
         self._slice_range = slice_range
-        self._most_recent_cursor_value_per_partition: MutableMapping[StreamSlice, Any] = {}
+        self._most_recent_cursor_value_per_partition: MutableMapping[Union[StreamSlice, Mapping[str, Any], None], Any] = {}
         self._has_closed_at_least_one_slice = False
         self._cursor_granularity = cursor_granularity
         # Flag to track if the logger has been triggered (per stream)

--- a/unit_tests/sources/streams/concurrent/test_cursor.py
+++ b/unit_tests/sources/streams/concurrent/test_cursor.py
@@ -101,6 +101,20 @@ class ConcurrentCursorStateTest(TestCase):
             _NO_LOOKBACK_WINDOW,
         )
 
+    def test_given_no_cursor_value_when_observe_then_do_not_raise(self) -> None:
+        cursor = self._cursor_with_slice_boundary_fields()
+        partition = _partition(_NO_SLICE)
+
+        cursor.observe(
+            Record(
+                data={"record_with_A_CURSOR_FIELD_KEY": "any value"},
+                associated_slice=partition.to_slice(),
+                stream_name=_A_STREAM_NAME,
+            )
+        )
+
+        # did not raise
+
     def test_given_boundary_fields_when_close_partition_then_emit_state(self) -> None:
         cursor = self._cursor_with_slice_boundary_fields()
         cursor.close_partition(


### PR DESCRIPTION
… concurrent cursor

## What

Following https://github.com/airbytehq/airbyte-internal-issues/issues/10550 change on source-pipedrive, we have seen issues when the cursor field was not provided. 

For now, we will assume that we need to sync those records but they won't influence the `most_recent_cursor_value`

## How
By not raising if the cursor value is not provided


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved error handling and logging for cursor value extraction in the `ConcurrentCursor` class.

- **Bug Fixes**
	- Enhanced stability by ensuring that the system does not raise exceptions when no cursor value is present.

- **Tests**
	- Added a new test to verify that the `observe` method behaves correctly when no cursor value is provided, along with updates to existing tests for comprehensive coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->