### PR TITLE
feat(Low-Code Concurrent CDK): Make SimpleRetriever thread-safe so that different partitions can share the same SimpleRetriever

### DIFF
--- a/airbyte_cdk/sources/declarative/concurrent_declarative_source.py
+++ b/airbyte_cdk/sources/declarative/concurrent_declarative_source.py
@@ -242,6 +242,8 @@ class ConcurrentDeclarativeSource(ManifestDeclarativeSource, Generic[TState]):
                         # still rely on a DatetimeBasedCursor that is properly initialized with state.
                         if retriever.cursor:
                             retriever.cursor.set_initial_state(stream_state=stream_state)
+                        # We zero it out here, but since this is a cursor reference, the state is still properly
+                        # instantiated for the other components that reference it
                         retriever.cursor = None
 
                     partition_generator = StreamSlicerPartitionGenerator(

--- a/airbyte_cdk/sources/declarative/concurrent_declarative_source.py
+++ b/airbyte_cdk/sources/declarative/concurrent_declarative_source.py
@@ -3,7 +3,7 @@
 #
 
 import logging
-from typing import Any, Callable, Generic, Iterator, List, Mapping, Optional, Tuple, Union
+from typing import Any, Generic, Iterator, List, Mapping, Optional, Tuple
 
 from airbyte_cdk.models import (
     AirbyteCatalog,
@@ -28,15 +28,11 @@ from airbyte_cdk.sources.declarative.models.declarative_component_schema import 
 from airbyte_cdk.sources.declarative.models.declarative_component_schema import (
     DatetimeBasedCursor as DatetimeBasedCursorModel,
 )
-from airbyte_cdk.sources.declarative.models.declarative_component_schema import (
-    DeclarativeStream as DeclarativeStreamModel,
-)
 from airbyte_cdk.sources.declarative.parsers.model_to_component_factory import (
-    ComponentDefinition,
     ModelToComponentFactory,
 )
 from airbyte_cdk.sources.declarative.requesters import HttpRequester
-from airbyte_cdk.sources.declarative.retrievers import Retriever, SimpleRetriever
+from airbyte_cdk.sources.declarative.retrievers import SimpleRetriever
 from airbyte_cdk.sources.declarative.stream_slicers.declarative_partition_generator import (
     DeclarativePartitionFactory,
     StreamSlicerPartitionGenerator,
@@ -52,7 +48,6 @@ from airbyte_cdk.sources.streams.concurrent.availability_strategy import (
 from airbyte_cdk.sources.streams.concurrent.cursor import FinalStateCursor
 from airbyte_cdk.sources.streams.concurrent.default_stream import DefaultStream
 from airbyte_cdk.sources.streams.concurrent.helpers import get_primary_key_from_stream
-from airbyte_cdk.sources.types import Config, StreamState
 
 
 class ConcurrentDeclarativeSource(ManifestDeclarativeSource, Generic[TState]):
@@ -240,15 +235,25 @@ class ConcurrentDeclarativeSource(ManifestDeclarativeSource, Generic[TState]):
                         stream_state=stream_state,
                     )
 
+                    retriever = declarative_stream.retriever
+
+                    # This is an optimization so that we don't invoke any cursor or state management flows within the
+                    # low-code framework because state management is handled through the ConcurrentCursor.
+                    if declarative_stream and isinstance(retriever, SimpleRetriever):
+                        # Also a temporary hack. In the legacy Stream implementation, as part of the read,
+                        # set_initial_state() is called to instantiate incoming state on the cursor. Although we no
+                        # longer rely on the legacy low-code cursor for concurrent checkpointing, low-code components
+                        # like StopConditionPaginationStrategyDecorator and ClientSideIncrementalRecordFilterDecorator
+                        # still rely on a DatetimeBasedCursor that is properly initialized with state.
+                        if retriever.cursor:
+                            retriever.cursor.set_initial_state(stream_state=stream_state)
+                        retriever.cursor = None
+
                     partition_generator = StreamSlicerPartitionGenerator(
                         DeclarativePartitionFactory(
                             declarative_stream.name,
                             declarative_stream.get_json_schema(),
-                            self._retriever_factory(
-                                name_to_stream_mapping[declarative_stream.name],
-                                config,
-                                stream_state,
-                            ),
+                            retriever,
                             self.message_repository,
                         ),
                         cursor,
@@ -274,26 +279,11 @@ class ConcurrentDeclarativeSource(ManifestDeclarativeSource, Generic[TState]):
                 elif (
                     is_substream_without_incremental or is_without_partition_router_or_cursor
                 ) and hasattr(declarative_stream.retriever, "stream_slicer"):
-                    if is_async_job_stream:
-                        # A stream's AsyncRetriever must be shared across all partitions because it uses a
-                        # shared JobRepository to manage the state of jobs requests and when they are ready
-                        async_retriever = declarative_stream.retriever
-
-                        def async_retriever_factory_method() -> Retriever:
-                            return async_retriever
-
-                        retriever_factory = async_retriever_factory_method
-                    else:
-                        retriever_factory = self._retriever_factory(
-                            name_to_stream_mapping[declarative_stream.name],
-                            config,
-                            {},
-                        )
                     partition_generator = StreamSlicerPartitionGenerator(
                         DeclarativePartitionFactory(
                             declarative_stream.name,
                             declarative_stream.get_json_schema(),
-                            retriever_factory,
+                            declarative_stream.retriever,
                             self.message_repository,
                         ),
                         declarative_stream.retriever.stream_slicer,
@@ -432,34 +422,3 @@ class ConcurrentDeclarativeSource(ManifestDeclarativeSource, Generic[TState]):
                 if stream.stream.name not in concurrent_stream_names
             ]
         )
-
-    def _retriever_factory(
-        self, stream_config: ComponentDefinition, source_config: Config, stream_state: StreamState
-    ) -> Callable[[], Retriever]:
-        def _factory_method() -> Retriever:
-            declarative_stream: DeclarativeStream = self._constructor.create_component(
-                DeclarativeStreamModel,
-                stream_config,
-                source_config,
-                emit_connector_builder_messages=self._emit_connector_builder_messages,
-            )
-
-            # This is an optimization so that we don't invoke any cursor or state management flows within the
-            # low-code framework because state management is handled through the ConcurrentCursor.
-            if (
-                declarative_stream
-                and declarative_stream.retriever
-                and isinstance(declarative_stream.retriever, SimpleRetriever)
-            ):
-                # Also a temporary hack. In the legacy Stream implementation, as part of the read, set_initial_state() is
-                # called to instantiate incoming state on the cursor. Although we no longer rely on the legacy low-code cursor
-                # for concurrent checkpointing, low-code components like StopConditionPaginationStrategyDecorator and
-                # ClientSideIncrementalRecordFilterDecorator still rely on a DatetimeBasedCursor that is properly initialized
-                # with state.
-                if declarative_stream.retriever.cursor:
-                    declarative_stream.retriever.cursor.set_initial_state(stream_state=stream_state)
-                declarative_stream.retriever.cursor = None
-
-            return declarative_stream.retriever
-
-        return _factory_method

--- a/airbyte_cdk/sources/declarative/concurrent_declarative_source.py
+++ b/airbyte_cdk/sources/declarative/concurrent_declarative_source.py
@@ -275,6 +275,8 @@ class ConcurrentDeclarativeSource(ManifestDeclarativeSource, Generic[TState]):
                     is_substream_without_incremental or is_without_partition_router_or_cursor
                 ) and hasattr(declarative_stream.retriever, "stream_slicer"):
                     if is_async_job_stream:
+                        # A stream's AsyncRetriever must be shared across all partitions because it uses a
+                        # shared JobRepository to manage the state of jobs requests and when they are ready
                         async_retriever = declarative_stream.retriever
 
                         def async_retriever_factory_method() -> Retriever:

--- a/airbyte_cdk/sources/declarative/concurrent_declarative_source.py
+++ b/airbyte_cdk/sources/declarative/concurrent_declarative_source.py
@@ -213,11 +213,6 @@ class ConcurrentDeclarativeSource(ManifestDeclarativeSource, Generic[TState]):
                     and not incremental_sync_component_definition
                 )
 
-                is_async_job_stream = (
-                    name_to_stream_mapping[declarative_stream.name].get("retriever", {}).get("type")
-                    == "AsyncRetriever"
-                )
-
                 if self._is_datetime_incremental_without_partition_routing(
                     declarative_stream, incremental_sync_component_definition
                 ):

--- a/airbyte_cdk/sources/declarative/requesters/paginators/default_paginator.py
+++ b/airbyte_cdk/sources/declarative/requesters/paginators/default_paginator.py
@@ -112,7 +112,6 @@ class DefaultPaginator(Paginator):
             )
         if isinstance(self.url_base, str):
             self.url_base = InterpolatedString(string=self.url_base, parameters=parameters)
-        # self._token: Optional[Any] = self.pagination_strategy.initial_token
 
     def get_initial_token(self) -> Optional[Any]:
         """
@@ -130,7 +129,6 @@ class DefaultPaginator(Paginator):
         last_record: Optional[Record],
         last_page_token_value: Optional[Any] = None,
     ) -> Optional[Mapping[str, Any]]:
-        print("At the DefaultPaginator")
         next_page_token = self.pagination_strategy.next_page_token(
             response=response,
             last_page_size=last_page_size,
@@ -241,8 +239,6 @@ class PaginatorTestReadDecorator(Paginator):
         last_record: Optional[Record],
         last_page_token_value: Optional[Any] = None,
     ) -> Optional[Mapping[str, Any]]:
-        print("At the PaginatorTestReadDecorator")
-        print(f"page count = {self._page_count} and max pages = {self._maximum_number_of_pages}")
         if self._page_count >= self._maximum_number_of_pages:
             return None
 

--- a/airbyte_cdk/sources/declarative/requesters/paginators/default_paginator.py
+++ b/airbyte_cdk/sources/declarative/requesters/paginators/default_paginator.py
@@ -112,27 +112,40 @@ class DefaultPaginator(Paginator):
             )
         if isinstance(self.url_base, str):
             self.url_base = InterpolatedString(string=self.url_base, parameters=parameters)
-        self._token: Optional[Any] = self.pagination_strategy.initial_token
+        # self._token: Optional[Any] = self.pagination_strategy.initial_token
+
+    def get_initial_token(self) -> Optional[Any]:
+        """
+        Return the page token that should be used for the first request of a stream
+
+        WARNING: get_initial_token() should not be used by streams that use RFR that perform checkpointing
+        of state using page numbers. Because paginators are stateless
+        """
+        return self.pagination_strategy.initial_token
 
     def next_page_token(
-        self, response: requests.Response, last_page_size: int, last_record: Optional[Record]
+        self,
+        response: requests.Response,
+        last_page_size: int,
+        last_record: Optional[Record],
+        last_page_token_value: Optional[Any] = None,
     ) -> Optional[Mapping[str, Any]]:
-        self._token = self.pagination_strategy.next_page_token(
-            response, last_page_size, last_record
+        next_page_token = self.pagination_strategy.next_page_token(
+            response=response,
+            last_page_size=last_page_size,
+            last_record=last_record,
+            last_page_token_value=last_page_token_value,
         )
-        if self._token:
-            return {"next_page_token": self._token}
+        if next_page_token:
+            return {"next_page_token": next_page_token}
         else:
             return None
 
-    def path(self) -> Optional[str]:
-        if (
-            self._token
-            and self.page_token_option
-            and isinstance(self.page_token_option, RequestPath)
-        ):
+    def path(self, next_page_token: Mapping[str, Any]) -> Optional[str]:
+        token = next_page_token.get("next_page_token") if next_page_token else None
+        if token and self.page_token_option and isinstance(self.page_token_option, RequestPath):
             # Replace url base to only return the path
-            return str(self._token).replace(self.url_base.eval(self.config), "")  # type: ignore # url_base is casted to a InterpolatedString in __post_init__
+            return str(token).replace(self.url_base.eval(self.config), "")  # type: ignore # url_base is casted to a InterpolatedString in __post_init__
         else:
             return None
 
@@ -143,7 +156,7 @@ class DefaultPaginator(Paginator):
         stream_slice: Optional[StreamSlice] = None,
         next_page_token: Optional[Mapping[str, Any]] = None,
     ) -> MutableMapping[str, Any]:
-        return self._get_request_options(RequestOptionType.request_parameter)
+        return self._get_request_options(RequestOptionType.request_parameter, next_page_token)
 
     def get_request_headers(
         self,
@@ -152,7 +165,7 @@ class DefaultPaginator(Paginator):
         stream_slice: Optional[StreamSlice] = None,
         next_page_token: Optional[Mapping[str, Any]] = None,
     ) -> Mapping[str, str]:
-        return self._get_request_options(RequestOptionType.header)
+        return self._get_request_options(RequestOptionType.header, next_page_token)
 
     def get_request_body_data(
         self,
@@ -161,7 +174,7 @@ class DefaultPaginator(Paginator):
         stream_slice: Optional[StreamSlice] = None,
         next_page_token: Optional[Mapping[str, Any]] = None,
     ) -> Mapping[str, Any]:
-        return self._get_request_options(RequestOptionType.body_data)
+        return self._get_request_options(RequestOptionType.body_data, next_page_token)
 
     def get_request_body_json(
         self,
@@ -170,25 +183,21 @@ class DefaultPaginator(Paginator):
         stream_slice: Optional[StreamSlice] = None,
         next_page_token: Optional[Mapping[str, Any]] = None,
     ) -> Mapping[str, Any]:
-        return self._get_request_options(RequestOptionType.body_json)
+        return self._get_request_options(RequestOptionType.body_json, next_page_token)
 
-    def reset(self, reset_value: Optional[Any] = None) -> None:
-        if reset_value:
-            self.pagination_strategy.reset(reset_value=reset_value)
-        else:
-            self.pagination_strategy.reset()
-        self._token = self.pagination_strategy.initial_token
-
-    def _get_request_options(self, option_type: RequestOptionType) -> MutableMapping[str, Any]:
+    def _get_request_options(
+        self, option_type: RequestOptionType, next_page_token: Optional[Mapping[str, Any]]
+    ) -> MutableMapping[str, Any]:
         options = {}
 
+        token = next_page_token.get("next_page_token") if next_page_token else None
         if (
             self.page_token_option
-            and self._token is not None
+            and token is not None
             and isinstance(self.page_token_option, RequestOption)
             and self.page_token_option.inject_into == option_type
         ):
-            options[self.page_token_option.field_name.eval(config=self.config)] = self._token  # type: ignore # field_name is always cast to an interpolated string
+            options[self.page_token_option.field_name.eval(config=self.config)] = token  # type: ignore # field_name is always cast to an interpolated string
         if (
             self.page_size_option
             and self.pagination_strategy.get_page_size()
@@ -217,17 +226,26 @@ class PaginatorTestReadDecorator(Paginator):
         self._decorated = decorated
         self._page_count = self._PAGE_COUNT_BEFORE_FIRST_NEXT_CALL
 
+    def get_initial_token(self) -> Optional[Any]:
+        return self._decorated.get_initial_token()
+
     def next_page_token(
-        self, response: requests.Response, last_page_size: int, last_record: Optional[Record]
+        self,
+        response: requests.Response,
+        last_page_size: int,
+        last_record: Optional[Record],
+        last_page_token_value: Optional[Any] = None,
     ) -> Optional[Mapping[str, Any]]:
         if self._page_count >= self._maximum_number_of_pages:
             return None
 
         self._page_count += 1
-        return self._decorated.next_page_token(response, last_page_size, last_record)
+        return self._decorated.next_page_token(
+            response, last_page_size, last_record, last_page_token_value
+        )
 
-    def path(self) -> Optional[str]:
-        return self._decorated.path()
+    def path(self, next_page_token: Mapping[str, Any]) -> Optional[str]:
+        return self._decorated.path(next_page_token)
 
     def get_request_params(
         self,
@@ -272,7 +290,3 @@ class PaginatorTestReadDecorator(Paginator):
         return self._decorated.get_request_body_json(
             stream_state=stream_state, stream_slice=stream_slice, next_page_token=next_page_token
         )
-
-    def reset(self, reset_value: Optional[Any] = None) -> None:
-        self._decorated.reset()
-        self._page_count = self._PAGE_COUNT_BEFORE_FIRST_NEXT_CALL

--- a/airbyte_cdk/sources/declarative/requesters/paginators/no_pagination.py
+++ b/airbyte_cdk/sources/declarative/requesters/paginators/no_pagination.py
@@ -19,7 +19,7 @@ class NoPagination(Paginator):
 
     parameters: InitVar[Mapping[str, Any]]
 
-    def path(self, next_page_token: Mapping[str, Any]) -> Optional[str]:
+    def path(self, next_page_token: Optional[Mapping[str, Any]]) -> Optional[str]:
         return None
 
     def get_request_params(

--- a/airbyte_cdk/sources/declarative/requesters/paginators/no_pagination.py
+++ b/airbyte_cdk/sources/declarative/requesters/paginators/no_pagination.py
@@ -19,7 +19,7 @@ class NoPagination(Paginator):
 
     parameters: InitVar[Mapping[str, Any]]
 
-    def path(self) -> Optional[str]:
+    def path(self, next_page_token: Mapping[str, Any]) -> Optional[str]:
         return None
 
     def get_request_params(
@@ -58,11 +58,14 @@ class NoPagination(Paginator):
     ) -> Mapping[str, Any]:
         return {}
 
-    def next_page_token(
-        self, response: requests.Response, last_page_size: int, last_record: Optional[Record]
-    ) -> Mapping[str, Any]:
-        return {}
+    def get_initial_token(self) -> Optional[Any]:
+        return None
 
-    def reset(self, reset_value: Optional[Any] = None) -> None:
-        # No state to reset
-        pass
+    def next_page_token(
+        self,
+        response: requests.Response,
+        last_page_size: int,
+        last_record: Optional[Record],
+        last_page_token_value: Optional[Any],
+    ) -> Optional[Mapping[str, Any]]:
+        return {}

--- a/airbyte_cdk/sources/declarative/requesters/paginators/paginator.py
+++ b/airbyte_cdk/sources/declarative/requesters/paginators/paginator.py
@@ -49,7 +49,7 @@ class Paginator(ABC, RequestOptionsProvider):
         pass
 
     @abstractmethod
-    def path(self, next_page_token: Mapping[str, Any]) -> Optional[str]:
+    def path(self, next_page_token: Optional[Mapping[str, Any]]) -> Optional[str]:
         """
         Returns the URL path to hit to fetch the next page of records
 

--- a/airbyte_cdk/sources/declarative/requesters/paginators/paginator.py
+++ b/airbyte_cdk/sources/declarative/requesters/paginators/paginator.py
@@ -24,14 +24,18 @@ class Paginator(ABC, RequestOptionsProvider):
     """
 
     @abstractmethod
-    def reset(self, reset_value: Optional[Any] = None) -> None:
+    def get_initial_token(self) -> Optional[Any]:
         """
-        Reset the pagination's inner state
+        Get the page token that should be included in the request to get the first page of records
         """
 
     @abstractmethod
     def next_page_token(
-        self, response: requests.Response, last_page_size: int, last_record: Optional[Record]
+        self,
+        response: requests.Response,
+        last_page_size: int,
+        last_record: Optional[Record],
+        last_page_token_value: Optional[Any],
     ) -> Optional[Mapping[str, Any]]:
         """
         Returns the next_page_token to use to fetch the next page of records.
@@ -39,12 +43,13 @@ class Paginator(ABC, RequestOptionsProvider):
         :param response: the response to process
         :param last_page_size: the number of records read from the response
         :param last_record: the last record extracted from the response
+        :param last_page_token_value: The current value of the page token made on the last request
         :return: A mapping {"next_page_token": <token>} for the next page from the input response object. Returning None means there are no more pages to read in this response.
         """
         pass
 
     @abstractmethod
-    def path(self) -> Optional[str]:
+    def path(self, next_page_token: Mapping[str, Any]) -> Optional[str]:
         """
         Returns the URL path to hit to fetch the next page of records
 

--- a/airbyte_cdk/sources/declarative/requesters/paginators/strategies/offset_increment.py
+++ b/airbyte_cdk/sources/declarative/requesters/paginators/strategies/offset_increment.py
@@ -52,7 +52,6 @@ class OffsetIncrement(PaginationStrategy):
     inject_on_first_request: bool = False
 
     def __post_init__(self, parameters: Mapping[str, Any]) -> None:
-        self._offset = 0
         page_size = str(self.page_size) if isinstance(self.page_size, int) else self.page_size
         if page_size:
             self._page_size: Optional[InterpolatedString] = InterpolatedString(
@@ -64,11 +63,15 @@ class OffsetIncrement(PaginationStrategy):
     @property
     def initial_token(self) -> Optional[Any]:
         if self.inject_on_first_request:
-            return self._offset
+            return 0
         return None
 
     def next_page_token(
-        self, response: requests.Response, last_page_size: int, last_record: Optional[Record]
+        self,
+        response: requests.Response,
+        last_page_size: int,
+        last_record: Optional[Record],
+        last_page_token_value: Optional[Any] = None,
     ) -> Optional[Any]:
         decoded_response = next(self.decoder.decode(response))
 
@@ -78,9 +81,17 @@ class OffsetIncrement(PaginationStrategy):
             and last_page_size < self._page_size.eval(self.config, response=decoded_response)
         ) or last_page_size == 0:
             return None
+        elif last_page_token_value is None:
+            # If the OffsetIncrement strategy does not inject on the first request, the incoming last_page_token_value
+            # will be None. For this case, we assume that None was the first page and progress to the next offset
+            return 0 + last_page_size
+        elif not isinstance(last_page_token_value, int):
+            raise ValueError(
+                "The page token for a OffsetIncrement pagination strategy must be an integer"
+            )
         else:
-            self._offset += last_page_size
-            return self._offset
+            next_page_token_value = last_page_token_value + last_page_size
+            return next_page_token_value
 
     def reset(self, reset_value: Optional[Any] = 0) -> None:
         if not isinstance(reset_value, int):

--- a/airbyte_cdk/sources/declarative/requesters/paginators/strategies/offset_increment.py
+++ b/airbyte_cdk/sources/declarative/requesters/paginators/strategies/offset_increment.py
@@ -87,19 +87,10 @@ class OffsetIncrement(PaginationStrategy):
             return 0 + last_page_size
         elif not isinstance(last_page_token_value, int):
             raise ValueError(
-                "The page token for a OffsetIncrement pagination strategy must be an integer"
+                f"Last page token value {last_page_token_value} for OffsetIncrement pagination strategy was not an integer"
             )
         else:
-            next_page_token_value = last_page_token_value + last_page_size
-            return next_page_token_value
-
-    def reset(self, reset_value: Optional[Any] = 0) -> None:
-        if not isinstance(reset_value, int):
-            raise ValueError(
-                f"Reset value {reset_value} for OffsetIncrement pagination strategy was not an integer"
-            )
-        else:
-            self._offset = reset_value
+            return last_page_token_value + last_page_size
 
     def get_page_size(self) -> Optional[int]:
         if self._page_size:

--- a/airbyte_cdk/sources/declarative/requesters/paginators/strategies/page_increment.py
+++ b/airbyte_cdk/sources/declarative/requesters/paginators/strategies/page_increment.py
@@ -62,7 +62,7 @@ class PageIncrement(PaginationStrategy):
             return self.start_from_page + 1
         elif not isinstance(last_page_token_value, int):
             raise ValueError(
-                "The page token for a PageIncrement pagination strategy must be an integer"
+                f"Last page token value {last_page_token_value} for PageIncrement pagination strategy was not an integer"
             )
         else:
             return last_page_token_value + 1

--- a/airbyte_cdk/sources/declarative/requesters/paginators/strategies/page_increment.py
+++ b/airbyte_cdk/sources/declarative/requesters/paginators/strategies/page_increment.py
@@ -31,7 +31,6 @@ class PageIncrement(PaginationStrategy):
     inject_on_first_request: bool = False
 
     def __post_init__(self, parameters: Mapping[str, Any]) -> None:
-        self._page = self.start_from_page
         if isinstance(self.page_size, int) or (self.page_size is None):
             self._page_size = self.page_size
         else:
@@ -43,28 +42,30 @@ class PageIncrement(PaginationStrategy):
     @property
     def initial_token(self) -> Optional[Any]:
         if self.inject_on_first_request:
-            return self._page
+            return self.start_from_page
         return None
 
     def next_page_token(
-        self, response: requests.Response, last_page_size: int, last_record: Optional[Record]
+        self,
+        response: requests.Response,
+        last_page_size: int,
+        last_record: Optional[Record],
+        last_page_token_value: Optional[Any],
     ) -> Optional[Any]:
         # Stop paginating when there are fewer records than the page size or the current page has no records
         if (self._page_size and last_page_size < self._page_size) or last_page_size == 0:
             return None
-        else:
-            self._page += 1
-            return self._page
-
-    def reset(self, reset_value: Optional[Any] = None) -> None:
-        if reset_value is None:
-            self._page = self.start_from_page
-        elif not isinstance(reset_value, int):
+        elif last_page_token_value is None:
+            # If the PageIncrement strategy does not inject on the first request, the incoming last_page_token_value
+            # may be None. When this is the case, we assume we've already requested the first page specified by
+            # start_from_page and must now get the next page
+            return self.start_from_page + 1
+        elif not isinstance(last_page_token_value, int):
             raise ValueError(
-                f"Reset value {reset_value} for PageIncrement pagination strategy was not an integer"
+                "The page token for a PageIncrement pagination strategy must be an integer"
             )
         else:
-            self._page = reset_value
+            return last_page_token_value + 1
 
     def get_page_size(self) -> Optional[int]:
         return self._page_size

--- a/airbyte_cdk/sources/declarative/requesters/paginators/strategies/pagination_strategy.py
+++ b/airbyte_cdk/sources/declarative/requesters/paginators/strategies/pagination_strategy.py
@@ -4,7 +4,7 @@
 
 from abc import abstractmethod
 from dataclasses import dataclass
-from typing import Any, Mapping, Optional
+from typing import Any, Optional
 
 import requests
 

--- a/airbyte_cdk/sources/declarative/requesters/paginators/strategies/pagination_strategy.py
+++ b/airbyte_cdk/sources/declarative/requesters/paginators/strategies/pagination_strategy.py
@@ -4,7 +4,7 @@
 
 from abc import abstractmethod
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any, Mapping, Optional
 
 import requests
 
@@ -26,21 +26,20 @@ class PaginationStrategy:
 
     @abstractmethod
     def next_page_token(
-        self, response: requests.Response, last_page_size: int, last_record: Optional[Record]
+        self,
+        response: requests.Response,
+        last_page_size: int,
+        last_record: Optional[Record],
+        last_page_token_value: Optional[Any],
     ) -> Optional[Any]:
         """
         :param response: response to process
         :param last_page_size: the number of records read from the response
         :param last_record: the last record extracted from the response
+        :param last_page_token_value: The current value of the page token made on the last request
         :return: next page token. Returns None if there are no more pages to fetch
         """
         pass
-
-    @abstractmethod
-    def reset(self, reset_value: Optional[Any] = None) -> None:
-        """
-        Reset the pagination's inner state
-        """
 
     @abstractmethod
     def get_page_size(self) -> Optional[int]:

--- a/airbyte_cdk/sources/declarative/requesters/paginators/strategies/stop_condition.py
+++ b/airbyte_cdk/sources/declarative/requesters/paginators/strategies/stop_condition.py
@@ -44,16 +44,19 @@ class StopConditionPaginationStrategyDecorator(PaginationStrategy):
         self._stop_condition = stop_condition
 
     def next_page_token(
-        self, response: requests.Response, last_page_size: int, last_record: Optional[Record]
+        self,
+        response: requests.Response,
+        last_page_size: int,
+        last_record: Optional[Record],
+        last_page_token_value: Optional[Any] = None,
     ) -> Optional[Any]:
-        # We evaluate in reverse order because the assumption is that most of the APIs using data feed structure will return records in
-        # descending order. In terms of performance/memory, we return the records lazily
+        # We evaluate in reverse order because the assumption is that most of the APIs using data feed structure
+        # will return records in descending order. In terms of performance/memory, we return the records lazily
         if last_record and self._stop_condition.is_met(last_record):
             return None
-        return self._delegate.next_page_token(response, last_page_size, last_record)
-
-    def reset(self, reset_value: Optional[Any] = None) -> None:
-        self._delegate.reset(reset_value)
+        return self._delegate.next_page_token(
+            response, last_page_size, last_record, last_page_token_value
+        )
 
     def get_page_size(self) -> Optional[int]:
         return self._delegate.get_page_size()

--- a/airbyte_cdk/sources/declarative/retrievers/async_retriever.py
+++ b/airbyte_cdk/sources/declarative/retrievers/async_retriever.py
@@ -7,10 +7,7 @@ from typing import Any, Iterable, Mapping, Optional
 from typing_extensions import deprecated
 
 from airbyte_cdk.models import FailureType
-from airbyte_cdk.sources.declarative.async_job.job_orchestrator import (
-    AsyncJobOrchestrator,
-    AsyncPartition,
-)
+from airbyte_cdk.sources.declarative.async_job.job_orchestrator import AsyncPartition
 from airbyte_cdk.sources.declarative.extractors.record_selector import RecordSelector
 from airbyte_cdk.sources.declarative.partition_routers.async_job_partition_router import (
     AsyncJobPartitionRouter,

--- a/airbyte_cdk/sources/declarative/retrievers/simple_retriever.py
+++ b/airbyte_cdk/sources/declarative/retrievers/simple_retriever.py
@@ -6,19 +6,7 @@ import json
 from dataclasses import InitVar, dataclass, field
 from functools import partial
 from itertools import islice
-from typing import (
-    Any,
-    Callable,
-    Generator,
-    Iterable,
-    List,
-    Mapping,
-    MutableMapping,
-    Optional,
-    Set,
-    Tuple,
-    Union,
-)
+from typing import Any, Callable, Iterable, List, Mapping, Optional, Set, Tuple, Union
 
 import requests
 
@@ -45,13 +33,6 @@ from airbyte_cdk.sources.types import Config, Record, StreamSlice, StreamState
 from airbyte_cdk.utils.mapping_helpers import combine_mappings
 
 FULL_REFRESH_SYNC_COMPLETE_KEY = "__ab_full_refresh_sync_complete"
-
-
-@dataclass
-class LastResponseValue:
-    last_response: Optional[requests.Response] = None
-    last_page_size: int = 0
-    last_record: Optional[Record] = None
 
 
 @dataclass

--- a/airbyte_cdk/sources/declarative/stream_slicers/declarative_partition_generator.py
+++ b/airbyte_cdk/sources/declarative/stream_slicers/declarative_partition_generator.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2024 Airbyte, Inc., all rights reserved.
 
-from typing import Any, Callable, Iterable, Mapping, Optional
+from typing import Any, Iterable, Mapping, Optional
 
 from airbyte_cdk.sources.declarative.retrievers import Retriever
 from airbyte_cdk.sources.message import MessageRepository

--- a/airbyte_cdk/sources/declarative/stream_slicers/declarative_partition_generator.py
+++ b/airbyte_cdk/sources/declarative/stream_slicers/declarative_partition_generator.py
@@ -16,7 +16,7 @@ class DeclarativePartitionFactory:
         self,
         stream_name: str,
         json_schema: Mapping[str, Any],
-        retriever_factory: Callable[[], Retriever],
+        retriever: Retriever,
         message_repository: MessageRepository,
     ) -> None:
         """
@@ -26,14 +26,14 @@ class DeclarativePartitionFactory:
         """
         self._stream_name = stream_name
         self._json_schema = json_schema
-        self._retriever_factory = retriever_factory
+        self._retriever = retriever
         self._message_repository = message_repository
 
     def create(self, stream_slice: StreamSlice) -> Partition:
         return DeclarativePartition(
             self._stream_name,
             self._json_schema,
-            self._retriever_factory(),
+            self._retriever,
             self._message_repository,
             stream_slice,
         )

--- a/unit_tests/sources/declarative/requesters/paginators/test_cursor_pagination_strategy.py
+++ b/unit_tests/sources/declarative/requesters/paginators/test_cursor_pagination_strategy.py
@@ -12,6 +12,7 @@ from airbyte_cdk.sources.declarative.interpolation.interpolated_boolean import I
 from airbyte_cdk.sources.declarative.requesters.paginators.strategies.cursor_pagination_strategy import (
     CursorPaginationStrategy,
 )
+from airbyte_cdk.sources.types import Record
 
 
 @pytest.mark.parametrize(
@@ -79,7 +80,7 @@ def test_cursor_pagination_strategy(template_string, stop_condition, expected_to
         "characters": {},
     }
     response._content = json.dumps(response_body).encode("utf-8")
-    last_record = {"id": 1, "more_records": True}
+    last_record = Record(data={"id": 1, "more_records": True}, stream_name="stream_name")
 
     token = strategy.next_page_token(response, 1, last_record)
     assert expected_token == token
@@ -111,18 +112,3 @@ def test_last_record_is_node_if_no_records():
     response = requests.Response()
     next_page_token = strategy.next_page_token(response, 0, None)
     assert next_page_token is None
-
-
-def test_reset_with_initial_token():
-    strategy = CursorPaginationStrategy(
-        page_size=10,
-        cursor_value="{{ response.next_page }}",
-        config={},
-        parameters={},
-    )
-
-    assert strategy.initial_token is None
-
-    strategy.reset("https://for-all-mankind.nasa.com/api/v1/astronauts")
-
-    assert strategy.initial_token == "https://for-all-mankind.nasa.com/api/v1/astronauts"

--- a/unit_tests/sources/declarative/requesters/paginators/test_default_paginator.py
+++ b/unit_tests/sources/declarative/requesters/paginators/test_default_paginator.py
@@ -354,18 +354,21 @@ def test_initial_token_with_offset_pagination():
             {"next_page_token": 20},
         ),
         pytest.param(
-            PageIncrement(config={}, page_size=5, start_from_page=0, parameters={}, inject_on_first_request=True),
+            PageIncrement(
+                config={},
+                page_size=5,
+                start_from_page=0,
+                parameters={},
+                inject_on_first_request=True,
+            ),
             5,
             {"next_page_token": 1},
             {"next_page_token": 2},
         ),
-    ]
+    ],
 )
 def test_no_inject_on_first_request_offset_pagination(
-    pagination_strategy,
-    last_page_size,
-    expected_next_page_token,
-    expected_second_next_page_token
+    pagination_strategy, last_page_size, expected_next_page_token, expected_second_next_page_token
 ):
     """
     Validate that the stateless next_page_token() works when the first page does not inject the value
@@ -398,7 +401,9 @@ def test_no_inject_on_first_request_offset_pagination(
     assert actual_next_page_token == expected_next_page_token
 
     last_page_token_value = actual_next_page_token["next_page_token"]
-    actual_next_page_token = paginator.next_page_token(response, last_page_size, last_record, last_page_token_value)
+    actual_next_page_token = paginator.next_page_token(
+        response, last_page_size, last_record, last_page_token_value
+    )
     assert actual_next_page_token == expected_second_next_page_token
 
 

--- a/unit_tests/sources/declarative/requesters/paginators/test_no_paginator.py
+++ b/unit_tests/sources/declarative/requesters/paginators/test_no_paginator.py
@@ -9,5 +9,5 @@ from airbyte_cdk.sources.declarative.requesters.paginators.no_pagination import 
 
 def test():
     paginator = NoPagination(parameters={})
-    next_page_token = paginator.next_page_token(requests.Response(), 0, [])
+    next_page_token = paginator.next_page_token(requests.Response(), 0, [], None)
     assert next_page_token == {}

--- a/unit_tests/sources/declarative/requesters/paginators/test_offset_increment.py
+++ b/unit_tests/sources/declarative/requesters/paginators/test_offset_increment.py
@@ -14,36 +14,46 @@ from airbyte_cdk.sources.declarative.requesters.paginators.strategies.offset_inc
 
 
 @pytest.mark.parametrize(
-    "page_size, parameters, last_page_size, last_record, expected_next_page_token, expected_offset",
+    "page_size, parameters, last_page_size, last_record, last_page_token_value, expected_next_page_token, expected_offset",
     [
-        pytest.param("2", {}, 2, {"id": 1}, 2, 2, id="test_same_page_size"),
-        pytest.param(2, {}, 2, {"id": 1}, 2, 2, id="test_same_page_size"),
+        pytest.param("2", {}, 2, {"id": 1}, 4, 6, 2, id="test_same_page_size"),
+        pytest.param(2, {}, 2, {"id": 1}, 4, 6, 2, id="test_same_page_size"),
         pytest.param(
             "{{ parameters['page_size'] }}",
             {"page_size": 3},
             2,
             {"id": 1},
+            3,
             None,
             0,
             id="test_larger_page_size",
         ),
-        pytest.param(None, {}, 0, [], None, 0, id="test_stop_if_no_records"),
+        pytest.param(None, {}, 0, [], 3, None, 0, id="test_stop_if_no_records"),
         pytest.param(
             "{{ response['page_metadata']['limit'] }}",
             {},
             2,
             {"id": 1},
+            3,
             None,
             0,
             id="test_page_size_from_response",
         ),
+        pytest.param(
+            2, {}, 2, {"id": 1}, None, 2, 2, id="test_get_second_page_with_first_page_not_injected"
+        ),
     ],
 )
 def test_offset_increment_paginator_strategy(
-    page_size, parameters, last_page_size, last_record, expected_next_page_token, expected_offset
+    page_size,
+    parameters,
+    last_page_size,
+    last_record,
+    last_page_token_value,
+    expected_next_page_token,
+    expected_offset,
 ):
     paginator_strategy = OffsetIncrement(page_size=page_size, parameters=parameters, config={})
-    assert paginator_strategy._offset == 0
 
     response = requests.Response()
 
@@ -51,12 +61,16 @@ def test_offset_increment_paginator_strategy(
     response_body = {"next": "https://airbyte.io/next_url", "page_metadata": {"limit": 5}}
     response._content = json.dumps(response_body).encode("utf-8")
 
-    next_page_token = paginator_strategy.next_page_token(response, last_page_size, last_record)
+    next_page_token = paginator_strategy.next_page_token(
+        response, last_page_size, last_record, last_page_token_value
+    )
     assert expected_next_page_token == next_page_token
-    assert expected_offset == paginator_strategy._offset
 
-    paginator_strategy.reset()
-    assert 0 == paginator_strategy._offset
+    # Validate that the PaginationStrategy is stateless and calling next_page_token() again returns the same result
+    next_page_token = paginator_strategy.next_page_token(
+        response, last_page_size, last_record, last_page_token_value
+    )
+    assert expected_next_page_token == next_page_token
 
 
 def test_offset_increment_paginator_strategy_rises():
@@ -85,27 +99,3 @@ def test_offset_increment_paginator_strategy_initial_token(
     )
 
     assert paginator_strategy.initial_token == expected_initial_token
-
-
-@pytest.mark.parametrize(
-    "reset_value, expected_initial_token, expected_error",
-    [
-        pytest.param(25, 25, None, id="test_reset_with_offset_value"),
-        pytest.param(None, 0, None, id="test_reset_with_default"),
-        pytest.param("Nope", None, ValueError, id="test_reset_with_invalid_value"),
-    ],
-)
-def test_offset_increment_reset(reset_value, expected_initial_token, expected_error):
-    paginator_strategy = OffsetIncrement(
-        page_size=20, parameters={}, config={}, inject_on_first_request=True
-    )
-
-    if expected_error:
-        with pytest.raises(expected_error):
-            paginator_strategy.reset(reset_value=reset_value)
-    else:
-        if reset_value is None:
-            paginator_strategy.reset()
-        else:
-            paginator_strategy.reset(reset_value=reset_value)
-        assert paginator_strategy.initial_token == expected_initial_token

--- a/unit_tests/sources/declarative/requesters/paginators/test_page_increment.py
+++ b/unit_tests/sources/declarative/requesters/paginators/test_page_increment.py
@@ -14,26 +14,45 @@ from airbyte_cdk.sources.declarative.requesters.paginators.strategies.page_incre
 
 
 @pytest.mark.parametrize(
-    "page_size, start_from, last_page_size, last_record, expected_next_page_token, expected_offset",
+    "page_size, start_from, last_page_size, last_record, last_page_token_value, expected_next_page_token, expected_offset",
     [
-        pytest.param(2, 1, 2, {"id": 1}, 2, 2, id="test_same_page_size_start_from_0"),
-        pytest.param(3, 1, 2, {"id": 1}, None, 1, id="test_larger_page_size_start_from_0"),
-        pytest.param(2, 0, 2, {"id": 1}, 1, 1, id="test_same_page_size_start_from_1"),
-        pytest.param(3, 0, 2, {"id": 1}, None, 0, id="test_larger_page_size_start_from_0"),
-        pytest.param(None, 0, 0, None, None, 0, id="test_no_page_size"),
-        pytest.param("2", 0, 2, {"id": 1}, 1, 1, id="test_page_size_from_string"),
+        pytest.param(2, 1, 2, {"id": 1}, 3, 4, 2, id="test_same_page_size_start_from_1"),
+        pytest.param(3, 1, 2, {"id": 1}, 3, None, 1, id="test_larger_page_size_start_from_1"),
+        pytest.param(2, 0, 2, {"id": 1}, 3, 4, 1, id="test_same_page_size_start_from_0"),
+        pytest.param(3, 0, 2, {"id": 1}, 3, None, 0, id="test_larger_page_size_start_from_0"),
+        pytest.param(None, 0, 0, None, 2, None, 0, id="test_no_page_size"),
+        pytest.param("2", 0, 2, {"id": 1}, 3, 4, 1, id="test_page_size_from_string"),
         pytest.param(
-            "{{ config['value'] }}", 0, 2, {"id": 1}, 1, 1, id="test_page_size_from_config"
+            "{{ config['value'] }}", 0, 2, {"id": 1}, 3, 4, 1, id="test_page_size_from_config"
+        ),
+        pytest.param(
+            2, 0, 2, {"id": 1}, None, 1, 2, id="test_start_from_not_injected_returns_second_page"
+        ),
+        pytest.param(
+            2,
+            10,
+            2,
+            {"id": 1},
+            None,
+            11,
+            2,
+            id="test_non_default_start_from_not_injected_returns_next_page",
         ),
     ],
 )
 def test_page_increment_paginator_strategy(
-    page_size, start_from, last_page_size, last_record, expected_next_page_token, expected_offset
+    page_size,
+    start_from,
+    last_page_size,
+    last_record,
+    last_page_token_value,
+    expected_next_page_token,
+    expected_offset,
 ):
     paginator_strategy = PageIncrement(
         page_size=page_size, parameters={}, start_from_page=start_from, config={"value": 2}
     )
-    assert paginator_strategy._page == start_from
+    assert paginator_strategy.start_from_page == start_from
 
     response = requests.Response()
 
@@ -41,12 +60,16 @@ def test_page_increment_paginator_strategy(
     response_body = {"next": "https://airbyte.io/next_url"}
     response._content = json.dumps(response_body).encode("utf-8")
 
-    next_page_token = paginator_strategy.next_page_token(response, last_page_size, last_record)
+    next_page_token = paginator_strategy.next_page_token(
+        response, last_page_size, last_record, last_page_token_value
+    )
     assert expected_next_page_token == next_page_token
-    assert expected_offset == paginator_strategy._page
 
-    paginator_strategy.reset()
-    assert start_from == paginator_strategy._page
+    # Validate that the PaginationStrategy is stateless and calling next_page_token() again returns the same result
+    next_page_token = paginator_strategy.next_page_token(
+        response, last_page_size, last_record, last_page_token_value
+    )
+    assert expected_next_page_token == next_page_token
 
 
 @pytest.mark.parametrize(
@@ -82,24 +105,3 @@ def test_page_increment_paginator_strategy_initial_token(
     )
 
     assert paginator_strategy.initial_token == expected_initial_token
-
-
-@pytest.mark.parametrize(
-    "reset_value, expected_initial_token, expected_error",
-    [
-        pytest.param(25, 25, None, id="test_reset_with_offset_value"),
-        pytest.param(None, 0, None, id="test_reset_with_default"),
-        pytest.param("Nope", None, ValueError, id="test_reset_with_invalid_value"),
-    ],
-)
-def test_offset_increment_reset(reset_value, expected_initial_token, expected_error):
-    paginator_strategy = PageIncrement(
-        page_size=100, parameters={}, config={}, inject_on_first_request=True
-    )
-
-    if expected_error:
-        with pytest.raises(expected_error):
-            paginator_strategy.reset(reset_value=reset_value)
-    else:
-        paginator_strategy.reset(reset_value=reset_value)
-        assert paginator_strategy.initial_token == expected_initial_token

--- a/unit_tests/sources/declarative/requesters/paginators/test_stop_condition.py
+++ b/unit_tests/sources/declarative/requesters/paginators/test_stop_condition.py
@@ -86,7 +86,9 @@ def test_given_stop_condition_is_not_met_when_next_page_token_then_delegate(
     next_page_token = decorator.next_page_token(ANY_RESPONSE, 2, last_record)
 
     assert next_page_token == mocked_pagination_strategy.next_page_token.return_value
-    mocked_pagination_strategy.next_page_token.assert_called_once_with(ANY_RESPONSE, 2, last_record)
+    mocked_pagination_strategy.next_page_token.assert_called_once_with(
+        ANY_RESPONSE, 2, last_record, None
+    )
     mocked_stop_condition.is_met.assert_has_calls([call(last_record)])
 
 
@@ -100,15 +102,9 @@ def test_given_no_records_when_next_page_token_then_delegate(
     next_page_token = decorator.next_page_token(ANY_RESPONSE, 0, NO_RECORD)
 
     assert next_page_token == mocked_pagination_strategy.next_page_token.return_value
-    mocked_pagination_strategy.next_page_token.assert_called_once_with(ANY_RESPONSE, 0, NO_RECORD)
-
-
-def test_when_reset_then_delegate(mocked_pagination_strategy, mocked_stop_condition):
-    decorator = StopConditionPaginationStrategyDecorator(
-        mocked_pagination_strategy, mocked_stop_condition
+    mocked_pagination_strategy.next_page_token.assert_called_once_with(
+        ANY_RESPONSE, 0, NO_RECORD, None
     )
-    decorator.reset()
-    mocked_pagination_strategy.reset.assert_called_once_with(None)
 
 
 def test_when_get_page_size_then_delegate(mocked_pagination_strategy, mocked_stop_condition):

--- a/unit_tests/sources/declarative/stream_slicers/test_declarative_partition_generator.py
+++ b/unit_tests/sources/declarative/stream_slicers/test_declarative_partition_generator.py
@@ -27,31 +27,33 @@ _A_RECORD = {"record_field": "record_value"}
 
 
 class StreamSlicerPartitionGeneratorTest(TestCase):
-    def setUp(self) -> None:
-        self._retriever_factory = Mock()
-        self._message_repository = Mock(spec=MessageRepository)
-        self._partition_factory = DeclarativePartitionFactory(
+    def test_given_multiple_slices_partition_generator_uses_the_same_retriever(self) -> None:
+        retriever = self._mock_retriever([])
+        message_repository = Mock(spec=MessageRepository)
+        partition_factory = DeclarativePartitionFactory(
             _STREAM_NAME,
             _JSON_SCHEMA,
-            self._retriever_factory,
-            self._message_repository,
+            retriever,
+            message_repository,
         )
 
-    def test_given_multiple_slices_when_read_then_read_from_different_retrievers(self) -> None:
-        first_retriever = self._mock_retriever([])
-        second_retriever = self._mock_retriever([])
-        self._retriever_factory.side_effect = [first_retriever, second_retriever]
+        list(partition_factory.create(_A_STREAM_SLICE).read())
+        list(partition_factory.create(_ANOTHER_STREAM_SLICE).read())
 
-        list(self._partition_factory.create(_A_STREAM_SLICE).read())
-        list(self._partition_factory.create(_ANOTHER_STREAM_SLICE).read())
-
-        first_retriever.read_records.assert_called_once()
-        second_retriever.read_records.assert_called_once()
+        assert retriever.read_records.call_count == 2
 
     def test_given_a_mapping_when_read_then_yield_record(self) -> None:
         retriever = self._mock_retriever([_A_RECORD])
-        self._retriever_factory.return_value = retriever
-        partition = self._partition_factory.create(_A_STREAM_SLICE)
+        message_repository = Mock(spec=MessageRepository)
+        partition_factory = DeclarativePartitionFactory(
+            _STREAM_NAME,
+            _JSON_SCHEMA,
+            retriever,
+            message_repository,
+        )
+
+        # self._retriever_factory.return_value = retriever
+        partition = partition_factory.create(_A_STREAM_SLICE)
 
         records = list(partition.read())
 
@@ -61,13 +63,20 @@ class StreamSlicerPartitionGeneratorTest(TestCase):
 
     def test_given_not_a_record_when_read_then_send_to_message_repository(self) -> None:
         retriever = self._mock_retriever([_AIRBYTE_LOG_MESSAGE])
-        self._retriever_factory.return_value = retriever
+        message_repository = Mock(spec=MessageRepository)
+        partition_factory = DeclarativePartitionFactory(
+            _STREAM_NAME,
+            _JSON_SCHEMA,
+            retriever,
+            message_repository,
+        )
 
-        list(self._partition_factory.create(_A_STREAM_SLICE).read())
+        list(partition_factory.create(_A_STREAM_SLICE).read())
 
-        self._message_repository.emit_message.assert_called_once_with(_AIRBYTE_LOG_MESSAGE)
+        message_repository.emit_message.assert_called_once_with(_AIRBYTE_LOG_MESSAGE)
 
-    def _mock_retriever(self, read_return_value: List[StreamData]) -> Mock:
+    @staticmethod
+    def _mock_retriever(read_return_value: List[StreamData]) -> Mock:
         retriever = Mock(spec=Retriever)
         retriever.read_records.return_value = iter(read_return_value)
         return retriever

--- a/unit_tests/sources/declarative/stream_slicers/test_declarative_partition_generator.py
+++ b/unit_tests/sources/declarative/stream_slicers/test_declarative_partition_generator.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+
 from typing import List
 from unittest import TestCase
 from unittest.mock import Mock
@@ -52,7 +54,6 @@ class StreamSlicerPartitionGeneratorTest(TestCase):
             message_repository,
         )
 
-        # self._retriever_factory.return_value = retriever
         partition = partition_factory.create(_A_STREAM_SLICE)
 
         records = list(partition.read())

--- a/unit_tests/sources/declarative/test_concurrent_declarative_source.py
+++ b/unit_tests/sources/declarative/test_concurrent_declarative_source.py
@@ -651,13 +651,15 @@ def test_group_streams():
     concurrent_streams, synchronous_streams = source._group_streams(config=_CONFIG)
 
     # 1 full refresh stream, 2 incremental streams, 1 substream w/o incremental, 1 list based substream w/o incremental
-    assert len(concurrent_streams) == 5
+    # 1 async job stream
+    assert len(concurrent_streams) == 6
     (
         concurrent_stream_0,
         concurrent_stream_1,
         concurrent_stream_2,
         concurrent_stream_3,
         concurrent_stream_4,
+        concurrent_stream_5,
     ) = concurrent_streams
     assert isinstance(concurrent_stream_0, DefaultStream)
     assert concurrent_stream_0.name == "party_members"
@@ -669,13 +671,13 @@ def test_group_streams():
     assert concurrent_stream_3.name == "party_members_skills"
     assert isinstance(concurrent_stream_4, DefaultStream)
     assert concurrent_stream_4.name == "arcana_personas"
+    assert isinstance(concurrent_stream_5, DefaultStream)
+    assert concurrent_stream_5.name == "async_job_stream"
 
     # 1 substream w/ incremental, 1 stream with async retriever
-    assert len(synchronous_streams) == 2
+    assert len(synchronous_streams) == 1
     assert isinstance(synchronous_streams[0], DeclarativeStream)
     assert synchronous_streams[0].name == "palace_enemies"
-    assert isinstance(synchronous_streams[1], DeclarativeStream)
-    assert synchronous_streams[1].name == "async_job_stream"
 
 
 @freezegun.freeze_time(time_to_freeze=datetime(2024, 9, 1, 0, 0, 0, 0, tzinfo=timezone.utc))
@@ -1456,10 +1458,10 @@ def test_streams_with_stream_state_interpolation_should_be_synchronous():
     )
     concurrent_streams, synchronous_streams = source._group_streams(config=_CONFIG)
 
-    # 1 full refresh stream, 2 with parent stream without incremental dependency
-    assert len(concurrent_streams) == 3
-    # 2 incremental stream with interpolation on state (locations and party_members), 1 incremental with parent stream (palace_enemies), 1 stream with async retriever
-    assert len(synchronous_streams) == 4
+    # 1 full refresh stream, 2 with parent stream without incremental dependency, 1 stream with async retriever
+    assert len(concurrent_streams) == 4
+    # 2 incremental stream with interpolation on state (locations and party_members), 1 incremental with parent stream (palace_enemies)
+    assert len(synchronous_streams) == 3
 
 
 def test_given_partition_routing_and_incremental_sync_then_stream_is_not_concurrent():

--- a/unit_tests/sources/declarative/test_manifest_declarative_source.py
+++ b/unit_tests/sources/declarative/test_manifest_declarative_source.py
@@ -1278,7 +1278,7 @@ def _create_page(response_body):
             )
             * 10,
             [{"ABC": 0}, {"AED": 1}],
-            [call({}, {})],
+            [call({}, {}, None)],
         ),
         (
             "test_read_manifest_with_added_fields",
@@ -1365,7 +1365,7 @@ def _create_page(response_body):
                 {"ABC": 0, "added_field_key": "added_field_value"},
                 {"AED": 1, "added_field_key": "added_field_value"},
             ],
-            [call({}, {})],
+            [call({}, {}, None)],
         ),
         (
             "test_read_manifest_with_flatten_fields",
@@ -1535,7 +1535,14 @@ def _create_page(response_body):
             )
             * 10,
             [{"ABC": 0}, {"AED": 1}, {"USD": 2}],
-            [call({}, {}), call({"next_page_token": "next"}, {"next_page_token": "next"})],
+            [
+                call({}, {}, None),
+                call(
+                    {"next_page_token": "next"},
+                    {"next_page_token": "next"},
+                    {"next_page_token": "next"},
+                ),
+            ],
         ),
         (
             "test_no_pagination_with_partition_router",

--- a/unit_tests/sources/declarative/test_manifest_declarative_source.py
+++ b/unit_tests/sources/declarative/test_manifest_declarative_source.py
@@ -1449,7 +1449,7 @@ def _create_page(response_body):
                 {"ABC": 0, "id": 1},
                 {"AED": 1, "id": 2},
             ],
-            [call({}, {})],
+            [call({}, {}, None)],
         ),
         (
             "test_read_with_pagination_no_partitions",


### PR DESCRIPTION
## What

Right now, because the SimpleRetriever has an internally managed and modified state, we cannot have multiple partitions running at the same time share the same SimpleRetriever. Otherwise we might run into data loss because the state of the SimpleRetriever (things like page number, etc) are modified by different partitions. We've seen this problem arise in some connections (link issue) and we have temporarily solved this by having every Partition instantiate it's own `SimpleRetriever`.

This however is very inefficient for a couple reasons like needing to perform auth for every partition (link issue). And this is a hard blocker on AsyncRetriever which must be shared across partitions in order to manage the shared job repository.

This PR replaces an internal state for `SimpleRetriever` and all of its dependencies which are manged via a `token` field and makes all methods stateless by relying on passing parameterized values for the `next_page_token` instead.

## How

This PR basically makes the following changes for thread safety:  to the underlying implementations of the `DefaultPaginator` and all the pagination strategies so that they no longer have internal fields and instead pass required information via parameters to be stateless

- The `SimpleRetriever` class had internal fields that were removed and replaced by local method variables like  `last_record`, and `last_page_size`. These are passed to and from methods local to the initial `read_records()` invocation
- The Paginator/DefaultPaginator interface has removed internal state so that the previous token is passed via parameter to determine the next token to supply to the retriever. Methods are now receiving parameters like `next_page_token` because we need the prior value to get the new value in a stateless manner. This will impact custom components that will no longer adhere to the original interface. More on that below.
- PaginationStrategy was also affected by methods needing to receive additional parameters
- All forms of resetting `PaginationStrategy` and `DefaultPaginator` components is removed because there is no longer an internal state field

I also added in the changes to allow `AsyncRetriever` to instantiated within the concurrent framework because I want to test some of this functionality with sendgrid which needs these changes.

## Other notes

- This is technically considered a breaking change because it changes the `Paginator` and `PaginationStrategy` method interfaces to now include additional parameters and our internal code now passes extra parameters
- The impact should be that only connectors that use custom components will be affected, and we expect them to fail loudly
- There is some debate about whether this should be a minor or major version bump:
  - [Connectors with no custom components] - Not breaking
  - [Connectors with custom components] - Independently versioned and will fail loudly when bumping to latest CDK
    - `source-freshdesk`: custom pagination strategy
    - `source-linkedin-ads`: custom retriever
    - `source-mixpanel`: custom pagination strategy
    - `source-monday`: custom pagination strategy
    - `source-zendesk-chat`: custom pagination strategy
  - [manifest-only with custom components] - These carry the risk of getting upgraded and now failing. They need to be fixed post-release
    - `source-the-guardian-api`: custom pagination strategy
  - [Customer created connectors] - The builder doesn't currently support custom components until the in progress project ships. But for the moment we're operating that there are none. Brian to confirm w/ marketplace.

Because there really seems to only be one very low usage community connector that would be affected by the breaking change, I am proposing we make this a minor change so that all of our connectors don't get pinned behind a breaking change and can continue to receive our future changes that will improve adoption of concurrency. I'm happy to pick up this discussion in the PR if there's opposition

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced concurrency handling for streaming data, supporting both synchronous and asynchronous stream types.
	- Improved pagination token management across various paginator classes.

- **Bug Fixes**
	- Updated error handling to prevent potential deadlocks in concurrent processing.
	- Adjusted pagination logic to ensure correct token retrieval and state management.

- **Tests**
	- Expanded test coverage for pagination strategies and concurrent sources.
	- Updated existing tests to align with new method signatures and behaviors.
	- Added new tests for `SimpleRetriever` to validate pagination scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->