### PR TITLE
ci: change dependabot github actions to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,7 +21,7 @@ updates:
     commit-message:
       prefix: "ci(deps): "
     schedule:
-      interval: daily
+      interval: monthly
     labels:
       - ci
     groups:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated Dependabot configuration to change the update schedule for GitHub Actions from daily to monthly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->