### PR TITLE
ci: fix CI reports not uploading

### DIFF
--- a/.github/workflows/connector-tests.yml
+++ b/.github/workflows/connector-tests.yml
@@ -177,14 +177,3 @@ jobs:
         with:
           name: ${{matrix.connector}}-job-output
           path: airbyte/airbyte-ci/connectors/pipelines/pipeline_reports
-
-      - name: Override Details URL for GitHub Check Run
-        if: steps.evaluate_output.outputs.html_report_url != ''
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh api \
-            -X PATCH \
-            -H "Accept: application/vnd.github.v3+json" \
-            "/repos/${{ github.repository }}/check-runs/${{ github.run_id }}" \
-            -f details_url="${{ steps.evaluate_output.outputs.html_report_url }}"

--- a/.github/workflows/connector-tests.yml
+++ b/.github/workflows/connector-tests.yml
@@ -119,7 +119,7 @@ jobs:
         if: steps.no_changes.outputs.status != 'cancelled'
         with:
           repository: airbytehq/airbyte
-          ref: master
+          ref: aj/airbyte-ci/allow-report-uploads-with-fewer-permissions
           path: airbyte
       - name: Test Connector
         if: steps.no_changes.outputs.status != 'cancelled'
@@ -131,6 +131,7 @@ jobs:
         run: |
           cd airbyte
           make tools.airbyte-ci-dev.install
+          --ci-report-bucket-name=airbyte-ci-reports-multi
           airbyte-ci-dev connectors \
           --name ${{matrix.connector}} \
           --use-local-cdk \

--- a/.github/workflows/connector-tests.yml
+++ b/.github/workflows/connector-tests.yml
@@ -121,7 +121,7 @@ jobs:
         if: steps.no_changes.outputs.status != 'cancelled'
         with:
           repository: airbytehq/airbyte
-          ref: aj/airbyte-ci/allow-report-uploads-with-fewer-permissions
+          ref: master
           path: airbyte
       - name: Test Connector
         if: steps.no_changes.outputs.status != 'cancelled'

--- a/.github/workflows/connector-tests.yml
+++ b/.github/workflows/connector-tests.yml
@@ -131,8 +131,9 @@ jobs:
         run: |
           cd airbyte
           make tools.airbyte-ci-dev.install
-          --ci-report-bucket-name=airbyte-ci-reports-multi
-          airbyte-ci-dev connectors \
+          airbyte-ci-dev \
+          --ci-report-bucket-name=airbyte-ci-reports-multi \
+          connectors \
           --name ${{matrix.connector}} \
           --use-local-cdk \
           test \

--- a/.github/workflows/connector-tests.yml
+++ b/.github/workflows/connector-tests.yml
@@ -94,6 +94,8 @@ jobs:
           #   cdk_extra: n/a
 
     name: "Check: '${{matrix.connector}}' (skip=${{needs.cdk_changes.outputs['src'] == 'false' || needs.cdk_changes.outputs[matrix.cdk_extra] == 'false'}})"
+    permissions:
+      checks: write
     steps:
       - name: Abort if extra not changed (${{matrix.cdk_extra}})
         id: no_changes
@@ -141,7 +143,8 @@ jobs:
           --skip-step qa_checks \
           --skip-step connector_live_tests
 
-      - name: Evaluate Test Output
+      - name: Evaluate Test
+        id: evaluate_output
         if: always() && steps.no_changes.outputs.status != 'cancelled'
         run: |
           # save job output json file as ci step output
@@ -150,7 +153,9 @@ jobs:
           success=$(echo ${job_output} | jq -r '.success')
           failed_step=$(echo ${job_output} | jq -r '.failed_steps | select(length > 0) | .[0] // "None"')
           run_duration=$(echo ${job_output} | jq -r '.run_duration')
+          html_report_url=$(echo ${job_output} | jq -r '.html_report_url')
           echo "## Job Output for ${{matrix.connector}}" >> $GITHUB_STEP_SUMMARY
+          echo "- [HTML Report](${html_report_url})" >> $GITHUB_STEP_SUMMARY
           echo "- Success: ${success}" >> $GITHUB_STEP_SUMMARY
           echo "- Test Duration: $(printf "%.0f" ${run_duration})s" >> $GITHUB_STEP_SUMMARY
           if [ "${success}" != "true" ]; then
@@ -161,6 +166,8 @@ jobs:
             echo "::error::Test failed for connector '${{ matrix.connector }}' on step '${failed_step}'. Check the logs for more details."
             exit 1
           fi
+          echo "success=${success}" >> $GITHUB_OUTPUT
+          echo "html_report_url=${html_report_url}" >> $GITHUB_OUTPUT
 
       # Upload the job output to the artifacts
       - name: Upload Job Output
@@ -170,3 +177,14 @@ jobs:
         with:
           name: ${{matrix.connector}}-job-output
           path: airbyte/airbyte-ci/connectors/pipelines/pipeline_reports
+
+      - name: Override Details URL for GitHub Check Run
+        if: steps.evaluate_output.outputs.html_report_url != ''
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api \
+            -X PATCH \
+            -H "Accept: application/vnd.github.v3+json" \
+            "/repos/${{ github.repository }}/check-runs/${{ github.run_id }}" \
+            -f details_url="${{ steps.evaluate_output.outputs.html_report_url }}"

--- a/airbyte_cdk/logger.py
+++ b/airbyte_cdk/logger.py
@@ -80,7 +80,6 @@ class AirbyteLogFormatter(logging.Formatter):
             )
             return orjson.dumps(AirbyteMessageSerializer.dump(log_message)).decode()
 
-
     @staticmethod
     def extract_extra_args_from_record(record: logging.LogRecord) -> Mapping[str, Any]:
         """

--- a/airbyte_cdk/logger.py
+++ b/airbyte_cdk/logger.py
@@ -80,6 +80,7 @@ class AirbyteLogFormatter(logging.Formatter):
             )
             return orjson.dumps(AirbyteMessageSerializer.dump(log_message)).decode()
 
+
     @staticmethod
     def extract_extra_args_from_record(record: logging.LogRecord) -> Mapping[str, Any]:
         """


### PR DESCRIPTION
This resolves the issue where `airbyte-ci` reports were not being uploaded, and the PR author would have to manually download the job results artifact, then decompress, and then navigate to the report url.

Requires this PR to be merged:

- https://github.com/airbytehq/airbyte/pull/48824

Now, the report URL is printed in the job execution log (as usual for Airbyte CI tests):

> ![image](https://github.com/user-attachments/assets/1a5e1511-8773-46d6-a371-85e5420d604d)

For convenient access, it is also posted to the "Summary" page of the GitHub Workflow for easy access, and to prevent having to scan through job logs:

https://github.com/airbytehq/airbyte-python-cdk/actions/runs/12187332389?pr=138

> ![image](https://github.com/user-attachments/assets/ee359f08-05d7-4682-8fc1-fb477698d06c)

The job artifacts are still downloadable from the bottom of the Summary page as well, in case other test report artifacts are useful - but for most cases, you can simply go to the summary page and click on the report link in the job summary.

> ![image](https://github.com/user-attachments/assets/c553fc9a-48c2-4cd0-8c16-3303325fd695)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced reporting capabilities with HTML report URL extraction.
	- Improved clarity in workflow execution outputs.
  
- **Bug Fixes**
	- Clearer output messages when the job is aborted due to no relevant changes.

- **Chores**
	- Updated job permissions to allow creating checks on pull requests.
	- Specified branch for code checkout in testing.
	- Adjusted job name for conditional skipping based on relevant changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->