### PR TITLE
fix: `Async Retriever` change url path for download retriever

### DIFF
--- a/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -2254,7 +2254,7 @@ class ModelToComponentFactory:
                 extractor=download_extractor,
                 name=name,
                 record_filter=None,
-                transformations=[],
+                transformations=transformations,
                 schema_normalization=TypeTransformer(TransformConfig.NoTransform),
                 config=config,
                 parameters={},

--- a/airbyte_cdk/sources/declarative/partition_routers/substream_partition_router.py
+++ b/airbyte_cdk/sources/declarative/partition_routers/substream_partition_router.py
@@ -4,7 +4,7 @@
 import copy
 import logging
 from dataclasses import InitVar, dataclass
-from typing import TYPE_CHECKING, Any, Iterable, List, Mapping, MutableMapping, Optional, Union
+from typing import TYPE_CHECKING, Any, Iterable, List, Mapping, Optional, Union
 
 import dpath
 
@@ -215,7 +215,7 @@ class SubstreamPartitionRouter(PartitionRouter):
         self,
         parent_record: Mapping[str, Any] | AirbyteMessage,
         extra_fields: Optional[List[List[str]]] = None,
-    ) -> MutableMapping[str, Any]:
+    ) -> Mapping[str, Any]:
         """
         Extracts additional fields specified by their paths from the parent record.
 

--- a/airbyte_cdk/sources/declarative/partition_routers/substream_partition_router.py
+++ b/airbyte_cdk/sources/declarative/partition_routers/substream_partition_router.py
@@ -4,7 +4,7 @@
 import copy
 import logging
 from dataclasses import InitVar, dataclass
-from typing import TYPE_CHECKING, Any, Iterable, List, Mapping, Optional, Union
+from typing import TYPE_CHECKING, Any, Iterable, List, Mapping, MutableMapping, Optional, Union
 
 import dpath
 
@@ -215,7 +215,7 @@ class SubstreamPartitionRouter(PartitionRouter):
         self,
         parent_record: Mapping[str, Any] | AirbyteMessage,
         extra_fields: Optional[List[List[str]]] = None,
-    ) -> Mapping[str, Any]:
+    ) -> MutableMapping[str, Any]:
         """
         Extracts additional fields specified by their paths from the parent record.
 

--- a/airbyte_cdk/sources/declarative/requesters/http_job_repository.py
+++ b/airbyte_cdk/sources/declarative/requesters/http_job_repository.py
@@ -189,7 +189,8 @@ class AsyncHttpJobRepository(AsyncJobRepository):
         for url in self.urls_extractor.extract_records(
             self._polling_job_response_by_id[job.api_job_id()]
         ):
-            stream_slice: StreamSlice = StreamSlice(partition={"url": url}, cursor_slice={})
+            stream_slice = job.job_parameters()
+            stream_slice.extra_fields.update({"url": url})
             for message in self.download_retriever.read_records({}, stream_slice):
                 if isinstance(message, Record):
                     yield message.data

--- a/airbyte_cdk/sources/declarative/requesters/http_job_repository.py
+++ b/airbyte_cdk/sources/declarative/requesters/http_job_repository.py
@@ -189,8 +189,12 @@ class AsyncHttpJobRepository(AsyncJobRepository):
         for url in self.urls_extractor.extract_records(
             self._polling_job_response_by_id[job.api_job_id()]
         ):
-            stream_slice = job.job_parameters()
-            stream_slice.extra_fields.update({"url": url})
+            job_slice = job.job_parameters()
+            stream_slice = StreamSlice(
+                partition=job_slice.partition,
+                cursor_slice=job_slice.cursor_slice,
+                extra_fields={**job_slice.extra_fields, "url": url},
+            )
             for message in self.download_retriever.read_records({}, stream_slice):
                 if isinstance(message, Record):
                     yield message.data

--- a/airbyte_cdk/sources/types.py
+++ b/airbyte_cdk/sources/types.py
@@ -4,7 +4,17 @@
 
 from __future__ import annotations
 
-from typing import Any, ItemsView, Iterator, KeysView, List, Mapping, Optional, ValuesView, MutableMapping
+from typing import (
+    Any,
+    ItemsView,
+    Iterator,
+    KeysView,
+    List,
+    Mapping,
+    MutableMapping,
+    Optional,
+    ValuesView,
+)
 
 import orjson
 
@@ -68,7 +78,7 @@ class StreamSlice(Mapping[str, Any]):
         *,
         partition: Mapping[str, Any],
         cursor_slice: Mapping[str, Any],
-        extra_fields: Optional[Mapping[str, Any]] = None,
+        extra_fields: Optional[MutableMapping[str, Any]] = None,
     ) -> None:
         """
         :param partition: The partition keys representing a unique partition in the stream.
@@ -153,5 +163,5 @@ class StreamSlice(Mapping[str, Any]):
     def __hash__(self) -> int:
         return hash(orjson.dumps(self._stream_slice, option=orjson.OPT_SORT_KEYS))
 
-    def __bool__(self):
+    def __bool__(self) -> bool:
         return bool(self._stream_slice) or bool(self._extra_fields)

--- a/airbyte_cdk/sources/types.py
+++ b/airbyte_cdk/sources/types.py
@@ -152,3 +152,6 @@ class StreamSlice(Mapping[str, Any]):
 
     def __hash__(self) -> int:
         return hash(orjson.dumps(self._stream_slice, option=orjson.OPT_SORT_KEYS))
+
+    def __bool__(self):
+        return bool(self._stream_slice) or bool(self._extra_fields)

--- a/airbyte_cdk/sources/types.py
+++ b/airbyte_cdk/sources/types.py
@@ -4,17 +4,7 @@
 
 from __future__ import annotations
 
-from typing import (
-    Any,
-    ItemsView,
-    Iterator,
-    KeysView,
-    List,
-    Mapping,
-    MutableMapping,
-    Optional,
-    ValuesView,
-)
+from typing import Any, ItemsView, Iterator, KeysView, List, Mapping, Optional, ValuesView
 
 import orjson
 
@@ -78,7 +68,7 @@ class StreamSlice(Mapping[str, Any]):
         *,
         partition: Mapping[str, Any],
         cursor_slice: Mapping[str, Any],
-        extra_fields: Optional[MutableMapping[str, Any]] = None,
+        extra_fields: Optional[Mapping[str, Any]] = None,
     ) -> None:
         """
         :param partition: The partition keys representing a unique partition in the stream.
@@ -112,7 +102,7 @@ class StreamSlice(Mapping[str, Any]):
         return c
 
     @property
-    def extra_fields(self) -> MutableMapping[str, Any]:
+    def extra_fields(self) -> Mapping[str, Any]:
         """Returns the extra fields that are not part of the partition."""
         return self._extra_fields
 

--- a/airbyte_cdk/sources/types.py
+++ b/airbyte_cdk/sources/types.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from typing import Any, ItemsView, Iterator, KeysView, List, Mapping, Optional, ValuesView
+from typing import Any, ItemsView, Iterator, KeysView, List, Mapping, Optional, ValuesView, MutableMapping
 
 import orjson
 
@@ -102,7 +102,7 @@ class StreamSlice(Mapping[str, Any]):
         return c
 
     @property
-    def extra_fields(self) -> Mapping[str, Any]:
+    def extra_fields(self) -> MutableMapping[str, Any]:
         """Returns the extra fields that are not part of the partition."""
         return self._extra_fields
 

--- a/unit_tests/sources/declarative/requesters/test_http_job_repository.py
+++ b/unit_tests/sources/declarative/requesters/test_http_job_repository.py
@@ -84,7 +84,7 @@ class HttpJobRepositoryTest(TestCase):
             requester=HttpRequester(
                 name="stream <name>: fetch_result",
                 url_base="",
-                path="{{stream_slice['url']}}",
+                path="{{stream_slice.extra_fields['url']}}",
                 error_handler=error_handler,
                 http_method=HttpMethod.GET,
                 config=_ANY_CONFIG,


### PR DESCRIPTION
# What

-  pass `url` as `extra_field` to ignore it in state manager
- add `transformations` to download retriever

> [!CAUTION]
> changing url path in `stream_slice` for download retriever is technically a **_breaking change_**, but I don't want to bump major version since `AsyncRetriever` is an `ExperimentalClass`

# Reason

see https://github.com/airbytehq/airbyte-python-cdk/pull/192#discussion_r1901702963

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enhanced `StreamSlice` class with boolean evaluation support
	- Improved record selector with customizable transformations

- **Improvements**
	- Updated async HTTP job repository to provide more flexible stream slice construction
	- Refined URL retrieval mechanism in job processing tests

The changes introduce more dynamic and flexible data processing capabilities within the Airbyte CDK, allowing for more nuanced record transformations and stream handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->