### PR TITLE
chore: update SDM image to be rootless

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/airbyte/python-connector-base:2.0.0@sha256:c44839ba84406116e8ba68722a0f30e8f6e7056c726f447681bb9e9ece8bd916
+FROM docker.io/airbyte/python-connector-base:3.0.0@sha256:1a0845ff2b30eafa793c6eee4e8f4283c2e52e1bbd44eed6cb9e9abd5d34d844
 
 WORKDIR /airbyte/integration_code
 
@@ -26,3 +26,4 @@ RUN rm -rf dist/ pyproject.toml poetry.lock README.md
 # Set the entrypoint
 ENV AIRBYTE_ENTRYPOINT="python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
+USER airbyte


### PR DESCRIPTION
This change is only at the SDM image level.
We want to use the latest version of our python connector base image.
This version has an airbyte user set with the right level of permissions.
We also modify the current Dockerfile to declare the current user as `airbyte`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the application to utilize a newer base image version, enhancing compatibility and performance.
  
- **Security Improvements**
	- The application now runs as a non-root user, improving security by minimizing privileges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->