### PR TITLE
feat: add `min` macros

### DIFF
--- a/airbyte_cdk/sources/declarative/interpolation/macros.py
+++ b/airbyte_cdk/sources/declarative/interpolation/macros.py
@@ -94,6 +94,26 @@ def max(*args: typing.Any) -> typing.Any:
     return builtins.max(*args)
 
 
+def min(*args: typing.Any) -> typing.Any:
+    """
+    Returns smallest object of an iterable, or two or more arguments.
+
+    min(iterable, *[, default=obj, key=func]) -> value
+    min(arg1, arg2, *args, *[, key=func]) -> value
+
+    Usage:
+    `"{{ min(2,3) }}"
+
+    With a single iterable argument, return its smallest item. The
+    default keyword-only argument specifies an object to return if
+    the provided iterable is empty.
+    With two or more arguments, return the smallest argument.
+    :param args: args to compare
+    :return: smallest argument
+    """
+    return builtins.min(*args)
+
+
 def day_delta(num_days: int, format: str = "%Y-%m-%dT%H:%M:%S.%f%z") -> str:
     """
     Returns datetime of now() + num_days
@@ -147,6 +167,7 @@ _macros_list = [
     today_utc,
     timestamp,
     max,
+    min,
     day_delta,
     duration,
     format_datetime,

--- a/unit_tests/sources/declarative/interpolation/test_jinja.py
+++ b/unit_tests/sources/declarative/interpolation/test_jinja.py
@@ -184,6 +184,7 @@ def test_to_string(test_name, input_value, expected_output):
             id="test_timestamp_from_rfc3339",
         ),
         pytest.param("{{ max(1,2) }}", 2, id="test_max"),
+        pytest.param("{{ min(1,2) }}", 1, id="test_min"),
     ],
 )
 def test_macros(s, expected_value):
@@ -291,6 +292,8 @@ def test_undeclared_variables(template_string, expected_error, expected_value):
         ),
         pytest.param("{{ max(2, 3) }}", 3, id="test_max_with_arguments"),
         pytest.param("{{ max([2, 3]) }}", 3, id="test_max_with_list"),
+        pytest.param("{{ min(2, 3) }}", 2, id="test_min_with_arguments"),
+        pytest.param("{{ min([2, 3]) }}", 2, id="test_min_with_list"),
         pytest.param("{{ day_delta(1) }}", "2021-09-02T00:00:00.000000+0000", id="test_day_delta"),
         pytest.param(
             "{{ day_delta(-1) }}", "2021-08-31T00:00:00.000000+0000", id="test_day_delta_negative"

--- a/unit_tests/sources/declarative/interpolation/test_macros.py
+++ b/unit_tests/sources/declarative/interpolation/test_macros.py
@@ -15,6 +15,7 @@ from airbyte_cdk.sources.declarative.interpolation.macros import macros
         ("test_now_utc", "now_utc", True),
         ("test_today_utc", "today_utc", True),
         ("test_max", "max", True),
+        ("test_min", "max", True),
         ("test_day_delta", "day_delta", True),
         ("test_format_datetime", "format_datetime", True),
         ("test_duration", "duration", True),


### PR DESCRIPTION
# What

add new macros to interpolation: min function