### PR TITLE
fix: (DeclarativeOAuthFlow) - fix the bug when `refresh_token` is not provided from the `test` authentication

### DIFF
--- a/airbyte_cdk/sources/streams/http/requests_native_auth/abstract_oauth.py
+++ b/airbyte_cdk/sources/streams/http/requests_native_auth/abstract_oauth.py
@@ -54,16 +54,12 @@ class AbstractOauth2Authenticator(AuthBase):
 
     def get_auth_header(self) -> Mapping[str, Any]:
         """HTTP header to set on the requests"""
-        token = (
-            self.access_token
-            if (
-                not self.get_token_refresh_endpoint()
-                or not self.get_refresh_token()
-                and self.access_token
-            )
-            else self.get_access_token()
-        )
+        token = self.access_token if self._is_access_token_flow else self.get_access_token()
         return {"Authorization": f"Bearer {token}"}
+
+    @property
+    def _is_access_token_flow(self) -> bool:
+        return self.get_token_refresh_endpoint() is None and self.access_token is not None
 
     def get_access_token(self) -> str:
         """Returns the access token"""


### PR DESCRIPTION
## What
Resolving the small regression after this change:
- https://github.com/airbytehq/airbyte-python-cdk/pull/182/files

The case, when `token_refresh_endpoint` and `client_id, client_secret` are provided to obtain the `refresh_token` or `access_token` from the `OAuth` authentication, with no `refresh_token` value provided in prior.

Related slack thread: https://airbytehq-team.slack.com/archives/C027KKE4BCZ/p1734877961838859

## How
- Removed the `self.get_refresh_token()` value check from the condition to determine the presence of the `access_token` and related flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new property to determine if the current flow is based on an access token.
- **Improvements**
	- Simplified token retrieval logic for better clarity.
	- Enhanced error logging for improved debugging capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->