### PR TITLE
fix(low-code cdk pagination): Fix the offset strategy so that it resets back to 0 when a stream is an incremental data feed

### DIFF
--- a/airbyte_cdk/sources/declarative/requesters/paginators/strategies/offset_increment.py
+++ b/airbyte_cdk/sources/declarative/requesters/paginators/strategies/offset_increment.py
@@ -83,7 +83,9 @@ class OffsetIncrement(PaginationStrategy):
             return self._offset
 
     def reset(self, reset_value: Optional[Any] = 0) -> None:
-        if not isinstance(reset_value, int):
+        if reset_value is None:
+            self._offset = 0
+        elif not isinstance(reset_value, int):
             raise ValueError(
                 f"Reset value {reset_value} for OffsetIncrement pagination strategy was not an integer"
             )

--- a/airbyte_cdk/sources/declarative/requesters/paginators/strategies/stop_condition.py
+++ b/airbyte_cdk/sources/declarative/requesters/paginators/strategies/stop_condition.py
@@ -53,7 +53,10 @@ class StopConditionPaginationStrategyDecorator(PaginationStrategy):
         return self._delegate.next_page_token(response, last_page_size, last_record)
 
     def reset(self, reset_value: Optional[Any] = None) -> None:
-        self._delegate.reset(reset_value)
+        if reset_value:
+            self._delegate.reset(reset_value)
+        else:
+            self._delegate.reset()
 
     def get_page_size(self) -> Optional[int]:
         return self._delegate.get_page_size()

--- a/unit_tests/sources/declarative/requesters/paginators/test_default_paginator.py
+++ b/unit_tests/sources/declarative/requesters/paginators/test_default_paginator.py
@@ -9,6 +9,7 @@ import pytest
 import requests
 
 from airbyte_cdk.sources.declarative.decoders import JsonDecoder, XmlDecoder
+from airbyte_cdk.sources.declarative.incremental import DatetimeBasedCursor
 from airbyte_cdk.sources.declarative.interpolation.interpolated_boolean import InterpolatedBoolean
 from airbyte_cdk.sources.declarative.requesters.paginators.default_paginator import (
     DefaultPaginator,
@@ -21,6 +22,10 @@ from airbyte_cdk.sources.declarative.requesters.paginators.strategies.cursor_pag
 )
 from airbyte_cdk.sources.declarative.requesters.paginators.strategies.offset_increment import (
     OffsetIncrement,
+)
+from airbyte_cdk.sources.declarative.requesters.paginators.strategies.stop_condition import (
+    CursorStopCondition,
+    StopConditionPaginationStrategyDecorator,
 )
 from airbyte_cdk.sources.declarative.requesters.request_path import RequestPath
 
@@ -354,6 +359,40 @@ def test_reset(inject_on_first_request):
     request_parameters_after_reset = paginator.get_request_params()
     assert initial_request_parameters == request_parameters_after_reset
     assert request_parameters_for_second_request != request_parameters_after_reset
+
+
+def test_data_feed_paginator_with_stop_page_condition():
+    config = {}
+
+    cursor = DatetimeBasedCursor(
+        cursor_field="updated_at",
+        datetime_format="%Y-%m-$d",
+        start_datetime="2024-01-01",
+        config=config,
+        parameters={},
+    )
+
+    wrapped_strategy = StopConditionPaginationStrategyDecorator(
+        _delegate=OffsetIncrement(
+            config={}, page_size=2, inject_on_first_request=False, parameters={}
+        ),
+        stop_condition=CursorStopCondition(cursor=cursor),
+    )
+
+    paginator = DefaultPaginator(
+        pagination_strategy=wrapped_strategy,
+        config=config,
+        url_base="https://airbyte.io",
+        parameters={},
+        page_size_option=RequestOption(
+            inject_into=RequestOptionType.request_parameter, field_name="limit", parameters={}
+        ),
+        page_token_option=RequestOption(
+            inject_into=RequestOptionType.request_parameter, field_name="offset", parameters={}
+        ),
+    )
+
+    paginator.reset()
 
 
 def test_initial_token_with_offset_pagination():

--- a/unit_tests/sources/declarative/requesters/paginators/test_default_paginator.py
+++ b/unit_tests/sources/declarative/requesters/paginators/test_default_paginator.py
@@ -366,7 +366,7 @@ def test_data_feed_paginator_with_stop_page_condition():
 
     cursor = DatetimeBasedCursor(
         cursor_field="updated_at",
-        datetime_format="%Y-%m-$d",
+        datetime_format="%Y-%m-%d",
         start_datetime="2024-01-01",
         config=config,
         parameters={},

--- a/unit_tests/sources/declarative/requesters/paginators/test_offset_increment.py
+++ b/unit_tests/sources/declarative/requesters/paginators/test_offset_increment.py
@@ -104,8 +104,5 @@ def test_offset_increment_reset(reset_value, expected_initial_token, expected_er
         with pytest.raises(expected_error):
             paginator_strategy.reset(reset_value=reset_value)
     else:
-        if reset_value is None:
-            paginator_strategy.reset()
-        else:
-            paginator_strategy.reset(reset_value=reset_value)
+        paginator_strategy.reset(reset_value=reset_value)
         assert paginator_strategy.initial_token == expected_initial_token

--- a/unit_tests/sources/declarative/requesters/paginators/test_stop_condition.py
+++ b/unit_tests/sources/declarative/requesters/paginators/test_stop_condition.py
@@ -108,7 +108,7 @@ def test_when_reset_then_delegate(mocked_pagination_strategy, mocked_stop_condit
         mocked_pagination_strategy, mocked_stop_condition
     )
     decorator.reset()
-    mocked_pagination_strategy.reset.assert_called_once_with(None)
+    mocked_pagination_strategy.reset.assert_called_once_with()
 
 
 def test_when_get_page_size_then_delegate(mocked_pagination_strategy, mocked_stop_condition):


### PR DESCRIPTION
Fixes https://github.com/airbytehq/oncall/issues/7210

## What

We were observing this error for low-code connectors using the offset pagination strategy:

```
  File "/home/airbyte/.pyenv/versions/3.10.15/lib/python3.10/site-packages/airbyte_cdk/sources/declarative/requesters/paginators/strategies/offset_increment.py", line 87, in reset
    raise ValueError(
ValueError: Reset value None for OffsetIncrement pagination strategy was not an integer
```

## How

After investigating this a bit, I realized that this was only happening when we used an incremental stream where `is_data_feed` was enabled. 

And that is because the `StopConditionPaginationStrategyDecorator` that gets instantiated for data feeds is not implemented correctly for reseting back to 0. We accept optional values, but the problem is that the decorator can still accidentally pass in `None` when the surrounding `reset()` passes None. Instead we need to call `reset()` with no incoming parameter. I also fixed this in the `OffsetPaginationStrategy` as well just to cover all our bases.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced pagination strategies with more flexible reset behaviors
	- Added support for stop page conditions in data feed pagination

- **Tests**
	- Introduced new test for data feed paginator with stop page condition
	- Simplified offset increment reset test logic

- **Bug Fixes**
	- Improved handling of reset values in pagination strategies
	- Added support for `None` reset values in offset increment and stop condition strategies
<!-- end of auto-generated comment: release notes by coderabbit.ai -->