### PR TITLE
ci: auto-publish sdm for each release

### DIFF
--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -150,11 +150,9 @@ jobs:
 
   publish_sdm:
     name: Publish SDM to DockerHub
-    # TODO: When we're ready to publish after each release, prefix the `if` below with:
-    #         (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) ||
-    # Until then, this workflow needs to be kicked off manually.
-    # Last remaining blocker documented here: https://github.com/airbytehq/airbyte-python-cdk/issues/64
     if: >
+      (github.event_name == 'push' &&
+       startsWith(github.ref, 'refs/tags/v')) ||
       (github.event_name == 'workflow_dispatch' &&
        github.event.inputs.publish_to_dockerhub == 'true'
       )


### PR DESCRIPTION
Originally I had wanted to wait for:

- #64 

This PR enables auto-release anyway, on the basis that if Builder adopts the CDK version before Platform does, it _also_ creates an outage.