### PR TITLE
fix: (Low-Code) (DeclarativeOAuthFlow) - fix `tooltip examples` and `labels` representation to show values instead of full object

### DIFF
--- a/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -2139,7 +2139,7 @@ definitions:
               - https://domain.host.com/marketing_api/auth?{client_id_key}={{client_id_key}}&{redirect_uri_key}={urlEncoder:{{redirect_uri_key}}}&{state_key}={{state_key}}
               - https://endpoint.host.com/oauth2/authorize?{client_id_key}={{client_id_key}}&{redirect_uri_key}={urlEncoder:{{redirect_uri_key}}}&{scope_key}={urlEncoder:{{scope_key}}}&{state_key}={{state_key}}&subdomain={subdomain}
           scope:
-            title: (Optional) Scope
+            title: Scopes
             type: string
             description: |-
               The DeclarativeOAuth Specific string of the scopes needed to be grant for authenticated user.
@@ -2154,7 +2154,7 @@ definitions:
             examples:
               - https://auth.host.com/oauth2/token?{client_id_key}={{client_id_key}}&{client_secret_key}={{client_secret_key}}&{auth_code_key}={{auth_code_key}}&{redirect_uri_key}={urlEncoder:{{redirect_uri_key}}}
           access_token_headers:
-            title: (Optional) Access Token Headers
+            title: Access Token Headers
             type: object
             additionalProperties: true
             description: |-
@@ -2162,14 +2162,18 @@ definitions:
             examples:
               - {"Authorization": "Basic {base64Encoder:{client_id}:{client_secret}}"}
           access_token_params:
-            title: (Optional) Access Token Query Params (Json Encoded)
+            title: Access Token Query Params (Json Encoded)
             type: object
             additionalProperties: true
             description: |-
               The DeclarativeOAuth Specific optional query parameters to inject while exchanging the `auth_code` to `access_token` during `completeOAuthFlow` step.
               When this property is provided, the query params will be encoded as `Json` and included in the outgoing API request.
             examples:
-              - {"{client_id_key}": "{{client_id_key}}"}
+              - {
+                  "{auth_code_key}": "{{auth_code_key}}",
+                  "{client_id_key}": "{{client_id_key}}",
+                  "{client_secret_key}": "{{client_secret_key}}",
+                }
           extract_output:
             title: Extract Output
             type: array
@@ -2180,7 +2184,7 @@ definitions:
             examples:
               - ["access_token", "refresh_token", "other_field"]
           state:
-            title: (Optional) Configurable State Query Param
+            title: Configurable State Query Param
             type: object
             additionalProperties: true
             required:
@@ -2197,42 +2201,42 @@ definitions:
             examples:
               - { "min": 7, "max": 128 }
           client_id_key:
-            title: (Optional) Client ID Key Override
+            title: Client ID Key Override
             type: string
             description: |-
               The DeclarativeOAuth Specific optional override to provide the custom `client_id` key name, if required by data-provider.
             examples:
               - "my_custom_client_id_key_name"
           client_secret_key:
-            title: (Optional) Client Secret Key Override
+            title: Client Secret Key Override
             type: string
             description: |-
               The DeclarativeOAuth Specific optional override to provide the custom `client_secret` key name, if required by data-provider.
             examples:
               - "my_custom_client_secret_key_name"
           scope_key:
-            title: (Optional) Scope Key Override
+            title: Scopes Key Override
             type: string
             description: |-
               The DeclarativeOAuth Specific optional override to provide the custom `scope` key name, if required by data-provider.
             examples:
               - "my_custom_scope_key_key_name"
           state_key:
-            title: (Optional) State Key Override
+            title: State Key Override
             type: string
             description: |-
               The DeclarativeOAuth Specific optional override to provide the custom `state` key name, if required by data-provider.
             examples:
               - "my_custom_state_key_key_name"
           auth_code_key:
-            title: (Optional) Auth Code Key Override
+            title: Auth Code Key Override
             type: string
             description: |-
               The DeclarativeOAuth Specific optional override to provide the custom `code` key name to something like `auth_code` or `custom_auth_code`, if required by data-provider.
             examples:
               - "my_custom_auth_code_key_name"
           redirect_uri_key:
-            title: (Optional) Redirect URI Key Override
+            title: Redirect URI Key Override
             type: string
             description: |-
               The DeclarativeOAuth Specific optional override to provide the custom `redirect_uri` key name to something like `callback_uri`, if required by data-provider.

--- a/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -2136,15 +2136,15 @@ definitions:
               The DeclarativeOAuth Specific string URL string template to initiate the authentication.
               The placeholders are replaced during the processing to provide neccessary values.
             examples:
-              - consent_url: https://domain.host.com/marketing_api/auth?{client_id_key}={{client_id_key}}&{redirect_uri_key}={urlEncoder:{{redirect_uri_key}}}&{state_key}={{state_key}}
-              - consent_url: https://endpoint.host.com/oauth2/authorize?{client_id_key}={{client_id_key}}&{redirect_uri_key}={urlEncoder:{{redirect_uri_key}}}&{scope_key}={urlEncoder:{{scope_key}}}&{state_key}={{state_key}}&subdomain={subdomain}
+              - https://domain.host.com/marketing_api/auth?{client_id_key}={{client_id_key}}&{redirect_uri_key}={urlEncoder:{{redirect_uri_key}}}&{state_key}={{state_key}}
+              - https://endpoint.host.com/oauth2/authorize?{client_id_key}={{client_id_key}}&{redirect_uri_key}={urlEncoder:{{redirect_uri_key}}}&{scope_key}={urlEncoder:{{scope_key}}}&{state_key}={{state_key}}&subdomain={subdomain}
           scope:
             title: (Optional) DeclarativeOAuth Scope
             type: string
             description: |-
               The DeclarativeOAuth Specific string of the scopes needed to be grant for authenticated user.
             examples:
-              - scope: user:read user:read_orders workspaces:read
+              - user:read user:read_orders workspaces:read
           access_token_url:
             title: DeclarativeOAuth Access Token URL
             type: string
@@ -2152,7 +2152,7 @@ definitions:
               The DeclarativeOAuth Specific URL templated string to obtain the `access_token`, `refresh_token` etc.
               The placeholders are replaced during the processing to provide neccessary values.
             examples:
-              - access_token_url: https://auth.host.com/oauth2/token?{client_id_key}={{client_id_key}}&{client_secret_key}={{client_secret_key}}&{auth_code_key}={{auth_code_key}}&{redirect_uri_key}={urlEncoder:{{redirect_uri_key}}}
+              - https://auth.host.com/oauth2/token?{client_id_key}={{client_id_key}}&{client_secret_key}={{client_secret_key}}&{auth_code_key}={{auth_code_key}}&{redirect_uri_key}={urlEncoder:{{redirect_uri_key}}}
           access_token_headers:
             title: (Optional) DeclarativeOAuth Access Token Headers
             type: object
@@ -2160,10 +2160,7 @@ definitions:
             description: |-
               The DeclarativeOAuth Specific optional headers to inject while exchanging the `auth_code` to `access_token` during `completeOAuthFlow` step.
             examples:
-              - access_token_headers:
-                  {
-                    "Authorization": "Basic {base64Encoder:{client_id}:{client_secret}}",
-                  }
+              - {"Authorization": "Basic {base64Encoder:{client_id}:{client_secret}}"}
           access_token_params:
             title: (Optional) DeclarativeOAuth Access Token Query Params (Json Encoded)
             type: object
@@ -2172,12 +2169,7 @@ definitions:
               The DeclarativeOAuth Specific optional query parameters to inject while exchanging the `auth_code` to `access_token` during `completeOAuthFlow` step.
               When this property is provided, the query params will be encoded as `Json` and included in the outgoing API request.
             examples:
-              - access_token_params:
-                  {
-                    "{auth_code_key}": "{{auth_code_key}}",
-                    "{client_id_key}": "{{client_id_key}}",
-                    "{client_secret_key}": "{{client_secret_key}}",
-                  }
+              - {"{client_id_key}": "{{client_id_key}}"}
           extract_output:
             title: DeclarativeOAuth Extract Output
             type: array
@@ -2186,7 +2178,7 @@ definitions:
             description: |-
               The DeclarativeOAuth Specific list of strings to indicate which keys should be extracted and returned back to the input config.
             examples:
-              - extract_output: ["access_token", "refresh_token", "other_field"]
+              - ["access_token", "refresh_token", "other_field"]
           state:
             title: (Optional) DeclarativeOAuth Configurable State Query Param
             type: object
@@ -2203,49 +2195,49 @@ definitions:
               max:
                 type: integer
             examples:
-              - state: { "min": 7, "max": 128 }
+              - { "min": 7, "max": 128 }
           client_id_key:
             title: (Optional) DeclarativeOAuth Client ID Key Override
             type: string
             description: |-
               The DeclarativeOAuth Specific optional override to provide the custom `client_id` key name, if required by data-provider.
             examples:
-              - client_id_key: "my_custom_client_id_key_name"
+              - "my_custom_client_id_key_name"
           client_secret_key:
             title: (Optional) DeclarativeOAuth Client Secret Key Override
             type: string
             description: |-
               The DeclarativeOAuth Specific optional override to provide the custom `client_secret` key name, if required by data-provider.
             examples:
-              - client_secret_key: "my_custom_client_secret_key_name"
+              - "my_custom_client_secret_key_name"
           scope_key:
             title: (Optional) DeclarativeOAuth Scope Key Override
             type: string
             description: |-
               The DeclarativeOAuth Specific optional override to provide the custom `scope` key name, if required by data-provider.
             examples:
-              - scope_key: "my_custom_scope_key_key_name"
+              - "my_custom_scope_key_key_name"
           state_key:
             title: (Optional) DeclarativeOAuth State Key Override
             type: string
             description: |-
               The DeclarativeOAuth Specific optional override to provide the custom `state` key name, if required by data-provider.
             examples:
-              - state_key: "my_custom_state_key_key_name"
+              - "my_custom_state_key_key_name"
           auth_code_key:
             title: (Optional) DeclarativeOAuth Auth Code Key Override
             type: string
             description: |-
               The DeclarativeOAuth Specific optional override to provide the custom `code` key name to something like `auth_code` or `custom_auth_code`, if required by data-provider.
             examples:
-              - auth_code_key: "my_custom_auth_code_key_name"
+              - "my_custom_auth_code_key_name"
           redirect_uri_key:
             title: (Optional) DeclarativeOAuth Redirect URI Key Override
             type: string
             description: |-
               The DeclarativeOAuth Specific optional override to provide the custom `redirect_uri` key name to something like `callback_uri`, if required by data-provider.
             examples:
-              - redirect_uri_key: "my_custom_redirect_uri_key_name"
+              - "my_custom_redirect_uri_key_name"
       complete_oauth_output_specification:
         title: "OAuth output specification"
         description: |-

--- a/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -2130,7 +2130,7 @@ definitions:
           - extract_output
         properties:
           consent_url:
-            title: DeclarativeOAuth Consent URL
+            title: Consent URL
             type: string
             description: |-
               The DeclarativeOAuth Specific string URL string template to initiate the authentication.
@@ -2139,14 +2139,14 @@ definitions:
               - https://domain.host.com/marketing_api/auth?{client_id_key}={{client_id_key}}&{redirect_uri_key}={urlEncoder:{{redirect_uri_key}}}&{state_key}={{state_key}}
               - https://endpoint.host.com/oauth2/authorize?{client_id_key}={{client_id_key}}&{redirect_uri_key}={urlEncoder:{{redirect_uri_key}}}&{scope_key}={urlEncoder:{{scope_key}}}&{state_key}={{state_key}}&subdomain={subdomain}
           scope:
-            title: (Optional) DeclarativeOAuth Scope
+            title: (Optional) Scope
             type: string
             description: |-
               The DeclarativeOAuth Specific string of the scopes needed to be grant for authenticated user.
             examples:
               - user:read user:read_orders workspaces:read
           access_token_url:
-            title: DeclarativeOAuth Access Token URL
+            title: Access Token URL
             type: string
             description: |-
               The DeclarativeOAuth Specific URL templated string to obtain the `access_token`, `refresh_token` etc.
@@ -2154,7 +2154,7 @@ definitions:
             examples:
               - https://auth.host.com/oauth2/token?{client_id_key}={{client_id_key}}&{client_secret_key}={{client_secret_key}}&{auth_code_key}={{auth_code_key}}&{redirect_uri_key}={urlEncoder:{{redirect_uri_key}}}
           access_token_headers:
-            title: (Optional) DeclarativeOAuth Access Token Headers
+            title: (Optional) Access Token Headers
             type: object
             additionalProperties: true
             description: |-
@@ -2162,7 +2162,7 @@ definitions:
             examples:
               - {"Authorization": "Basic {base64Encoder:{client_id}:{client_secret}}"}
           access_token_params:
-            title: (Optional) DeclarativeOAuth Access Token Query Params (Json Encoded)
+            title: (Optional) Access Token Query Params (Json Encoded)
             type: object
             additionalProperties: true
             description: |-
@@ -2171,7 +2171,7 @@ definitions:
             examples:
               - {"{client_id_key}": "{{client_id_key}}"}
           extract_output:
-            title: DeclarativeOAuth Extract Output
+            title: Extract Output
             type: array
             items:
               type: string
@@ -2180,7 +2180,7 @@ definitions:
             examples:
               - ["access_token", "refresh_token", "other_field"]
           state:
-            title: (Optional) DeclarativeOAuth Configurable State Query Param
+            title: (Optional) Configurable State Query Param
             type: object
             additionalProperties: true
             required:
@@ -2197,42 +2197,42 @@ definitions:
             examples:
               - { "min": 7, "max": 128 }
           client_id_key:
-            title: (Optional) DeclarativeOAuth Client ID Key Override
+            title: (Optional) Client ID Key Override
             type: string
             description: |-
               The DeclarativeOAuth Specific optional override to provide the custom `client_id` key name, if required by data-provider.
             examples:
               - "my_custom_client_id_key_name"
           client_secret_key:
-            title: (Optional) DeclarativeOAuth Client Secret Key Override
+            title: (Optional) Client Secret Key Override
             type: string
             description: |-
               The DeclarativeOAuth Specific optional override to provide the custom `client_secret` key name, if required by data-provider.
             examples:
               - "my_custom_client_secret_key_name"
           scope_key:
-            title: (Optional) DeclarativeOAuth Scope Key Override
+            title: (Optional) Scope Key Override
             type: string
             description: |-
               The DeclarativeOAuth Specific optional override to provide the custom `scope` key name, if required by data-provider.
             examples:
               - "my_custom_scope_key_key_name"
           state_key:
-            title: (Optional) DeclarativeOAuth State Key Override
+            title: (Optional) State Key Override
             type: string
             description: |-
               The DeclarativeOAuth Specific optional override to provide the custom `state` key name, if required by data-provider.
             examples:
               - "my_custom_state_key_key_name"
           auth_code_key:
-            title: (Optional) DeclarativeOAuth Auth Code Key Override
+            title: (Optional) Auth Code Key Override
             type: string
             description: |-
               The DeclarativeOAuth Specific optional override to provide the custom `code` key name to something like `auth_code` or `custom_auth_code`, if required by data-provider.
             examples:
               - "my_custom_auth_code_key_name"
           redirect_uri_key:
-            title: (Optional) DeclarativeOAuth Redirect URI Key Override
+            title: (Optional) Redirect URI Key Override
             type: string
             description: |-
               The DeclarativeOAuth Specific optional override to provide the custom `redirect_uri` key name to something like `callback_uri`, if required by data-provider.

--- a/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
+++ b/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
@@ -798,13 +798,13 @@ class OauthConnectorInputSpecification(BaseModel):
             "https://domain.host.com/marketing_api/auth?{client_id_key}={{client_id_key}}&{redirect_uri_key}={urlEncoder:{{redirect_uri_key}}}&{state_key}={{state_key}}",
             "https://endpoint.host.com/oauth2/authorize?{client_id_key}={{client_id_key}}&{redirect_uri_key}={urlEncoder:{{redirect_uri_key}}}&{scope_key}={urlEncoder:{{scope_key}}}&{state_key}={{state_key}}&subdomain={subdomain}",
         ],
-        title="DeclarativeOAuth Consent URL",
+        title="Consent URL",
     )
     scope: Optional[str] = Field(
         None,
         description="The DeclarativeOAuth Specific string of the scopes needed to be grant for authenticated user.",
         examples=["user:read user:read_orders workspaces:read"],
-        title="(Optional) DeclarativeOAuth Scope",
+        title="(Optional) Scope",
     )
     access_token_url: str = Field(
         ...,
@@ -812,67 +812,67 @@ class OauthConnectorInputSpecification(BaseModel):
         examples=[
             "https://auth.host.com/oauth2/token?{client_id_key}={{client_id_key}}&{client_secret_key}={{client_secret_key}}&{auth_code_key}={{auth_code_key}}&{redirect_uri_key}={urlEncoder:{{redirect_uri_key}}}"
         ],
-        title="DeclarativeOAuth Access Token URL",
+        title="Access Token URL",
     )
     access_token_headers: Optional[Dict[str, Any]] = Field(
         None,
         description="The DeclarativeOAuth Specific optional headers to inject while exchanging the `auth_code` to `access_token` during `completeOAuthFlow` step.",
         examples=[{"Authorization": "Basic {base64Encoder:{client_id}:{client_secret}}"}],
-        title="(Optional) DeclarativeOAuth Access Token Headers",
+        title="(Optional) Access Token Headers",
     )
     access_token_params: Optional[Dict[str, Any]] = Field(
         None,
         description="The DeclarativeOAuth Specific optional query parameters to inject while exchanging the `auth_code` to `access_token` during `completeOAuthFlow` step.\nWhen this property is provided, the query params will be encoded as `Json` and included in the outgoing API request.",
         examples=[{"{client_id_key}": "{{client_id_key}}"}],
-        title="(Optional) DeclarativeOAuth Access Token Query Params (Json Encoded)",
+        title="(Optional) Access Token Query Params (Json Encoded)",
     )
     extract_output: List[str] = Field(
         ...,
         description="The DeclarativeOAuth Specific list of strings to indicate which keys should be extracted and returned back to the input config.",
         examples=[["access_token", "refresh_token", "other_field"]],
-        title="DeclarativeOAuth Extract Output",
+        title="Extract Output",
     )
     state: Optional[State] = Field(
         None,
         description="The DeclarativeOAuth Specific object to provide the criteria of how the `state` query param should be constructed,\nincluding length and complexity.",
         examples=[{"min": 7, "max": 128}],
-        title="(Optional) DeclarativeOAuth Configurable State Query Param",
+        title="(Optional) Configurable State Query Param",
     )
     client_id_key: Optional[str] = Field(
         None,
         description="The DeclarativeOAuth Specific optional override to provide the custom `client_id` key name, if required by data-provider.",
         examples=["my_custom_client_id_key_name"],
-        title="(Optional) DeclarativeOAuth Client ID Key Override",
+        title="(Optional) Client ID Key Override",
     )
     client_secret_key: Optional[str] = Field(
         None,
         description="The DeclarativeOAuth Specific optional override to provide the custom `client_secret` key name, if required by data-provider.",
         examples=["my_custom_client_secret_key_name"],
-        title="(Optional) DeclarativeOAuth Client Secret Key Override",
+        title="(Optional) Client Secret Key Override",
     )
     scope_key: Optional[str] = Field(
         None,
         description="The DeclarativeOAuth Specific optional override to provide the custom `scope` key name, if required by data-provider.",
         examples=["my_custom_scope_key_key_name"],
-        title="(Optional) DeclarativeOAuth Scope Key Override",
+        title="(Optional) Scope Key Override",
     )
     state_key: Optional[str] = Field(
         None,
         description="The DeclarativeOAuth Specific optional override to provide the custom `state` key name, if required by data-provider.",
         examples=["my_custom_state_key_key_name"],
-        title="(Optional) DeclarativeOAuth State Key Override",
+        title="(Optional) State Key Override",
     )
     auth_code_key: Optional[str] = Field(
         None,
         description="The DeclarativeOAuth Specific optional override to provide the custom `code` key name to something like `auth_code` or `custom_auth_code`, if required by data-provider.",
         examples=["my_custom_auth_code_key_name"],
-        title="(Optional) DeclarativeOAuth Auth Code Key Override",
+        title="(Optional) Auth Code Key Override",
     )
     redirect_uri_key: Optional[str] = Field(
         None,
         description="The DeclarativeOAuth Specific optional override to provide the custom `redirect_uri` key name to something like `callback_uri`, if required by data-provider.",
         examples=["my_custom_redirect_uri_key_name"],
-        title="(Optional) DeclarativeOAuth Redirect URI Key Override",
+        title="(Optional) Redirect URI Key Override",
     )
 
 

--- a/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
+++ b/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
@@ -804,7 +804,7 @@ class OauthConnectorInputSpecification(BaseModel):
         None,
         description="The DeclarativeOAuth Specific string of the scopes needed to be grant for authenticated user.",
         examples=["user:read user:read_orders workspaces:read"],
-        title="(Optional) Scope",
+        title="Scopes",
     )
     access_token_url: str = Field(
         ...,
@@ -818,13 +818,19 @@ class OauthConnectorInputSpecification(BaseModel):
         None,
         description="The DeclarativeOAuth Specific optional headers to inject while exchanging the `auth_code` to `access_token` during `completeOAuthFlow` step.",
         examples=[{"Authorization": "Basic {base64Encoder:{client_id}:{client_secret}}"}],
-        title="(Optional) Access Token Headers",
+        title="Access Token Headers",
     )
     access_token_params: Optional[Dict[str, Any]] = Field(
         None,
         description="The DeclarativeOAuth Specific optional query parameters to inject while exchanging the `auth_code` to `access_token` during `completeOAuthFlow` step.\nWhen this property is provided, the query params will be encoded as `Json` and included in the outgoing API request.",
-        examples=[{"{client_id_key}": "{{client_id_key}}"}],
-        title="(Optional) Access Token Query Params (Json Encoded)",
+        examples=[
+            {
+                "{auth_code_key}": "{{auth_code_key}}",
+                "{client_id_key}": "{{client_id_key}}",
+                "{client_secret_key}": "{{client_secret_key}}",
+            }
+        ],
+        title="Access Token Query Params (Json Encoded)",
     )
     extract_output: List[str] = Field(
         ...,
@@ -836,43 +842,43 @@ class OauthConnectorInputSpecification(BaseModel):
         None,
         description="The DeclarativeOAuth Specific object to provide the criteria of how the `state` query param should be constructed,\nincluding length and complexity.",
         examples=[{"min": 7, "max": 128}],
-        title="(Optional) Configurable State Query Param",
+        title="Configurable State Query Param",
     )
     client_id_key: Optional[str] = Field(
         None,
         description="The DeclarativeOAuth Specific optional override to provide the custom `client_id` key name, if required by data-provider.",
         examples=["my_custom_client_id_key_name"],
-        title="(Optional) Client ID Key Override",
+        title="Client ID Key Override",
     )
     client_secret_key: Optional[str] = Field(
         None,
         description="The DeclarativeOAuth Specific optional override to provide the custom `client_secret` key name, if required by data-provider.",
         examples=["my_custom_client_secret_key_name"],
-        title="(Optional) Client Secret Key Override",
+        title="Client Secret Key Override",
     )
     scope_key: Optional[str] = Field(
         None,
         description="The DeclarativeOAuth Specific optional override to provide the custom `scope` key name, if required by data-provider.",
         examples=["my_custom_scope_key_key_name"],
-        title="(Optional) Scope Key Override",
+        title="Scopes Key Override",
     )
     state_key: Optional[str] = Field(
         None,
         description="The DeclarativeOAuth Specific optional override to provide the custom `state` key name, if required by data-provider.",
         examples=["my_custom_state_key_key_name"],
-        title="(Optional) State Key Override",
+        title="State Key Override",
     )
     auth_code_key: Optional[str] = Field(
         None,
         description="The DeclarativeOAuth Specific optional override to provide the custom `code` key name to something like `auth_code` or `custom_auth_code`, if required by data-provider.",
         examples=["my_custom_auth_code_key_name"],
-        title="(Optional) Auth Code Key Override",
+        title="Auth Code Key Override",
     )
     redirect_uri_key: Optional[str] = Field(
         None,
         description="The DeclarativeOAuth Specific optional override to provide the custom `redirect_uri` key name to something like `callback_uri`, if required by data-provider.",
         examples=["my_custom_redirect_uri_key_name"],
-        title="(Optional) Redirect URI Key Override",
+        title="Redirect URI Key Override",
     )
 
 

--- a/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
+++ b/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
@@ -795,103 +795,83 @@ class OauthConnectorInputSpecification(BaseModel):
         ...,
         description="The DeclarativeOAuth Specific string URL string template to initiate the authentication.\nThe placeholders are replaced during the processing to provide neccessary values.",
         examples=[
-            {
-                "consent_url": "https://domain.host.com/marketing_api/auth?{client_id_key}={{client_id_key}}&{redirect_uri_key}={urlEncoder:{{redirect_uri_key}}}&{state_key}={{state_key}}"
-            },
-            {
-                "consent_url": "https://endpoint.host.com/oauth2/authorize?{client_id_key}={{client_id_key}}&{redirect_uri_key}={urlEncoder:{{redirect_uri_key}}}&{scope_key}={urlEncoder:{{scope_key}}}&{state_key}={{state_key}}&subdomain={subdomain}"
-            },
+            "https://domain.host.com/marketing_api/auth?{client_id_key}={{client_id_key}}&{redirect_uri_key}={urlEncoder:{{redirect_uri_key}}}&{state_key}={{state_key}}",
+            "https://endpoint.host.com/oauth2/authorize?{client_id_key}={{client_id_key}}&{redirect_uri_key}={urlEncoder:{{redirect_uri_key}}}&{scope_key}={urlEncoder:{{scope_key}}}&{state_key}={{state_key}}&subdomain={subdomain}",
         ],
         title="DeclarativeOAuth Consent URL",
     )
     scope: Optional[str] = Field(
         None,
         description="The DeclarativeOAuth Specific string of the scopes needed to be grant for authenticated user.",
-        examples=[{"scope": "user:read user:read_orders workspaces:read"}],
+        examples=["user:read user:read_orders workspaces:read"],
         title="(Optional) DeclarativeOAuth Scope",
     )
     access_token_url: str = Field(
         ...,
         description="The DeclarativeOAuth Specific URL templated string to obtain the `access_token`, `refresh_token` etc.\nThe placeholders are replaced during the processing to provide neccessary values.",
         examples=[
-            {
-                "access_token_url": "https://auth.host.com/oauth2/token?{client_id_key}={{client_id_key}}&{client_secret_key}={{client_secret_key}}&{auth_code_key}={{auth_code_key}}&{redirect_uri_key}={urlEncoder:{{redirect_uri_key}}}"
-            }
+            "https://auth.host.com/oauth2/token?{client_id_key}={{client_id_key}}&{client_secret_key}={{client_secret_key}}&{auth_code_key}={{auth_code_key}}&{redirect_uri_key}={urlEncoder:{{redirect_uri_key}}}"
         ],
         title="DeclarativeOAuth Access Token URL",
     )
     access_token_headers: Optional[Dict[str, Any]] = Field(
         None,
         description="The DeclarativeOAuth Specific optional headers to inject while exchanging the `auth_code` to `access_token` during `completeOAuthFlow` step.",
-        examples=[
-            {
-                "access_token_headers": {
-                    "Authorization": "Basic {base64Encoder:{client_id}:{client_secret}}"
-                }
-            }
-        ],
+        examples=[{"Authorization": "Basic {base64Encoder:{client_id}:{client_secret}}"}],
         title="(Optional) DeclarativeOAuth Access Token Headers",
     )
     access_token_params: Optional[Dict[str, Any]] = Field(
         None,
         description="The DeclarativeOAuth Specific optional query parameters to inject while exchanging the `auth_code` to `access_token` during `completeOAuthFlow` step.\nWhen this property is provided, the query params will be encoded as `Json` and included in the outgoing API request.",
-        examples=[
-            {
-                "access_token_params": {
-                    "{auth_code_key}": "{{auth_code_key}}",
-                    "{client_id_key}": "{{client_id_key}}",
-                    "{client_secret_key}": "{{client_secret_key}}",
-                }
-            }
-        ],
+        examples=[{"{client_id_key}": "{{client_id_key}}"}],
         title="(Optional) DeclarativeOAuth Access Token Query Params (Json Encoded)",
     )
     extract_output: List[str] = Field(
         ...,
         description="The DeclarativeOAuth Specific list of strings to indicate which keys should be extracted and returned back to the input config.",
-        examples=[{"extract_output": ["access_token", "refresh_token", "other_field"]}],
+        examples=[["access_token", "refresh_token", "other_field"]],
         title="DeclarativeOAuth Extract Output",
     )
     state: Optional[State] = Field(
         None,
         description="The DeclarativeOAuth Specific object to provide the criteria of how the `state` query param should be constructed,\nincluding length and complexity.",
-        examples=[{"state": {"min": 7, "max": 128}}],
+        examples=[{"min": 7, "max": 128}],
         title="(Optional) DeclarativeOAuth Configurable State Query Param",
     )
     client_id_key: Optional[str] = Field(
         None,
         description="The DeclarativeOAuth Specific optional override to provide the custom `client_id` key name, if required by data-provider.",
-        examples=[{"client_id_key": "my_custom_client_id_key_name"}],
+        examples=["my_custom_client_id_key_name"],
         title="(Optional) DeclarativeOAuth Client ID Key Override",
     )
     client_secret_key: Optional[str] = Field(
         None,
         description="The DeclarativeOAuth Specific optional override to provide the custom `client_secret` key name, if required by data-provider.",
-        examples=[{"client_secret_key": "my_custom_client_secret_key_name"}],
+        examples=["my_custom_client_secret_key_name"],
         title="(Optional) DeclarativeOAuth Client Secret Key Override",
     )
     scope_key: Optional[str] = Field(
         None,
         description="The DeclarativeOAuth Specific optional override to provide the custom `scope` key name, if required by data-provider.",
-        examples=[{"scope_key": "my_custom_scope_key_key_name"}],
+        examples=["my_custom_scope_key_key_name"],
         title="(Optional) DeclarativeOAuth Scope Key Override",
     )
     state_key: Optional[str] = Field(
         None,
         description="The DeclarativeOAuth Specific optional override to provide the custom `state` key name, if required by data-provider.",
-        examples=[{"state_key": "my_custom_state_key_key_name"}],
+        examples=["my_custom_state_key_key_name"],
         title="(Optional) DeclarativeOAuth State Key Override",
     )
     auth_code_key: Optional[str] = Field(
         None,
         description="The DeclarativeOAuth Specific optional override to provide the custom `code` key name to something like `auth_code` or `custom_auth_code`, if required by data-provider.",
-        examples=[{"auth_code_key": "my_custom_auth_code_key_name"}],
+        examples=["my_custom_auth_code_key_name"],
         title="(Optional) DeclarativeOAuth Auth Code Key Override",
     )
     redirect_uri_key: Optional[str] = Field(
         None,
         description="The DeclarativeOAuth Specific optional override to provide the custom `redirect_uri` key name to something like `callback_uri`, if required by data-provider.",
-        examples=[{"redirect_uri_key": "my_custom_redirect_uri_key_name"}],
+        examples=["my_custom_redirect_uri_key_name"],
         title="(Optional) DeclarativeOAuth Redirect URI Key Override",
     )
 


### PR DESCRIPTION
## What
Based on this review comment, there is a need to fix how tooltip are represented in order not to confuse Customers.

https://github.com/airbytehq/airbyte-platform-internal/pull/14785#discussion_r1881195226

## How
- edited the `declarative_component_schema.yaml`
- rebuild the models

## User Impact
No impact is expected. Not a breaking change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced new components: `ComponentMappingDefinition`, `HttpComponentsResolver`, and `StreamConfig` for enhanced data handling and configuration.

- **Updates**
  - Enhanced `OAuthConfigSpecification` with clearer descriptions and simplified examples.
  - Refined `DeclarativeStream` and `DynamicDeclarativeStream` for better clarity on their functionalities.

- **Improvements**
  - Expanded interpolation section with new macros and filters for dynamic data management.
  - Streamlined example values in `OauthConnectorInputSpecification` for improved readability and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->