### PR TITLE
fix(Low-Code Concurrent CDK): Refactor the low-code AsyncRetriever to use an underlying StreamSlicer

### DIFF
--- a/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -308,6 +308,9 @@ from airbyte_cdk.sources.declarative.partition_routers import (
     SinglePartitionRouter,
     SubstreamPartitionRouter,
 )
+from airbyte_cdk.sources.declarative.partition_routers.async_job_partition_router import (
+    AsyncJobPartitionRouter,
+)
 from airbyte_cdk.sources.declarative.partition_routers.substream_partition_router import (
     ParentStreamConfig,
 )
@@ -2146,18 +2149,24 @@ class ModelToComponentFactory:
             urls_extractor=urls_extractor,
         )
 
-        return AsyncRetriever(
+        async_job_partition_router = AsyncJobPartitionRouter(
             job_orchestrator_factory=lambda stream_slices: AsyncJobOrchestrator(
                 job_repository,
                 stream_slices,
-                JobTracker(
-                    1
-                ),  # FIXME eventually make the number of concurrent jobs in the API configurable. Until then, we limit to 1
+                JobTracker(1),
+                # FIXME eventually make the number of concurrent jobs in the API configurable. Until then, we limit to 1
                 self._message_repository,
-                has_bulk_parent=False,  # FIXME work would need to be done here in order to detect if a stream as a parent stream that is bulk
+                has_bulk_parent=False,
+                # FIXME work would need to be done here in order to detect if a stream as a parent stream that is bulk
             ),
-            record_selector=record_selector,
             stream_slicer=stream_slicer,
+            config=config,
+            parameters=model.parameters or {},
+        )
+
+        return AsyncRetriever(
+            record_selector=record_selector,
+            stream_slicer=async_job_partition_router,
             config=config,
             parameters=model.parameters or {},
         )

--- a/airbyte_cdk/sources/declarative/partition_routers/__init__.py
+++ b/airbyte_cdk/sources/declarative/partition_routers/__init__.py
@@ -2,10 +2,18 @@
 # Copyright (c) 2022 Airbyte, Inc., all rights reserved.
 #
 
+from airbyte_cdk.sources.declarative.partition_routers.async_job_partition_router import AsyncJobPartitionRouter
 from airbyte_cdk.sources.declarative.partition_routers.cartesian_product_stream_slicer import CartesianProductStreamSlicer
 from airbyte_cdk.sources.declarative.partition_routers.list_partition_router import ListPartitionRouter
 from airbyte_cdk.sources.declarative.partition_routers.single_partition_router import SinglePartitionRouter
 from airbyte_cdk.sources.declarative.partition_routers.substream_partition_router import SubstreamPartitionRouter
 from airbyte_cdk.sources.declarative.partition_routers.partition_router import PartitionRouter
 
-__all__ = ["CartesianProductStreamSlicer", "ListPartitionRouter", "SinglePartitionRouter", "SubstreamPartitionRouter", "PartitionRouter"]
+__all__ = [
+    "AsyncJobPartitionRouter",
+    "CartesianProductStreamSlicer",
+    "ListPartitionRouter",
+    "SinglePartitionRouter",
+    "SubstreamPartitionRouter",
+    "PartitionRouter"
+]

--- a/airbyte_cdk/sources/declarative/partition_routers/async_job_partition_router.py
+++ b/airbyte_cdk/sources/declarative/partition_routers/async_job_partition_router.py
@@ -48,6 +48,13 @@ class AsyncJobPartitionRouter(StreamSlicer):
             )
 
     def fetch_records(self, partition: AsyncPartition) -> Iterable[Mapping[str, Any]]:
+        """
+        This method of fetching records extends beyond what a PartitionRouter/StreamSlicer should
+        be responsible for. However, this was added in because the JobOrchestrator is required to
+        retrieve records. And without defining fetch_records() on this class, we're stuck with either
+        passing the JobOrchestrator to the AsyncRetriever or storing it on multiple classes.
+        """
+
         if not self._job_orchestrator:
             raise AirbyteTracedException(
                 message="Invalid state within AsyncJobRetriever. Please contact Airbyte Support",

--- a/airbyte_cdk/sources/declarative/partition_routers/async_job_partition_router.py
+++ b/airbyte_cdk/sources/declarative/partition_routers/async_job_partition_router.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+
+from dataclasses import InitVar, dataclass, field
+from typing import Any, Callable, Iterable, Mapping, Optional
+
+from airbyte_cdk.models import FailureType
+from airbyte_cdk.sources.declarative.async_job.job_orchestrator import (
+    AsyncJobOrchestrator,
+    AsyncPartition,
+)
+from airbyte_cdk.sources.declarative.partition_routers.single_partition_router import (
+    SinglePartitionRouter,
+)
+from airbyte_cdk.sources.streams.concurrent.partitions.stream_slicer import StreamSlicer
+from airbyte_cdk.sources.types import Config, StreamSlice
+from airbyte_cdk.utils.traced_exception import AirbyteTracedException
+
+
+@dataclass
+class AsyncJobPartitionRouter(StreamSlicer):
+    """
+    Partition router that creates async jobs in a source API, periodically polls for job
+    completion, and supplies the completed job URL locations as stream slices so that
+    records can be extracted.
+    """
+
+    config: Config
+    parameters: InitVar[Mapping[str, Any]]
+    job_orchestrator_factory: Callable[[Iterable[StreamSlice]], AsyncJobOrchestrator]
+    stream_slicer: StreamSlicer = field(
+        default_factory=lambda: SinglePartitionRouter(parameters={})
+    )
+
+    def __post_init__(self, parameters: Mapping[str, Any]) -> None:
+        self._job_orchestrator_factory = self.job_orchestrator_factory
+        self._job_orchestrator: Optional[AsyncJobOrchestrator] = None
+        self._parameters = parameters
+
+    def stream_slices(self) -> Iterable[StreamSlice]:
+        slices = self.stream_slicer.stream_slices()
+        self._job_orchestrator = self._job_orchestrator_factory(slices)
+
+        for completed_partition in self._job_orchestrator.create_and_get_completed_partitions():
+            yield StreamSlice(
+                partition=dict(completed_partition.stream_slice.partition)
+                | {"partition": completed_partition},
+                cursor_slice=completed_partition.stream_slice.cursor_slice,
+            )
+
+    def fetch_records(self, partition: AsyncPartition) -> Iterable[Mapping[str, Any]]:
+        if not self._job_orchestrator:
+            raise AirbyteTracedException(
+                message="Invalid state within AsyncJobRetriever. Please contact Airbyte Support",
+                internal_message="AsyncPartitionRepository is expected to be accessed only after `stream_slices`",
+                failure_type=FailureType.system_error,
+            )
+
+        return self._job_orchestrator.fetch_records(partition=partition)

--- a/airbyte_cdk/sources/declarative/retrievers/async_retriever.py
+++ b/airbyte_cdk/sources/declarative/retrievers/async_retriever.py
@@ -1,8 +1,8 @@
 # Copyright (c) 2024 Airbyte, Inc., all rights reserved.
 
 
-from dataclasses import InitVar, dataclass, field
-from typing import Any, Callable, Iterable, Mapping, Optional
+from dataclasses import InitVar, dataclass
+from typing import Any, Iterable, Mapping, Optional
 
 from typing_extensions import deprecated
 
@@ -12,9 +12,10 @@ from airbyte_cdk.sources.declarative.async_job.job_orchestrator import (
     AsyncPartition,
 )
 from airbyte_cdk.sources.declarative.extractors.record_selector import RecordSelector
-from airbyte_cdk.sources.declarative.partition_routers import SinglePartitionRouter
+from airbyte_cdk.sources.declarative.partition_routers.async_job_partition_router import (
+    AsyncJobPartitionRouter,
+)
 from airbyte_cdk.sources.declarative.retrievers import Retriever
-from airbyte_cdk.sources.declarative.stream_slicers import StreamSlicer
 from airbyte_cdk.sources.source import ExperimentalClassWarning
 from airbyte_cdk.sources.streams.core import StreamData
 from airbyte_cdk.sources.types import Config, StreamSlice, StreamState
@@ -29,15 +30,10 @@ from airbyte_cdk.utils.traced_exception import AirbyteTracedException
 class AsyncRetriever(Retriever):
     config: Config
     parameters: InitVar[Mapping[str, Any]]
-    job_orchestrator_factory: Callable[[Iterable[StreamSlice]], AsyncJobOrchestrator]
     record_selector: RecordSelector
-    stream_slicer: StreamSlicer = field(
-        default_factory=lambda: SinglePartitionRouter(parameters={})
-    )
+    stream_slicer: AsyncJobPartitionRouter
 
     def __post_init__(self, parameters: Mapping[str, Any]) -> None:
-        self._job_orchestrator_factory = self.job_orchestrator_factory
-        self.__job_orchestrator: Optional[AsyncJobOrchestrator] = None
         self._parameters = parameters
 
     @property
@@ -53,17 +49,6 @@ class AsyncRetriever(Retriever):
         As a first iteration for sendgrid, there is no state to be managed
         """
         pass
-
-    @property
-    def _job_orchestrator(self) -> AsyncJobOrchestrator:
-        if not self.__job_orchestrator:
-            raise AirbyteTracedException(
-                message="Invalid state within AsyncJobRetriever. Please contact Airbyte Support",
-                internal_message="AsyncPartitionRepository is expected to be accessed only after `stream_slices`",
-                failure_type=FailureType.system_error,
-            )
-
-        return self.__job_orchestrator
 
     def _get_stream_state(self) -> StreamState:
         """
@@ -99,15 +84,7 @@ class AsyncRetriever(Retriever):
         return stream_slice["partition"]  # type: ignore  # stream_slice["partition"] has been added as an AsyncPartition as part of stream_slices
 
     def stream_slices(self) -> Iterable[Optional[StreamSlice]]:
-        slices = self.stream_slicer.stream_slices()
-        self.__job_orchestrator = self._job_orchestrator_factory(slices)
-
-        for completed_partition in self._job_orchestrator.create_and_get_completed_partitions():
-            yield StreamSlice(
-                partition=dict(completed_partition.stream_slice.partition)
-                | {"partition": completed_partition},
-                cursor_slice=completed_partition.stream_slice.cursor_slice,
-            )
+        return self.stream_slicer.stream_slices()
 
     def read_records(
         self,
@@ -116,7 +93,7 @@ class AsyncRetriever(Retriever):
     ) -> Iterable[StreamData]:
         stream_state: StreamState = self._get_stream_state()
         partition: AsyncPartition = self._validate_and_get_stream_slice_partition(stream_slice)
-        records: Iterable[Mapping[str, Any]] = self._job_orchestrator.fetch_records(partition)
+        records: Iterable[Mapping[str, Any]] = self.stream_slicer.fetch_records(partition)
 
         yield from self.record_selector.filter_and_transform(
             all_data=records,

--- a/unit_tests/sources/declarative/async_job/test_integration.py
+++ b/unit_tests/sources/declarative/async_job/test_integration.py
@@ -20,6 +20,9 @@ from airbyte_cdk.sources.declarative.async_job.repository import AsyncJobReposit
 from airbyte_cdk.sources.declarative.async_job.status import AsyncJobStatus
 from airbyte_cdk.sources.declarative.extractors.record_extractor import RecordExtractor
 from airbyte_cdk.sources.declarative.extractors.record_selector import RecordSelector
+from airbyte_cdk.sources.declarative.partition_routers.async_job_partition_router import (
+    AsyncJobPartitionRouter,
+)
 from airbyte_cdk.sources.declarative.retrievers.async_retriever import AsyncRetriever
 from airbyte_cdk.sources.declarative.schema import InlineSchemaLoader
 from airbyte_cdk.sources.declarative.stream_slicers import StreamSlicer
@@ -79,12 +82,16 @@ class MockSource(AbstractSource):
                     config={},
                     parameters={},
                     record_selector=noop_record_selector,
-                    stream_slicer=self._stream_slicer,
-                    job_orchestrator_factory=lambda stream_slices: AsyncJobOrchestrator(
-                        MockAsyncJobRepository(),
-                        stream_slices,
-                        JobTracker(_NO_LIMIT),
-                        self._message_repository,
+                    stream_slicer=AsyncJobPartitionRouter(
+                        stream_slicer=self._stream_slicer,
+                        job_orchestrator_factory=lambda stream_slices: AsyncJobOrchestrator(
+                            MockAsyncJobRepository(),
+                            stream_slices,
+                            JobTracker(_NO_LIMIT),
+                            self._message_repository,
+                        ),
+                        config={},
+                        parameters={},
                     ),
                 ),
                 config={},

--- a/unit_tests/sources/declarative/async_job/test_integration.py
+++ b/unit_tests/sources/declarative/async_job/test_integration.py
@@ -38,7 +38,7 @@ _NO_LIMIT = 10000
 
 class MockAsyncJobRepository(AsyncJobRepository):
     def start(self, stream_slice: StreamSlice) -> AsyncJob:
-        return AsyncJob("a_job_id", StreamSlice(partition={}, cursor_slice={}))
+        return AsyncJob("a_job_id", stream_slice)
 
     def update_jobs_status(self, jobs: Set[AsyncJob]) -> None:
         for job in jobs:

--- a/unit_tests/sources/declarative/partition_routers/test_async_job_partition_router.py
+++ b/unit_tests/sources/declarative/partition_routers/test_async_job_partition_router.py
@@ -78,5 +78,7 @@ def test_stream_slices_with_parent_slicer():
         attempts_per_job = list(partition.jobs)
         assert len(attempts_per_job) == 1
         assert attempts_per_job[0].api_job_id() == "a_job_id"
-        assert attempts_per_job[0].job_parameters() == StreamSlice(partition={}, cursor_slice={})
+        assert attempts_per_job[0].job_parameters() == StreamSlice(
+            partition={"parent_id": str(i)}, cursor_slice={}
+        )
         assert attempts_per_job[0].status() == AsyncJobStatus.COMPLETED

--- a/unit_tests/sources/declarative/partition_routers/test_async_job_partition_router.py
+++ b/unit_tests/sources/declarative/partition_routers/test_async_job_partition_router.py
@@ -1,0 +1,82 @@
+# Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+
+from airbyte_cdk.sources.declarative.async_job.job_orchestrator import (
+    AsyncJobOrchestrator,
+    AsyncPartition,
+)
+from airbyte_cdk.sources.declarative.async_job.job_tracker import JobTracker
+from airbyte_cdk.sources.declarative.async_job.status import AsyncJobStatus
+from airbyte_cdk.sources.declarative.partition_routers import ListPartitionRouter
+from airbyte_cdk.sources.declarative.partition_routers.async_job_partition_router import (
+    AsyncJobPartitionRouter,
+)
+from airbyte_cdk.sources.declarative.partition_routers.single_partition_router import (
+    SinglePartitionRouter,
+)
+from airbyte_cdk.sources.message import NoopMessageRepository
+from airbyte_cdk.sources.types import StreamSlice
+from unit_tests.sources.declarative.async_job.test_integration import MockAsyncJobRepository
+
+_NO_LIMIT = 10000
+
+
+def test_stream_slices_with_single_partition_router():
+    partition_router = AsyncJobPartitionRouter(
+        stream_slicer=SinglePartitionRouter(parameters={}),
+        job_orchestrator_factory=lambda stream_slices: AsyncJobOrchestrator(
+            MockAsyncJobRepository(),
+            stream_slices,
+            JobTracker(_NO_LIMIT),
+            NoopMessageRepository(),
+        ),
+        config={},
+        parameters={},
+    )
+
+    slices = list(partition_router.stream_slices())
+    assert len(slices) == 1
+    partition = slices[0].partition.get("partition")
+    assert isinstance(partition, AsyncPartition)
+    assert partition.stream_slice == StreamSlice(partition={}, cursor_slice={})
+    assert partition.status == AsyncJobStatus.COMPLETED
+
+    attempts_per_job = list(partition.jobs)
+    assert len(attempts_per_job) == 1
+    assert attempts_per_job[0].api_job_id() == "a_job_id"
+    assert attempts_per_job[0].job_parameters() == StreamSlice(partition={}, cursor_slice={})
+    assert attempts_per_job[0].status() == AsyncJobStatus.COMPLETED
+
+
+def test_stream_slices_with_parent_slicer():
+    partition_router = AsyncJobPartitionRouter(
+        stream_slicer=ListPartitionRouter(
+            values=["0", "1", "2"],
+            cursor_field="parent_id",
+            config={},
+            parameters={},
+        ),
+        job_orchestrator_factory=lambda stream_slices: AsyncJobOrchestrator(
+            MockAsyncJobRepository(),
+            stream_slices,
+            JobTracker(_NO_LIMIT),
+            NoopMessageRepository(),
+        ),
+        config={},
+        parameters={},
+    )
+
+    slices = list(partition_router.stream_slices())
+    assert len(slices) == 3
+    for i, partition in enumerate(slices):
+        partition = partition.partition.get("partition")
+        assert isinstance(partition, AsyncPartition)
+        assert partition.stream_slice == StreamSlice(
+            partition={"parent_id": str(i)}, cursor_slice={}
+        )
+        assert partition.status == AsyncJobStatus.COMPLETED
+
+        attempts_per_job = list(partition.jobs)
+        assert len(attempts_per_job) == 1
+        assert attempts_per_job[0].api_job_id() == "a_job_id"
+        assert attempts_per_job[0].job_parameters() == StreamSlice(partition={}, cursor_slice={})
+        assert attempts_per_job[0].status() == AsyncJobStatus.COMPLETED


### PR DESCRIPTION
## What is the issue

Something uncovered while using the latest version of the Concurrent CDK on `source-sendgrid` was that because it relied on the assumption all Retrievers had an underlying `stream_slicer` defined. This however was not the way the `AsyncRetriever` was implemented. 

## Implementation Details

To fix this, I've refactored the `AsyncRetriever` to follow a more established pattern exhibited by our existing `Retrievers`. Now the retriever will always have an underlying `stream_slicer` that can be invoked to generate the partitions within the concurrent framework. This allows us to continue to use the `StreamSlicerPartitionGenerator`.

This change was also designed to be non-breaking because we are not changing the developer facing interface. Instead we use the existing `AsyncRetriever` fields to construct the `AsyncJobPartitionGenerator` which is effectively an implementation detail.

Note:
This will not completely give us the ability to run streams using the `AsyncRetriever` in the concurrent framework. This just fixed the first issue identified in https://github.com/airbytehq/airbyte-python-cdk/issues/168.  I will work on a follow up PR that addresses the second issue. But I wanted to separate the PRs so I can release this refactor which should be a no-op for existing connectors like `source-sendgrid` and we should see no change in behavior. And because of that, I have not ungated the async report streams  `concurrent_declarative_source.py` since we need to address part 2.

todo: add unit tests to AsyncJobPartitionRouter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced `AsyncJobPartitionRouter` for improved management of asynchronous job handling.
  - Added `AsyncRetriever` component for managing asynchronous job operations.

- **Bug Fixes**
  - Streamlined logic in `AsyncRetriever` to enhance performance and reduce complexity.

- **Tests**
  - Added tests for the new `AsyncRetriever` and `AsyncJobPartitionRouter` components to ensure proper functionality and integration.
  - Created unit tests for `AsyncJobPartitionRouter` to validate its behavior with different partitioning scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->