### PR TITLE
fix: %s formatted state values were being converted to str in state blob

### DIFF
--- a/airbyte_cdk/sources/declarative/datetime/datetime_parser.py
+++ b/airbyte_cdk/sources/declarative/datetime/datetime_parser.py
@@ -37,12 +37,12 @@ class DatetimeParser:
             return parsed_datetime.replace(tzinfo=datetime.timezone.utc)
         return parsed_datetime
 
-    def format(self, dt: datetime.datetime, format: str) -> str:
+    def format(self, dt: datetime.datetime, format: str) -> Union[str, int]:
         # strftime("%s") is unreliable because it ignores the time zone information and assumes the time zone of the system it's running on
         # It's safer to use the timestamp() method than the %s directive
         # See https://stackoverflow.com/a/4974930
         if format == "%s":
-            return str(int(dt.timestamp()))
+            return int(dt.timestamp())
         if format == "%s_as_float":
             return str(float(dt.timestamp()))
         if format == "%ms":

--- a/airbyte_cdk/sources/declarative/datetime/datetime_parser.py
+++ b/airbyte_cdk/sources/declarative/datetime/datetime_parser.py
@@ -37,7 +37,7 @@ class DatetimeParser:
             return parsed_datetime.replace(tzinfo=datetime.timezone.utc)
         return parsed_datetime
 
-    def format(self, dt: datetime.datetime, format: str) -> Union[str, int]:
+    def format(self, dt: datetime.datetime, format: str) -> Union[str, int, float]:
         # strftime("%s") is unreliable because it ignores the time zone information and assumes the time zone of the system it's running on
         # It's safer to use the timestamp() method than the %s directive
         # See https://stackoverflow.com/a/4974930

--- a/airbyte_cdk/sources/declarative/datetime/datetime_parser.py
+++ b/airbyte_cdk/sources/declarative/datetime/datetime_parser.py
@@ -44,10 +44,10 @@ class DatetimeParser:
         if format == "%s":
             return int(dt.timestamp())
         if format == "%s_as_float":
-            return str(float(dt.timestamp()))
+            return float(dt.timestamp())
         if format == "%ms":
             # timstamp() returns a float representing the number of seconds since the unix epoch
-            return str(int(dt.timestamp() * 1000))
+            return int(dt.timestamp() * 1000)
         else:
             return dt.strftime(format)
 

--- a/airbyte_cdk/sources/declarative/incremental/datetime_based_cursor.py
+++ b/airbyte_cdk/sources/declarative/incremental/datetime_based_cursor.py
@@ -247,8 +247,8 @@ class DatetimeBasedCursor(DeclarativeCursor):
             return self.parse_date(stream_state[self.cursor_field.eval(self.config)])  # type: ignore  # cursor_field is converted to an InterpolatedString in __post_init__
         return datetime.datetime.min.replace(tzinfo=datetime.timezone.utc)
 
-    def _format_datetime(self, dt: datetime.datetime) -> Union[str, int]:
-        return self._parser.format(dt, self.datetime_format)
+    def _format_datetime(self, dt: datetime.datetime) -> str:
+        return str(self._parser.format(dt, self.datetime_format))
 
     def _partition_daterange(
         self,

--- a/airbyte_cdk/sources/declarative/incremental/datetime_based_cursor.py
+++ b/airbyte_cdk/sources/declarative/incremental/datetime_based_cursor.py
@@ -247,7 +247,7 @@ class DatetimeBasedCursor(DeclarativeCursor):
             return self.parse_date(stream_state[self.cursor_field.eval(self.config)])  # type: ignore  # cursor_field is converted to an InterpolatedString in __post_init__
         return datetime.datetime.min.replace(tzinfo=datetime.timezone.utc)
 
-    def _format_datetime(self, dt: datetime.datetime) -> str:
+    def _format_datetime(self, dt: datetime.datetime) -> Union[str, int]:
         return self._parser.format(dt, self.datetime_format)
 
     def _partition_daterange(

--- a/airbyte_cdk/sources/streams/concurrent/state_converters/datetime_stream_state_converter.py
+++ b/airbyte_cdk/sources/streams/concurrent/state_converters/datetime_stream_state_converter.py
@@ -202,7 +202,7 @@ class CustomFormatConcurrentStreamStateConverter(IsoMillisConcurrentStreamStateC
         self._input_datetime_formats += [self._datetime_format]
         self._parser = DatetimeParser()
 
-    def output_format(self, timestamp: datetime) -> Union[str, int]:
+    def output_format(self, timestamp: datetime) -> Union[str, int, float]:
         return self._parser.format(timestamp, self._datetime_format)
 
     def parse_timestamp(self, timestamp: str) -> datetime:

--- a/airbyte_cdk/sources/streams/concurrent/state_converters/datetime_stream_state_converter.py
+++ b/airbyte_cdk/sources/streams/concurrent/state_converters/datetime_stream_state_converter.py
@@ -4,7 +4,7 @@
 
 from abc import abstractmethod
 from datetime import datetime, timedelta, timezone
-from typing import Any, Callable, List, MutableMapping, Optional, Tuple
+from typing import Any, Callable, List, MutableMapping, Optional, Tuple, Union
 
 import pendulum
 from pendulum.datetime import DateTime
@@ -202,7 +202,7 @@ class CustomFormatConcurrentStreamStateConverter(IsoMillisConcurrentStreamStateC
         self._input_datetime_formats += [self._datetime_format]
         self._parser = DatetimeParser()
 
-    def output_format(self, timestamp: datetime) -> str:
+    def output_format(self, timestamp: datetime) -> Union[str, int]:
         return self._parser.format(timestamp, self._datetime_format)
 
     def parse_timestamp(self, timestamp: str) -> datetime:

--- a/unit_tests/sources/declarative/datetime/test_datetime_parser.py
+++ b/unit_tests/sources/declarative/datetime/test_datetime_parser.py
@@ -71,13 +71,13 @@ def test_parse_date(test_name, input_date, date_format, expected_output_date):
             "test_format_timestamp_ms",
             datetime.datetime(2021, 1, 1, 0, 0, 0, 1000, tzinfo=datetime.timezone.utc),
             "%ms",
-            "1609459200001",
+            1609459200001,
         ),
         (
             "test_format_timestamp_as_float",
             datetime.datetime(2023, 1, 30, 15, 28, 28, 873709, tzinfo=datetime.timezone.utc),
             "%s_as_float",
-            "1675092508.873709",
+            1675092508.873709,
         ),
         (
             "test_format_string",

--- a/unit_tests/sources/declarative/datetime/test_datetime_parser.py
+++ b/unit_tests/sources/declarative/datetime/test_datetime_parser.py
@@ -65,7 +65,7 @@ def test_parse_date(test_name, input_date, date_format, expected_output_date):
             "test_format_timestamp",
             datetime.datetime(2021, 1, 1, 0, 0, tzinfo=datetime.timezone.utc),
             "%s",
-            "1609459200",
+            1609459200,
         ),
         (
             "test_format_timestamp_ms",

--- a/unit_tests/sources/declarative/incremental/test_datetime_based_cursor.py
+++ b/unit_tests/sources/declarative/incremental/test_datetime_based_cursor.py
@@ -919,7 +919,7 @@ def test_request_option_with_empty_stream_slice(stream_slice):
         ),
         (
             "test_parse_timestamp",
-            "1609459200",
+            1609459200,
             "%s",
             "PT1S",
             datetime.datetime(2021, 1, 1, 0, 0, tzinfo=datetime.timezone.utc),


### PR DESCRIPTION
## What
- [This PR](https://github.com/airbytehq/airbyte/pull/48389) updated the default stream state converter to always be the `CustomFormatConcurrentStreamStateConverter`, which relies on the `DatetimeParser` for parsing and formatting dates. Inadvertently the returned `output_format` of cursor values for %s timestamps was changed from `int` to `str`.
- This PR updates the `DatetimeParser` to return int, float, or str for its `format` method.
- This also updated the `DatetimeBasedCursor` to convert the formatted datetime to a string to maintain compatibility
- Update the DateTimeParser to output the same type as the input state value.
    - %s -> int
    - %s_as_float -> float
    - %ms -> int
    - else -> str


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enhanced datetime handling with methods now returning string, integer, or float representations for timestamps.
	- Introduced a new method to dynamically adjust the lookback window based on runtime conditions.

- **Bug Fixes**
	- Updated test cases to align with the new output types for datetime formatting, ensuring accurate validation.

- **Tests**
	- Improved test coverage for datetime parsing to accommodate both string and integer inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->