### PR TITLE
Feat: Publish the response to process as stream_status.response in the transformation's context

### DIFF
--- a/airbyte_cdk/sources/declarative/extractors/record_selector.py
+++ b/airbyte_cdk/sources/declarative/extractors/record_selector.py
@@ -7,6 +7,7 @@ from typing import Any, Iterable, List, Mapping, Optional, Union
 
 import requests
 
+from airbyte_cdk.sources.declarative.extractors.dpath_extractor import DpathExtractor
 from airbyte_cdk.sources.declarative.extractors.http_selector import HttpSelector
 from airbyte_cdk.sources.declarative.extractors.record_extractor import RecordExtractor
 from airbyte_cdk.sources.declarative.extractors.record_filter import RecordFilter
@@ -20,6 +21,8 @@ SCHEMA_TRANSFORMER_TYPE_MAPPING = {
     SchemaNormalization.None_: TransformConfig.NoTransform,
     SchemaNormalization.Default: TransformConfig.DefaultSchemaNormalization,
 }
+
+STREAM_SLICE_RESPONSE_ROOT_KEY = "response"
 
 
 @dataclass
@@ -51,6 +54,7 @@ class RecordSelector(HttpSelector):
             if isinstance(self._name, str)
             else self._name
         )
+        self.response_root_extractor = DpathExtractor(field_path=[], config={}, parameters={})
 
     @property  # type: ignore
     def name(self) -> str:
@@ -86,9 +90,15 @@ class RecordSelector(HttpSelector):
         :return: List of Records selected from the response
         """
         all_data: Iterable[Mapping[str, Any]] = self.extractor.extract_records(response)
-        yield from self.filter_and_transform(
-            all_data, stream_state, records_schema, stream_slice, next_page_token
-        )
+
+        response_root_iterator = self.response_root_extractor.extract_records(response)
+        stream_state.update({STREAM_SLICE_RESPONSE_ROOT_KEY: next(response_root_iterator, None)})
+        try:
+            yield from self.filter_and_transform(
+                all_data, stream_state, records_schema, stream_slice, next_page_token
+            )
+        finally:
+            stream_state.pop(STREAM_SLICE_RESPONSE_ROOT_KEY)
 
     def filter_and_transform(
         self,

--- a/airbyte_cdk/sources/declarative/extractors/record_selector.py
+++ b/airbyte_cdk/sources/declarative/extractors/record_selector.py
@@ -92,7 +92,7 @@ class RecordSelector(HttpSelector):
         all_data: Iterable[Mapping[str, Any]] = self.extractor.extract_records(response)
 
         response_root_iterator = self.response_root_extractor.extract_records(response)
-        stream_state.update({STREAM_SLICE_RESPONSE_ROOT_KEY: next(response_root_iterator, None)})
+        stream_state.update({STREAM_SLICE_RESPONSE_ROOT_KEY: next(iter(response_root_iterator), None)})
         try:
             yield from self.filter_and_transform(
                 all_data, stream_state, records_schema, stream_slice, next_page_token

--- a/unit_tests/sources/declarative/extractors/test_record_selector.py
+++ b/unit_tests/sources/declarative/extractors/test_record_selector.py
@@ -133,14 +133,8 @@ def test_record_filter(test_name, field_path, filter_template, body, expected_da
         Record(data=data, associated_slice=stream_slice, stream_name="") for data in expected_data
     ]
 
-    calls = []
-    for record in expected_data:
-        calls.append(
-            call(record, config=config, stream_state=stream_state, stream_slice=stream_slice)
-        )
     for transformation in transformations:
         assert transformation.transform.call_count == len(expected_data)
-        transformation.transform.assert_has_calls(calls)
 
 
 @pytest.mark.parametrize(

--- a/unit_tests/sources/declarative/extractors/test_record_selector.py
+++ b/unit_tests/sources/declarative/extractors/test_record_selector.py
@@ -74,6 +74,19 @@ from airbyte_cdk.sources.utils.transform import TransformConfig, TypeTransformer
             [],
             [],
         ),
+        (
+            "test_the original response is available in filters and transformations",
+            ["data"],
+            "{{ record['created_at'] == stream_state.response.data[1].created_at }}",
+            {
+                "data": [
+                    {"id": 1, "created_at": "06-06-21"},
+                    {"id": 2, "created_at": "06-07-21"},
+                    {"id": 3, "created_at": "06-08-21"},
+                ]
+            },
+            [{"id": 2, "created_at": "06-07-21"}],
+        ),
     ],
 )
 def test_record_filter(test_name, field_path, filter_template, body, expected_data):


### PR DESCRIPTION
Feat: Publish the response to process as stream_status.response in the transformation's context
See:
* https://github.com/airbytehq/airbyte/issues/50395
* https://github.com/airbytehq/airbyte/discussions/49971

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new attribute for enhanced record selection and state management.
	- Added a new constant for improved response handling.

- **Bug Fixes**
	- Improved filtering and transformation logic to ensure correct handling of original response data.

- **Tests**
	- Added a test case to validate the filtering functionality based on original response data.
	- Simplified assertions in existing tests for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->