### PR TITLE
fix(concurrent-cdk): Move the grouping of concurrent and synchronous streams into the read and discover commands instead of when initializing the source

### DIFF
--- a/unit_tests/sources/declarative/decoders/test_json_decoder.py
+++ b/unit_tests/sources/declarative/decoders/test_json_decoder.py
@@ -54,7 +54,7 @@ def test_jsonl_decoder(requests_mock, response_body, expected_json):
 def large_event_response_fixture():
     data = {"email": "email1@example.com"}
     jsonl_string = f"{json.dumps(data)}\n"
-    lines_in_response = 2  # ≈ 58 MB of response
+    lines_in_response = 2_000_000  # ≈ 58 MB of response
     dir_path = os.path.dirname(os.path.realpath(__file__))
     file_path = f"{dir_path}/test_response.txt"
     with open(file_path, "w") as file:


### PR DESCRIPTION
## Problem

We've seen a number of issues crop up due to the fact that in low-code sources, we instantiate the streams within the source's `__init__()` method. It also created issues for config migrations because we would instantiate a source's streams using an unmigrated config which might fail validations earlier than originally expected

## Solution

This PR moves the logic of grouping and creating streams back into the `read()` and `discover()` where errors will properly be surfaced where the used to be prior to moving to the concurrent CDK.

todo :

- [x] unit tests passing
- [x] retest locally on asana or other manifest-only source with an invalid config which would not properly surface check failed message

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced handling of concurrent and synchronous streams in data processing.
	- Simplified state management in the `ConcurrentDeclarativeSource` class.

- **Bug Fixes**
	- Improved test coverage for JSON and JSONL decoders with larger datasets.

- **Tests**
	- Updated tests for `ConcurrentDeclarativeSource` to align with new stream grouping logic.
	- Increased line count in test responses to better simulate larger datasets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->