### PR TITLE
ci: run airbyte connector tests from master branch

### DIFF
--- a/.github/workflows/connector-tests.yml
+++ b/.github/workflows/connector-tests.yml
@@ -74,6 +74,8 @@ jobs:
             cdk_extra: n/a
           - connector: source-chargebee
             cdk_extra: n/a
+          - connector: source-zendesk-support
+            cdk_extra: n/a
           - connector: source-s3
             cdk_extra: file-based
           - connector: destination-pinecone

--- a/.github/workflows/connector-tests.yml
+++ b/.github/workflows/connector-tests.yml
@@ -74,16 +74,18 @@ jobs:
             cdk_extra: n/a
           - connector: source-chargebee
             cdk_extra: n/a
-          - connector: source-zendesk-support
-            cdk_extra: n/a
           - connector: source-s3
             cdk_extra: file-based
           - connector: destination-pinecone
             cdk_extra: vector-db-based
           - connector: destination-motherduck
             cdk_extra: sql
-          # # TODO: These are manifest connectors and won't work as expected until we
-          # #       add `--use-local-cdk` support for manifest connectors.
+          # ZenDesk currently failing (as of 2024-12-02)
+          # TODO: Re-enable once fixed
+          # - connector: source-zendesk-support
+          #   cdk_extra: n/a
+          # TODO: These are manifest connectors and won't work as expected until we
+          #       add `--use-local-cdk` support for manifest connectors.
           # - connector: source-the-guardian-api
           #   cdk_extra: n/a
           # - connector: source-pokeapi

--- a/.github/workflows/connector-tests.yml
+++ b/.github/workflows/connector-tests.yml
@@ -74,21 +74,18 @@ jobs:
             cdk_extra: n/a
           - connector: source-chargebee
             cdk_extra: n/a
-          # Currently not passing CI (unrelated)
-          # - connector: source-zendesk-support
-          #   cdk_extra: n/a
           - connector: source-s3
             cdk_extra: file-based
           - connector: destination-pinecone
             cdk_extra: vector-db-based
           - connector: destination-motherduck
             cdk_extra: sql
-          # TODO: These are manifest connectors and won't work as expected until we
-          #       add `--use-local-cdk` support for manifest connectors.
-          - connector: source-the-guardian-api
-            cdk_extra: n/a
-          - connector: source-pokeapi
-            cdk_extra: n/a
+          # # TODO: These are manifest connectors and won't work as expected until we
+          # #       add `--use-local-cdk` support for manifest connectors.
+          # - connector: source-the-guardian-api
+          #   cdk_extra: n/a
+          # - connector: source-pokeapi
+          #   cdk_extra: n/a
 
     name: "Check: '${{matrix.connector}}' (skip=${{needs.cdk_changes.outputs[matrix.cdk_extra] == 'false'}})"
     steps:
@@ -112,8 +109,7 @@ jobs:
         if: steps.no_changes.outputs.status != 'cancelled'
         with:
           repository: airbytehq/airbyte
-          # TODO: Revert to `master` after Airbyte CI released:
-          ref: aj/airbyte-ci/update-python-local-cdk-code
+          ref: master
           path: airbyte
       - name: Test Connector
         if: steps.no_changes.outputs.status != 'cancelled'


### PR DESCRIPTION
This reverts a previous change that pulled airbyte-ci and connector images from a fixed branch where we were iterating on airbyte-ci improvements.

After this change:
- All connector definitions in the "Test Connectors" workflow will be pulled from `master` branch on the monorepo.
- Manifest-only connectors (PokeAPI and The Guardian) are removed from the matrix since they otherwise would represent a false positive success. The work to enable them again is logged here:
  - https://github.com/airbytehq/airbyte-python-cdk/issues/64

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated workflow configuration for testing connectors to enhance clarity and functionality.
	- Improved comments regarding filters and job cancellation logic.
	- Refined connector references for better readability without altering functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->