### PR TITLE
ci: Don't bump Connector Builder to prerelease CDK versions

### DIFF
--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -115,7 +115,13 @@ jobs:
     environment:
       name: PyPi
       url: https://pypi.org/p/airbyte-cdk/
-    if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) || (github.event_name == 'workflow_dispatch' && (github.event.inputs.publish_to_pypi == 'true' || github.event.inputs.update_connector_builder == 'true'))
+    if: >
+      (github.event_name == 'push' &&
+       startsWith(github.ref, 'refs/tags/v')) ||
+      (github.event_name == 'workflow_dispatch' &&
+       (github.event.inputs.publish_to_pypi == 'true' ||
+        github.event.inputs.update_connector_builder == 'true'
+      ))
     env:
       VERSION: ${{ needs.build.outputs.VERSION }}
       IS_PRERELEASE: ${{ needs.build.outputs.IS_PRERELEASE }}
@@ -136,7 +142,10 @@ jobs:
           file_glob: true
 
       - name: Publish to PyPI
-        if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) || github.event.inputs.publish_to_pypi == 'true'
+        if: >
+          (github.event_name == 'push' &&
+           startsWith(github.ref, 'refs/tags/v')
+          ) || github.event.inputs.publish_to_pypi == 'true'
         uses: pypa/gh-action-pypi-publish@v1.10.3
 
   publish_sdm:
@@ -145,7 +154,10 @@ jobs:
     #         (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) ||
     # Until then, this workflow needs to be kicked off manually.
     # Last remaining blocker documented here: https://github.com/airbytehq/airbyte-python-cdk/issues/64
-    if: (github.event_name == 'workflow_dispatch' && github.event.inputs.publish_to_dockerhub == 'true')
+    if: >
+      (github.event_name == 'workflow_dispatch' &&
+       github.event.inputs.publish_to_dockerhub == 'true'
+      )
     runs-on: ubuntu-latest
     needs: [build]
     environment:
@@ -234,7 +246,12 @@ jobs:
     needs:
       - build
       - publish_cdk
-    if: (github.event_name == 'push' && ${{ needs.build.outputs.IS_PRERELEASE == 'false' }} && startsWith(github.ref, 'refs/tags/v')) || (github.event_name == 'workflow_dispatch' && github.event.inputs.update_connector_builder == 'true')
+    if: >
+      (github.event_name == 'push' &&
+       needs.build.outputs.IS_PRERELEASE == 'false' &&
+       startsWith(github.ref, 'refs/tags/v')) ||
+      (github.event_name == 'workflow_dispatch' &&
+       github.event.inputs.update_connector_builder == 'true')
     env:
       VERSION: ${{ needs.build.outputs.VERSION }}
       IS_PRERELEASE: ${{ needs.build.outputs.IS_PRERELEASE }}

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -234,7 +234,7 @@ jobs:
     needs:
       - build
       - publish_cdk
-    if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) || (github.event_name == 'workflow_dispatch' && github.event.inputs.update_connector_builder == 'true')
+    if: (github.event_name == 'push' && ${{ needs.build.outputs.IS_PRERELEASE == 'false' }} && startsWith(github.ref, 'refs/tags/v')) || (github.event_name == 'workflow_dispatch' && github.event.inputs.update_connector_builder == 'true')
     env:
       VERSION: ${{ needs.build.outputs.VERSION }}
       IS_PRERELEASE: ${{ needs.build.outputs.IS_PRERELEASE }}

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -243,6 +243,9 @@ jobs:
     # Create a PR against the Builder, to update the CDK version that it uses.
     # In the future, Builder may use the SDM docker image instead of the Python CDK package.
     name: Bump Connector Builder CDK version
+    environment:
+      name: Connector Builder
+      url: https://github.com/airbytehq/airbyte-platform-internal/pulls?q=is%3Apr+automatic-cdk-release+
     needs:
       - build
       - publish_cdk


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Improved workflow conditions for the Connector Builder update to ensure it only runs for stable releases.
	- Enhanced version detection and validation steps for better control over the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->