### PR TITLE
fix: (HttpClient) rate limit fix unlimited tries

### DIFF
--- a/airbyte_cdk/sources/streams/http/http_client.py
+++ b/airbyte_cdk/sources/streams/http/http_client.py
@@ -262,7 +262,7 @@ class HttpClient:
         user_backoff_handler = user_defined_backoff_handler(max_tries=max_tries, max_time=max_time)(
             self._send
         )
-        rate_limit_backoff_handler = rate_limit_default_backoff_handler()
+        rate_limit_backoff_handler = rate_limit_default_backoff_handler(max_tries=max_tries)
         backoff_handler = http_client_default_backoff_handler(
             max_tries=max_tries, max_time=max_time
         )

--- a/airbyte_cdk/sources/streams/http/http_client.py
+++ b/airbyte_cdk/sources/streams/http/http_client.py
@@ -472,7 +472,9 @@ class HttpClient:
 
             elif retry_endlessly:
                 raise RateLimitBackoffException(
-                    request=request, response=response or exc, error_message=error_message
+                    request=request,
+                    response=(response if response is not None else exc),
+                    error_message=error_message,
                 )
 
             raise DefaultBackoffException(

--- a/unit_tests/sources/streams/http/test_http_client.py
+++ b/unit_tests/sources/streams/http/test_http_client.py
@@ -20,9 +20,9 @@ from airbyte_cdk.sources.streams.http.error_handlers import (
 )
 from airbyte_cdk.sources.streams.http.exceptions import (
     DefaultBackoffException,
+    RateLimitBackoffException,
     RequestBodyException,
     UserDefinedBackoffException,
-    RateLimitBackoffException
 )
 from airbyte_cdk.sources.streams.http.requests_native_auth import TokenAuthenticator
 from airbyte_cdk.utils.traced_exception import AirbyteTracedException
@@ -694,7 +694,9 @@ def test_send_emit_stream_status_with_rate_limit_reason(capsys):
     [[True, 6, DefaultBackoffException], [False, 6, RateLimitBackoffException]],
 )
 @pytest.mark.usefixtures("mock_sleep")
-def test_backoff_strategy_endless(exit_on_rate_limit: bool, expected_call_count: int, expected_error: Exception):
+def test_backoff_strategy_endless(
+    exit_on_rate_limit: bool, expected_call_count: int, expected_error: Exception
+):
     http_client = HttpClient(
         name="test", logger=MagicMock(), error_handler=HttpStatusErrorHandler(logger=MagicMock())
     )

--- a/unit_tests/sources/streams/http/test_http_client.py
+++ b/unit_tests/sources/streams/http/test_http_client.py
@@ -22,6 +22,7 @@ from airbyte_cdk.sources.streams.http.exceptions import (
     DefaultBackoffException,
     RequestBodyException,
     UserDefinedBackoffException,
+    RateLimitBackoffException
 )
 from airbyte_cdk.sources.streams.http.requests_native_auth import TokenAuthenticator
 from airbyte_cdk.utils.traced_exception import AirbyteTracedException
@@ -690,10 +691,10 @@ def test_send_emit_stream_status_with_rate_limit_reason(capsys):
 
 @pytest.mark.parametrize(
     "exit_on_rate_limit, expected_call_count, expected_error",
-    [[True, 6, DefaultBackoffException], [False, 38, OverflowError]],
+    [[True, 6, DefaultBackoffException], [False, 6, RateLimitBackoffException]],
 )
 @pytest.mark.usefixtures("mock_sleep")
-def test_backoff_strategy_endless(exit_on_rate_limit, expected_call_count, expected_error):
+def test_backoff_strategy_endless(exit_on_rate_limit: bool, expected_call_count: int, expected_error: Exception):
     http_client = HttpClient(
         name="test", logger=MagicMock(), error_handler=HttpStatusErrorHandler(logger=MagicMock())
     )


### PR DESCRIPTION
# What

Resolving Source Amazon Seller Partner CDK migration

bugfix for:

- empty response field in  `RateLimitBackoffException` (boolean comparison return `exc` since all non `ok` responses are `False`
- rate limit handler ignores max_tries

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling and retry logic in the HTTP client, improving robustness during rate limiting.
	- Introduced a new `RateLimitBackoffException` for clearer error messaging.

- **Bug Fixes**
	- Improved consistency in error handling when encountering rate limits.

- **Tests**
	- Updated test cases to reflect the new exception and modified function signatures for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->