### PR TITLE
fix(concurrent): Reduce occurrences of database table is locked errors

### DIFF
--- a/airbyte_cdk/sources/streams/http/http_client.py
+++ b/airbyte_cdk/sources/streams/http/http_client.py
@@ -146,8 +146,8 @@ class HttpClient:
                 else "file::memory:?cache=shared"
             )
             backend = requests_cache.SQLiteCache(
-                sqlite_path, wal=True
-            )  # by using `PRAGMA journal_mode=WAL`, we avoid having `database table is locked` errors
+                sqlite_path, fast_save=True, wal=True
+            )  # By using `PRAGMA synchronous=OFF` and `PRAGMA journal_mode=WAL`, we avoid having `database table is locked` errors. Note that those were blindly added at the same time and one or the other might be sufficient to prevent the issues but we have seen good results with both. Feel free to revisit given more information.
             return CachedLimiterSession(
                 sqlite_path, backend=backend, api_budget=self._api_budget, match_headers=True
             )

--- a/airbyte_cdk/sources/streams/http/http_client.py
+++ b/airbyte_cdk/sources/streams/http/http_client.py
@@ -145,9 +145,13 @@ class HttpClient:
                 if cache_dir
                 else "file::memory:?cache=shared"
             )
-            backend = requests_cache.SQLiteCache(
-                sqlite_path, fast_save=True, wal=True
-            )  # By using `PRAGMA synchronous=OFF` and `PRAGMA journal_mode=WAL`, we avoid having `database table is locked` errors. Note that those were blindly added at the same time and one or the other might be sufficient to prevent the issues but we have seen good results with both. Feel free to revisit given more information.
+            # By using `PRAGMA synchronous=OFF` and `PRAGMA journal_mode=WAL`, we reduce the possible occurrences of `database table is locked` errors.
+            # Note that those were blindly added at the same time and one or the other might be sufficient to prevent the issues but we have seen good results with both. Feel free to revisit given more information.
+            # There are strong signals that `fast_save` might create problems but if the sync crashes, we start back from the beginning in terms of sqlite anyway so the impact should be minimal. Signals are:
+            # * https://github.com/requests-cache/requests-cache/commit/7fa89ffda300331c37d8fad7f773348a3b5b0236#diff-f43db4a5edf931647c32dec28ea7557aae4cae8444af4b26c8ecbe88d8c925aaR238
+            # * https://github.com/requests-cache/requests-cache/commit/7fa89ffda300331c37d8fad7f773348a3b5b0236#diff-2e7f95b7d7be270ff1a8118f817ea3e6663cdad273592e536a116c24e6d23c18R164-R168
+            # * `If the application running SQLite crashes, the data will be safe, but the database [might become corrupted](https://www.sqlite.org/howtocorrupt.html#cfgerr) if the operating system crashes or the computer loses power before that data has been written to the disk surface.` in [this description](https://www.sqlite.org/pragma.html#pragma_synchronous).
+            backend = requests_cache.SQLiteCache(sqlite_path, fast_save=True, wal=True)
             return CachedLimiterSession(
                 sqlite_path, backend=backend, api_budget=self._api_budget, match_headers=True
             )


### PR DESCRIPTION
Following the release of source-jira concurrent, we have seen some `database table is locked` issue on a connection.

## History
**source-jira:3.4.0**
We have seen `sqlite3.OperationalError: database table is locked` [here](https://cloud.airbyte.com/workspaces/31aa8a38-fbd0-468e-bd31-075456c4ea75/connections/3ff4bbf4-d2cc-4e8c-9930-b7ab342b24dc/timeline) for the first time after enabling concurrency for source-jira. We had already seen similar issues ([database is locked](https://airbytehq-team.slack.com/archives/C063B9A434H/p1706294433164409?thread_ts=1705351381.223439&cid=C063B9A434H) but I can't see references for `database table is locked`). This error was happening consistently for this sync.

**source-jira:3.4.0-dev.1e489a955b**
Trying to wrap the write in a failsafe manner, we were now seeing `sqlite3.OperationalError: database table is locked: responses` on reads.

```
class SkipFailureSQLiteDict(requests_cache.backends.sqlite.SQLiteDict):
    def _write(self, key: str, value: str) -> None:
        try:
            super()._write(key, value)  # type: ignore  # lib is not typed
        except Exception as exception:
            logger.warning(exception)
```

**source-jira:3.4.0-dev.ba45526fa4**
As part of this release, we've also wrapped the read. This caused the app to logs warnings likes `WARN Error while retrieving item from cache: database table is locked: responses` but did not crash because of that


**source-jira:3.4.0-dev.657e80a526**
At that point, we fix part of the memory issue. There were a lot of errors `database table is locked` but the connector was running longer because it would not consume the memory so fast

**source-jira:3.4.0-dev.272b13a278**
Blindly adding mode `fast_save` and `wal` to True. At this point, we don't see the error anymore.

## Proposed solution
The sync that was generating the issues is now running and since there is >30 hours or I/O before it is done, it is annoying to just cancel it. I would have liked to test without `fast_save` because it seems to have some important drawback on consistency based on [this](https://github.com/requests-cache/requests-cache/commit/7fa89ffda300331c37d8fad7f773348a3b5b0236#diff-f43db4a5edf931647c32dec28ea7557aae4cae8444af4b26c8ecbe88d8c925aaR238), [this](https://github.com/requests-cache/requests-cache/commit/7fa89ffda300331c37d8fad7f773348a3b5b0236#diff-2e7f95b7d7be270ff1a8118f817ea3e6663cdad273592e536a116c24e6d23c18R164-R168) and `If the application running SQLite crashes, the data will be safe, but the database [might become corrupted](https://www.sqlite.org/howtocorrupt.html#cfgerr) if the operating system crashes or the computer loses power before that data has been written to the disk surface.` in [this description](https://www.sqlite.org/pragma.html#pragma_synchronous). In the last statement, I don't know what `SQLite crashes` means but my reasoning is the if one thread crashes, there are a couple of possible things that can happen:
* sqlite is not corrupted so other threads can run
* sqlite is corrupted but the other threads are resilient to it
* sqlite is corrupted and it makes other threads crash as well so we restart the syncs

I'm fine with this level of risk.

If we still see some issues with database being locked, we can add the [SkipFailureSQLiteDict implementation](https://github.com/airbytehq/airbyte-python-cdk/pull/115/files#diff-92e204ea3ab9f873f9f1babb7ee887fb1ae7cf5325238925561cac6445157a51R525-R563) that was used to fix the customer's connection which would just ignore caching errors entirely.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved handling of SQLite cache for HTTP requests.
	- Enhanced error logging and handling for various response actions.

- **Refactor**
	- Streamlined logic for determining SQLite path in the HTTP client.
	- Updated method for handling session requests.

These changes enhance the efficiency and reliability of the HTTP client, providing a smoother user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->