### PR TITLE
fix(concurrent): Ensure default concurrency level does not generate deadlock

### DIFF
--- a/airbyte_cdk/sources/declarative/concurrent_declarative_source.py
+++ b/airbyte_cdk/sources/declarative/concurrent_declarative_source.py
@@ -56,8 +56,9 @@ from airbyte_cdk.sources.types import Config, StreamState
 
 
 class ConcurrentDeclarativeSource(ManifestDeclarativeSource, Generic[TState]):
-    # By default, we defer to a value of 1 which represents running a connector using the Concurrent CDK engine on only one thread.
-    SINGLE_THREADED_CONCURRENCY_LEVEL = 1
+    # By default, we defer to a value of 2. A value lower than than could cause a PartitionEnqueuer to be stuck in a state of deadlock
+    # because it has hit the limit of futures but not partition reader is consuming them.
+    SINGLE_THREADED_CONCURRENCY_LEVEL = 2
 
     def __init__(
         self,
@@ -108,7 +109,7 @@ class ConcurrentDeclarativeSource(ManifestDeclarativeSource, Generic[TState]):
             )  # Partition_generation iterates using range based on this value. If this is floored to zero we end up in a dead lock during start up
         else:
             concurrency_level = self.SINGLE_THREADED_CONCURRENCY_LEVEL
-            initial_number_of_partitions_to_generate = self.SINGLE_THREADED_CONCURRENCY_LEVEL
+            initial_number_of_partitions_to_generate = self.SINGLE_THREADED_CONCURRENCY_LEVEL // 2
 
         self._concurrent_source = ConcurrentSource.create(
             num_workers=concurrency_level,

--- a/airbyte_cdk/sources/declarative/concurrent_declarative_source.py
+++ b/airbyte_cdk/sources/declarative/concurrent_declarative_source.py
@@ -58,7 +58,7 @@ from airbyte_cdk.sources.types import Config, StreamState
 class ConcurrentDeclarativeSource(ManifestDeclarativeSource, Generic[TState]):
     # By default, we defer to a value of 2. A value lower than than could cause a PartitionEnqueuer to be stuck in a state of deadlock
     # because it has hit the limit of futures but not partition reader is consuming them.
-    SINGLE_THREADED_CONCURRENCY_LEVEL = 2
+    _LOWEST_SAFE_CONCURRENCY_LEVEL = 2
 
     def __init__(
         self,
@@ -108,8 +108,8 @@ class ConcurrentDeclarativeSource(ManifestDeclarativeSource, Generic[TState]):
                 concurrency_level // 2, 1
             )  # Partition_generation iterates using range based on this value. If this is floored to zero we end up in a dead lock during start up
         else:
-            concurrency_level = self.SINGLE_THREADED_CONCURRENCY_LEVEL
-            initial_number_of_partitions_to_generate = self.SINGLE_THREADED_CONCURRENCY_LEVEL // 2
+            concurrency_level = self._LOWEST_SAFE_CONCURRENCY_LEVEL
+            initial_number_of_partitions_to_generate = self._LOWEST_SAFE_CONCURRENCY_LEVEL // 2
 
         self._concurrent_source = ConcurrentSource.create(
             num_workers=concurrency_level,

--- a/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -327,7 +327,7 @@ definitions:
         additionalProperties: true
   ConcurrencyLevel:
     title: Concurrency Level
-    description: Defines the amount of parallelization for the streams that are being synced. The factor of parallelization is how many partitions or streams are synced at the same time. For example, with a concurrency_level of 10, ten streams or partitions of data will processed at the same time.
+    description: Defines the amount of parallelization for the streams that are being synced. The factor of parallelization is how many partitions or streams are synced at the same time. For example, with a concurrency_level of 10, ten streams or partitions of data will processed at the same time. Note that a value of 1 could create deadlock if a stream has a very high number of partitions.
     type: object
     required:
       - default_concurrency


### PR DESCRIPTION
Given a stream that has a lot of partitions, we can end up in a case where the only thread (which is a PartitionEnqueuer that is generating partition) can't generate more partitions because they are not consumed. 

[This comment](https://github.com/airbytehq/airbyte-python-cdk/blob/a8b1b2b6cfa3c342b486bbabb290a3add3551489/airbyte_cdk/sources/streams/concurrent/partition_enqueuer.py#L47-L59) explains how we limit the number of partitions being generated. Basically, every time we try to add a partition to the list of partitions ready to be consumed, we do [this](https://github.com/airbytehq/airbyte-python-cdk/blob/main/airbyte_cdk/sources/concurrent_source/thread_pool_manager.py#L37-L43):
* prune the list of futures to only keep the partition reader threads that have been completed
* if the number of futures remaining is higher than a certain value, the thread will sleep before checking again if we can create a thread for this partition

The locks on this algorithm seems approximative hence why we have this log in case we really go too much over it:
```
        if len(self._futures) > self._logging_threshold:
            self._logger.warning(
                f"ThreadPoolManager: The list of futures is getting bigger than expected ({len(self._futures)})"
            )
```

The current limit is 10 000 threads waiting in the queue.

In order to prevent if nothing is configured, we will set the default to 2 threads. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new field definition for flexible data manipulation within component schemas.
- **Improvements**
	- Updated concurrency handling to enhance performance and prevent potential deadlocks.
	- Refined authentication sections for clearer usage instructions.
- **Documentation**
	- Enhanced schema definitions with improved descriptions and examples for better understanding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->