### PR TITLE
feat(file-based): changes for not mirroring paths

### DIFF
--- a/airbyte_cdk/sources/file_based/config/abstract_file_based_spec.py
+++ b/airbyte_cdk/sources/file_based/config/abstract_file_based_spec.py
@@ -14,13 +14,6 @@ from airbyte_cdk.sources.file_based.config.file_based_stream_config import FileB
 from airbyte_cdk.sources.utils import schema_helpers
 
 
-class DeliveryOptions(BaseModel):
-    preserve_subdirectories_directories: bool = Field(
-        True,
-        description="Flag indicating we should preserve subdirectories directories",
-    )
-
-
 class DeliverRecords(BaseModel):
     class Config(OneOfOptionConfig):
         title = "Replicate Records"
@@ -37,10 +30,11 @@ class DeliverRawFiles(BaseModel):
         discriminator = "delivery_type"
 
     delivery_type: Literal["use_file_transfer"] = Field("use_file_transfer", const=True)
-    delivery_options: Optional[DeliveryOptions] = Field(
-        title="Delivery Options",
-        type="object",
-        order=2,
+
+    preserve_subdirectories_directories: bool = Field(
+        title="Preserve Subdirectories Directories",
+        description="Flag indicating we should preserve subdirectories directories",
+        default=True,
     )
 
 
@@ -77,10 +71,10 @@ class AbstractFileBasedSpec(BaseModel):
         airbyte_hidden=True,
     )
 
-    delivery_options: Optional[DeliveryOptions] = Field(
-        title="Delivery Options",
-        type="object",
-        order=8,
+    preserve_subdirectories_directories: bool = Field(
+        title="Preserve Subdirectories Directories",
+        description="Flag indicating we should preserve subdirectories directories",
+        default=True,
     )
 
     @classmethod

--- a/airbyte_cdk/sources/file_based/config/abstract_file_based_spec.py
+++ b/airbyte_cdk/sources/file_based/config/abstract_file_based_spec.py
@@ -32,8 +32,8 @@ class DeliverRawFiles(BaseModel):
     delivery_type: Literal["use_file_transfer"] = Field("use_file_transfer", const=True)
 
     preserve_subdirectories_directories: bool = Field(
-        title="Preserve Subdirectories Directories",
-        description="Flag indicating we should preserve subdirectories directories",
+        title="Preserve Subdirectories in File Paths",
+        description="If enabled replicate source folder structure",
         default=True,
     )
 
@@ -69,12 +69,6 @@ class AbstractFileBasedSpec(BaseModel):
         group="advanced",
         default="use_records_transfer",
         airbyte_hidden=True,
-    )
-
-    preserve_subdirectories_directories: bool = Field(
-        title="Preserve Subdirectories Directories",
-        description="Flag indicating we should preserve subdirectories directories",
-        default=True,
     )
 
     @classmethod

--- a/airbyte_cdk/sources/file_based/config/abstract_file_based_spec.py
+++ b/airbyte_cdk/sources/file_based/config/abstract_file_based_spec.py
@@ -31,7 +31,7 @@ class DeliverRawFiles(BaseModel):
 
     delivery_type: Literal["use_file_transfer"] = Field("use_file_transfer", const=True)
 
-    preserve_subdirectories_directories: bool = Field(
+    preserve_directory_structure: bool = Field(
         title="Preserve Sub-Directories in File Paths",
         description=(
             "If enabled, sends subdirectory folder structure "

--- a/airbyte_cdk/sources/file_based/config/abstract_file_based_spec.py
+++ b/airbyte_cdk/sources/file_based/config/abstract_file_based_spec.py
@@ -32,7 +32,7 @@ class DeliverRawFiles(BaseModel):
     delivery_type: Literal["use_file_transfer"] = Field("use_file_transfer", const=True)
 
     preserve_subdirectories_directories: bool = Field(
-        title="Preserve Subdirectories in File Paths",
+        title="Preserve Sub-Directories in File Paths",
         description="If enabled replicate source folder structure",
         default=True,
     )

--- a/airbyte_cdk/sources/file_based/config/abstract_file_based_spec.py
+++ b/airbyte_cdk/sources/file_based/config/abstract_file_based_spec.py
@@ -14,6 +14,13 @@ from airbyte_cdk.sources.file_based.config.file_based_stream_config import FileB
 from airbyte_cdk.sources.utils import schema_helpers
 
 
+class DeliveryOptions(BaseModel):
+    preserve_subdirectories_directories: bool = Field(
+        True,
+        description="Flag indicating we should preserve subdirectories directories",
+    )
+
+
 class DeliverRecords(BaseModel):
     class Config(OneOfOptionConfig):
         title = "Replicate Records"
@@ -30,6 +37,11 @@ class DeliverRawFiles(BaseModel):
         discriminator = "delivery_type"
 
     delivery_type: Literal["use_file_transfer"] = Field("use_file_transfer", const=True)
+    delivery_options: Optional[DeliveryOptions] = Field(
+        title="Delivery Options",
+        type="object",
+        order=2,
+    )
 
 
 class AbstractFileBasedSpec(BaseModel):
@@ -63,6 +75,12 @@ class AbstractFileBasedSpec(BaseModel):
         group="advanced",
         default="use_records_transfer",
         airbyte_hidden=True,
+    )
+
+    delivery_options: Optional[DeliveryOptions] = Field(
+        title="Delivery Options",
+        type="object",
+        order=8,
     )
 
     @classmethod

--- a/airbyte_cdk/sources/file_based/config/abstract_file_based_spec.py
+++ b/airbyte_cdk/sources/file_based/config/abstract_file_based_spec.py
@@ -33,7 +33,12 @@ class DeliverRawFiles(BaseModel):
 
     preserve_subdirectories_directories: bool = Field(
         title="Preserve Sub-Directories in File Paths",
-        description="If enabled replicate source folder structure",
+        description=(
+            "If enabled, sends subdirectory folder structure "
+            "along with source file names to the destination. "
+            "Otherwise, files will be synced by their names only. "
+            "This option is ignored when file-based replication is not enabled."
+        ),
         default=True,
     )
 

--- a/airbyte_cdk/sources/file_based/exceptions.py
+++ b/airbyte_cdk/sources/file_based/exceptions.py
@@ -111,6 +111,10 @@ class ErrorListingFiles(BaseFileBasedSourceError):
     pass
 
 
+class DuplicatedFilesError(BaseFileBasedSourceError):
+    pass
+
+
 class CustomFileBasedException(AirbyteTracedException):
     """
     A specialized exception for file-based connectors.
@@ -123,3 +127,23 @@ class CustomFileBasedException(AirbyteTracedException):
 
 class FileSizeLimitError(CustomFileBasedException):
     pass
+
+
+def format_duplicate_files_error_message(stream_name: str, duplicated_files_names: List):
+    duplicated_files_messages = []
+    for duplicated_file in duplicated_files_names:
+        for duplicated_file_name, file_paths in duplicated_file.items():
+            file_duplicated_message = (
+                f"{len(file_paths)} duplicates found for file name {duplicated_file_name}:\n\n"
+                + "".join(f"\n - {file_paths}")
+            )
+            duplicated_files_messages.append(file_duplicated_message)
+
+    error_message = (
+        f"ERROR: Duplicate filenames found for stream {stream_name}. "
+        "Duplicate file names are not allowed if the Preserve Subdirectories in File Paths option is disabled. "
+        "Please remove or rename the duplicate files before attempting to re-run the sync.\n\n"
+        + "\n".join(duplicated_files_messages)
+    )
+
+    return error_message

--- a/airbyte_cdk/sources/file_based/exceptions.py
+++ b/airbyte_cdk/sources/file_based/exceptions.py
@@ -143,7 +143,7 @@ def format_duplicate_files_error_message(
 
     error_message = (
         f"ERROR: Duplicate filenames found for stream {stream_name}. "
-        "Duplicate file names are not allowed if the Preserve Subdirectories in File Paths option is disabled. "
+        "Duplicate file names are not allowed if the Preserve Sub-Directories in File Paths option is disabled. "
         "Please remove or rename the duplicate files before attempting to re-run the sync.\n\n"
         + "\n".join(duplicated_files_messages)
     )

--- a/airbyte_cdk/sources/file_based/exceptions.py
+++ b/airbyte_cdk/sources/file_based/exceptions.py
@@ -112,7 +112,7 @@ class ErrorListingFiles(BaseFileBasedSourceError):
 
 
 class DuplicatedFilesError(BaseFileBasedSourceError):
-    def __init__(self, duplicated_files_names: List[dict[str, List[str]]], **kwargs):
+    def __init__(self, duplicated_files_names: List[dict[str, List[str]]], **kwargs: Any):
         self._duplicated_files_names = duplicated_files_names
         self._stream_name: str = kwargs["stream"]
         super().__init__(self._format_duplicate_files_error_message(), **kwargs)

--- a/airbyte_cdk/sources/file_based/exceptions.py
+++ b/airbyte_cdk/sources/file_based/exceptions.py
@@ -129,7 +129,9 @@ class FileSizeLimitError(CustomFileBasedException):
     pass
 
 
-def format_duplicate_files_error_message(stream_name: str, duplicated_files_names: List):
+def format_duplicate_files_error_message(
+    stream_name: str, duplicated_files_names: List[dict[str, List[str]]]
+) -> str:
     duplicated_files_messages = []
     for duplicated_file in duplicated_files_names:
         for duplicated_file_name, file_paths in duplicated_file.items():

--- a/airbyte_cdk/sources/file_based/exceptions.py
+++ b/airbyte_cdk/sources/file_based/exceptions.py
@@ -112,7 +112,37 @@ class ErrorListingFiles(BaseFileBasedSourceError):
 
 
 class DuplicatedFilesError(BaseFileBasedSourceError):
-    pass
+    def __init__(self, duplicated_files_names: List[dict[str, List[str]]], **kwargs):
+        self._duplicated_files_names = duplicated_files_names
+        self._stream_name: str = kwargs["stream"]
+        super().__init__(self._format_duplicate_files_error_message(), **kwargs)
+
+    def _format_duplicate_files_error_message(self) -> str:
+        duplicated_files_messages = []
+        for duplicated_file in self._duplicated_files_names:
+            for duplicated_file_name, file_paths in duplicated_file.items():
+                file_duplicated_message = (
+                    f"{len(file_paths)} duplicates found for file name {duplicated_file_name}:\n\n"
+                    + "".join(f"\n - {file_paths}")
+                )
+                duplicated_files_messages.append(file_duplicated_message)
+
+        error_message = (
+            f"ERROR: Duplicate filenames found for stream {self._stream_name}. "
+            "Duplicate file names are not allowed if the Preserve Sub-Directories in File Paths option is disabled. "
+            "Please remove or rename the duplicate files before attempting to re-run the sync.\n\n"
+            + "\n".join(duplicated_files_messages)
+        )
+
+        return error_message
+
+    def __repr__(self) -> str:
+        """Return a string representation of the exception."""
+        class_name = self.__class__.__name__
+        properties_str = ", ".join(
+            f"{k}={v!r}" for k, v in self.__dict__.items() if not k.startswith("_")
+        )
+        return f"{class_name}({properties_str})"
 
 
 class CustomFileBasedException(AirbyteTracedException):
@@ -127,25 +157,3 @@ class CustomFileBasedException(AirbyteTracedException):
 
 class FileSizeLimitError(CustomFileBasedException):
     pass
-
-
-def format_duplicate_files_error_message(
-    stream_name: str, duplicated_files_names: List[dict[str, List[str]]]
-) -> str:
-    duplicated_files_messages = []
-    for duplicated_file in duplicated_files_names:
-        for duplicated_file_name, file_paths in duplicated_file.items():
-            file_duplicated_message = (
-                f"{len(file_paths)} duplicates found for file name {duplicated_file_name}:\n\n"
-                + "".join(f"\n - {file_paths}")
-            )
-            duplicated_files_messages.append(file_duplicated_message)
-
-    error_message = (
-        f"ERROR: Duplicate filenames found for stream {stream_name}. "
-        "Duplicate file names are not allowed if the Preserve Sub-Directories in File Paths option is disabled. "
-        "Please remove or rename the duplicate files before attempting to re-run the sync.\n\n"
-        + "\n".join(duplicated_files_messages)
-    )
-
-    return error_message

--- a/airbyte_cdk/sources/file_based/file_based_source.py
+++ b/airbyte_cdk/sources/file_based/file_based_source.py
@@ -393,9 +393,8 @@ class FileBasedSource(ConcurrentSourceAdapter, ABC):
     def _preserve_subdirectories_directories(parsed_config: AbstractFileBasedSpec) -> bool:
         # fall back to preserve subdirectories if config is not present or incomplete
         if (
-            hasattr(parsed_config, "delivery_options")
-            and parsed_config.delivery_options is not None
-            and hasattr(parsed_config.delivery_options, "preserve_subdirectories_directories")
+            hasattr(parsed_config, "preserve_subdirectories_directories")
+            and parsed_config.preserve_subdirectories_directories is not None
         ):
-            return parsed_config.delivery_options.preserve_subdirectories_directories
+            return parsed_config.preserve_subdirectories_directories
         return True

--- a/airbyte_cdk/sources/file_based/file_based_source.py
+++ b/airbyte_cdk/sources/file_based/file_based_source.py
@@ -311,9 +311,7 @@ class FileBasedSource(ConcurrentSourceAdapter, ABC):
             errors_collector=self.errors_collector,
             cursor=cursor,
             use_file_transfer=self._use_file_transfer(parsed_config),
-            preserve_directory_structure=self._preserve_directory_structure(
-                parsed_config
-            ),
+            preserve_directory_structure=self._preserve_directory_structure(parsed_config),
         )
 
     def _get_stream_from_catalog(

--- a/airbyte_cdk/sources/file_based/file_based_source.py
+++ b/airbyte_cdk/sources/file_based/file_based_source.py
@@ -389,7 +389,18 @@ class FileBasedSource(ConcurrentSourceAdapter, ABC):
 
     @staticmethod
     def _preserve_directory_structure(parsed_config: AbstractFileBasedSpec) -> bool:
-        # fall back to preserve subdirectories if config is not present or incomplete
+        """
+        Determines whether to preserve directory structure during file transfer.
+
+        When enabled, files maintain their subdirectory paths in the destination.
+        When disabled, files are flattened to the root of the destination.
+
+        Args:
+            parsed_config: The parsed configuration containing delivery method settings
+
+        Returns:
+            True if directory structure should be preserved (default), False otherwise
+        """
         if (
             FileBasedSource._use_file_transfer(parsed_config)
             and hasattr(parsed_config.delivery_method, "preserve_directory_structure")

--- a/airbyte_cdk/sources/file_based/file_based_source.py
+++ b/airbyte_cdk/sources/file_based/file_based_source.py
@@ -242,7 +242,7 @@ class FileBasedSource(ConcurrentSourceAdapter, ABC):
                         stream=self._make_default_stream(
                             stream_config=stream_config,
                             cursor=cursor,
-                            use_file_transfer=self._use_file_transfer(parsed_config),
+                            parsed_config=parsed_config,
                         ),
                         source=self,
                         logger=self.logger,
@@ -273,7 +273,7 @@ class FileBasedSource(ConcurrentSourceAdapter, ABC):
                         stream=self._make_default_stream(
                             stream_config=stream_config,
                             cursor=cursor,
-                            use_file_transfer=self._use_file_transfer(parsed_config),
+                            parsed_config=parsed_config,
                         ),
                         source=self,
                         logger=self.logger,
@@ -285,7 +285,7 @@ class FileBasedSource(ConcurrentSourceAdapter, ABC):
                     stream = self._make_default_stream(
                         stream_config=stream_config,
                         cursor=cursor,
-                        use_file_transfer=self._use_file_transfer(parsed_config),
+                        parsed_config=parsed_config,
                     )
 
                 streams.append(stream)
@@ -298,7 +298,7 @@ class FileBasedSource(ConcurrentSourceAdapter, ABC):
         self,
         stream_config: FileBasedStreamConfig,
         cursor: Optional[AbstractFileBasedCursor],
-        use_file_transfer: bool = False,
+        parsed_config: AbstractFileBasedSpec,
     ) -> AbstractFileBasedStream:
         return DefaultFileBasedStream(
             config=stream_config,
@@ -310,7 +310,10 @@ class FileBasedSource(ConcurrentSourceAdapter, ABC):
             validation_policy=self._validate_and_get_validation_policy(stream_config),
             errors_collector=self.errors_collector,
             cursor=cursor,
-            use_file_transfer=use_file_transfer,
+            use_file_transfer=self._use_file_transfer(parsed_config),
+            preserve_subdirectories_directories=self._preserve_subdirectories_directories(
+                parsed_config
+            ),
         )
 
     def _get_stream_from_catalog(
@@ -385,3 +388,12 @@ class FileBasedSource(ConcurrentSourceAdapter, ABC):
             and parsed_config.delivery_method.delivery_type == "use_file_transfer"
         )
         return use_file_transfer
+
+    @staticmethod
+    def _preserve_subdirectories_directories(parsed_config: AbstractFileBasedSpec):
+        # fall back to preserve subdirectories if config is not present or incomplete
+        if hasattr(parsed_config, "delivery_options") and hasattr(
+            parsed_config.delivery_options, "preserve_subdirectories_directories"
+        ):
+            return parsed_config.delivery_options.preserve_subdirectories_directories
+        return True

--- a/airbyte_cdk/sources/file_based/file_based_source.py
+++ b/airbyte_cdk/sources/file_based/file_based_source.py
@@ -393,8 +393,9 @@ class FileBasedSource(ConcurrentSourceAdapter, ABC):
     def _preserve_subdirectories_directories(parsed_config: AbstractFileBasedSpec) -> bool:
         # fall back to preserve subdirectories if config is not present or incomplete
         if (
-            hasattr(parsed_config, "preserve_subdirectories_directories")
-            and parsed_config.preserve_subdirectories_directories is not None
+            FileBasedSource._use_file_transfer(parsed_config)
+            and hasattr(parsed_config.delivery_method, "preserve_subdirectories_directories")
+            and parsed_config.delivery_method.preserve_subdirectories_directories is not None
         ):
-            return parsed_config.preserve_subdirectories_directories
+            return parsed_config.delivery_method.preserve_subdirectories_directories
         return True

--- a/airbyte_cdk/sources/file_based/file_based_source.py
+++ b/airbyte_cdk/sources/file_based/file_based_source.py
@@ -311,7 +311,7 @@ class FileBasedSource(ConcurrentSourceAdapter, ABC):
             errors_collector=self.errors_collector,
             cursor=cursor,
             use_file_transfer=self._use_file_transfer(parsed_config),
-            preserve_subdirectories_directories=self._preserve_subdirectories_directories(
+            preserve_directory_structure=self._preserve_directory_structure(
                 parsed_config
             ),
         )
@@ -390,12 +390,12 @@ class FileBasedSource(ConcurrentSourceAdapter, ABC):
         return use_file_transfer
 
     @staticmethod
-    def _preserve_subdirectories_directories(parsed_config: AbstractFileBasedSpec) -> bool:
+    def _preserve_directory_structure(parsed_config: AbstractFileBasedSpec) -> bool:
         # fall back to preserve subdirectories if config is not present or incomplete
         if (
             FileBasedSource._use_file_transfer(parsed_config)
-            and hasattr(parsed_config.delivery_method, "preserve_subdirectories_directories")
-            and parsed_config.delivery_method.preserve_subdirectories_directories is not None
+            and hasattr(parsed_config.delivery_method, "preserve_directory_structure")
+            and parsed_config.delivery_method.preserve_directory_structure is not None
         ):
-            return parsed_config.delivery_method.preserve_subdirectories_directories
+            return parsed_config.delivery_method.preserve_directory_structure
         return True

--- a/airbyte_cdk/sources/file_based/file_based_source.py
+++ b/airbyte_cdk/sources/file_based/file_based_source.py
@@ -390,10 +390,12 @@ class FileBasedSource(ConcurrentSourceAdapter, ABC):
         return use_file_transfer
 
     @staticmethod
-    def _preserve_subdirectories_directories(parsed_config: AbstractFileBasedSpec):
+    def _preserve_subdirectories_directories(parsed_config: AbstractFileBasedSpec) -> bool:
         # fall back to preserve subdirectories if config is not present or incomplete
-        if hasattr(parsed_config, "delivery_options") and hasattr(
-            parsed_config.delivery_options, "preserve_subdirectories_directories"
+        if (
+            hasattr(parsed_config, "delivery_options")
+            and parsed_config.delivery_options is not None
+            and hasattr(parsed_config.delivery_options, "preserve_subdirectories_directories")
         ):
             return parsed_config.delivery_options.preserve_subdirectories_directories
         return True

--- a/airbyte_cdk/sources/file_based/file_based_stream_reader.py
+++ b/airbyte_cdk/sources/file_based/file_based_stream_reader.py
@@ -140,6 +140,7 @@ class AbstractFileBasedStreamReader(ABC):
         if (
             self.config
             and hasattr(self.config, "delivery_options")
+            and self.config.delivery_options is not None
             and hasattr(self.config.delivery_options, "preserve_subdirectories_directories")
         ):
             return self.config.delivery_options.preserve_subdirectories_directories

--- a/airbyte_cdk/sources/file_based/file_based_stream_reader.py
+++ b/airbyte_cdk/sources/file_based/file_based_stream_reader.py
@@ -138,11 +138,11 @@ class AbstractFileBasedStreamReader(ABC):
     def preserve_subdirectories_directories(self) -> bool:
         # fall back to preserve subdirectories if config is not present or incomplete
         if (
-            self.config
-            and hasattr(self.config, "preserve_subdirectories_directories")
-            and self.config.preserve_subdirectories_directories is not None
+            self.use_file_transfer()
+            and hasattr(self.config.delivery_method, "preserve_subdirectories_directories")
+            and self.config.delivery_method.preserve_subdirectories_directories is not None
         ):
-            return self.config.preserve_subdirectories_directories
+            return self.config.delivery_method.preserve_subdirectories_directories
         return True
 
     @abstractmethod

--- a/airbyte_cdk/sources/file_based/file_based_stream_reader.py
+++ b/airbyte_cdk/sources/file_based/file_based_stream_reader.py
@@ -139,11 +139,10 @@ class AbstractFileBasedStreamReader(ABC):
         # fall back to preserve subdirectories if config is not present or incomplete
         if (
             self.config
-            and hasattr(self.config, "delivery_options")
-            and self.config.delivery_options is not None
-            and hasattr(self.config.delivery_options, "preserve_subdirectories_directories")
+            and hasattr(self.config, "preserve_subdirectories_directories")
+            and self.config.preserve_subdirectories_directories is not None
         ):
-            return self.config.delivery_options.preserve_subdirectories_directories
+            return self.config.preserve_subdirectories_directories
         return True
 
     @abstractmethod

--- a/airbyte_cdk/sources/file_based/file_based_stream_reader.py
+++ b/airbyte_cdk/sources/file_based/file_based_stream_reader.py
@@ -139,6 +139,7 @@ class AbstractFileBasedStreamReader(ABC):
         # fall back to preserve subdirectories if config is not present or incomplete
         if (
             self.use_file_transfer()
+            and self.config
             and hasattr(self.config.delivery_method, "preserve_subdirectories_directories")
             and self.config.delivery_method.preserve_subdirectories_directories is not None
         ):

--- a/airbyte_cdk/sources/file_based/file_based_stream_reader.py
+++ b/airbyte_cdk/sources/file_based/file_based_stream_reader.py
@@ -135,15 +135,15 @@ class AbstractFileBasedStreamReader(ABC):
             return use_file_transfer
         return False
 
-    def preserve_subdirectories_directories(self) -> bool:
+    def preserve_directory_structure(self) -> bool:
         # fall back to preserve subdirectories if config is not present or incomplete
         if (
             self.use_file_transfer()
             and self.config
-            and hasattr(self.config.delivery_method, "preserve_subdirectories_directories")
-            and self.config.delivery_method.preserve_subdirectories_directories is not None
+            and hasattr(self.config.delivery_method, "preserve_directory_structure")
+            and self.config.delivery_method.preserve_directory_structure is not None
         ):
-            return self.config.delivery_method.preserve_subdirectories_directories
+            return self.config.delivery_method.preserve_directory_structure
         return True
 
     @abstractmethod
@@ -171,8 +171,8 @@ class AbstractFileBasedStreamReader(ABC):
         ...
 
     def _get_file_transfer_paths(self, file: RemoteFile, local_directory: str) -> List[str]:
-        preserve_subdirectories_directories = self.preserve_subdirectories_directories()
-        if preserve_subdirectories_directories:
+        preserve_directory_structure = self.preserve_directory_structure()
+        if preserve_directory_structure:
             # Remove left slashes from source path format to make relative path for writing locally
             file_relative_path = file.uri.lstrip("/")
         else:

--- a/airbyte_cdk/sources/file_based/file_types/unstructured_parser.py
+++ b/airbyte_cdk/sources/file_based/file_types/unstructured_parser.py
@@ -49,9 +49,11 @@ try:
     nltk.data.path.append(nltk_data_dir)
     nltk.data.find("tokenizers/punkt.zip")
     nltk.data.find("tokenizers/punkt_tab.zip")
+    nltk.data.find("tokenizers/averaged_perceptron_tagger_eng.zip")
 except LookupError:
     nltk.download("punkt", download_dir=nltk_data_dir)
     nltk.download("punkt_tab", download_dir=nltk_data_dir)
+    nltk.download("averaged_perceptron_tagger_eng", download_dir=nltk_data_dir)
 
 
 def optional_decode(contents: Union[str, bytes]) -> str:

--- a/airbyte_cdk/sources/file_based/file_types/unstructured_parser.py
+++ b/airbyte_cdk/sources/file_based/file_types/unstructured_parser.py
@@ -42,10 +42,24 @@ from airbyte_cdk.utils.traced_exception import AirbyteTracedException
 unstructured_partition_pdf = None
 unstructured_partition_docx = None
 unstructured_partition_pptx = None
-nltk_data_dir = "/tmp/nltk_data"
+
+
+def get_ntlk_temp_folder():
+    """
+    For non-root connectors /tmp is not currently writable, but we should allow it in the future.
+    It's safe to use /airbyte for now. Fallback to /tmp for local development.
+    """
+    try:
+        nltk_data_dir = "/airbyte/nltk_data"
+        os.makedirs(nltk_data_dir, exist_ok=True)
+    except OSError:
+        nltk_data_dir = "/tmp/nltk_data"
+        os.makedirs(nltk_data_dir, exist_ok=True)
+    return nltk_data_dir
+
 
 try:
-    os.makedirs(nltk_data_dir, exist_ok=True)
+    nltk_data_dir = get_ntlk_temp_folder()
     nltk.data.path.append(nltk_data_dir)
     nltk.data.find("tokenizers/punkt.zip")
     nltk.data.find("tokenizers/punkt_tab.zip")

--- a/airbyte_cdk/sources/file_based/file_types/unstructured_parser.py
+++ b/airbyte_cdk/sources/file_based/file_types/unstructured_parser.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
 import logging
+import os
 import traceback
 from datetime import datetime
 from io import BytesIO, IOBase
@@ -41,13 +42,16 @@ from airbyte_cdk.utils.traced_exception import AirbyteTracedException
 unstructured_partition_pdf = None
 unstructured_partition_docx = None
 unstructured_partition_pptx = None
+nltk_data_dir = "/tmp/nltk_data"
 
 try:
+    os.makedirs(nltk_data_dir, exist_ok=True)
+    nltk.data.path.append(nltk_data_dir)
     nltk.data.find("tokenizers/punkt.zip")
     nltk.data.find("tokenizers/punkt_tab.zip")
 except LookupError:
-    nltk.download("punkt")
-    nltk.download("punkt_tab")
+    nltk.download("punkt", download_dir=nltk_data_dir)
+    nltk.download("punkt_tab", download_dir=nltk_data_dir)
 
 
 def optional_decode(contents: Union[str, bytes]) -> str:

--- a/airbyte_cdk/sources/file_based/file_types/unstructured_parser.py
+++ b/airbyte_cdk/sources/file_based/file_types/unstructured_parser.py
@@ -43,23 +43,26 @@ unstructured_partition_pdf = None
 unstructured_partition_docx = None
 unstructured_partition_pptx = None
 
+AIRBYTE_NLTK_DATA_DIR = "/airbyte/nltk_data"
+TMP_NLTK_DATA_DIR = "/tmp/nltk_data"
 
-def get_ntlk_temp_folder() -> str:
+
+def get_nltk_temp_folder() -> str:
     """
     For non-root connectors /tmp is not currently writable, but we should allow it in the future.
     It's safe to use /airbyte for now. Fallback to /tmp for local development.
     """
     try:
-        nltk_data_dir = "/airbyte/nltk_data"
+        nltk_data_dir = AIRBYTE_NLTK_DATA_DIR
         os.makedirs(nltk_data_dir, exist_ok=True)
     except OSError:
-        nltk_data_dir = "/tmp/nltk_data"
+        nltk_data_dir = TMP_NLTK_DATA_DIR
         os.makedirs(nltk_data_dir, exist_ok=True)
     return nltk_data_dir
 
 
 try:
-    nltk_data_dir = get_ntlk_temp_folder()
+    nltk_data_dir = get_nltk_temp_folder()
     nltk.data.path.append(nltk_data_dir)
     nltk.data.find("tokenizers/punkt.zip")
     nltk.data.find("tokenizers/punkt_tab.zip")

--- a/airbyte_cdk/sources/file_based/file_types/unstructured_parser.py
+++ b/airbyte_cdk/sources/file_based/file_types/unstructured_parser.py
@@ -65,9 +65,9 @@ try:
     nltk.data.find("tokenizers/punkt_tab.zip")
     nltk.data.find("tokenizers/averaged_perceptron_tagger_eng.zip")
 except LookupError:
-    nltk.download("punkt", download_dir=nltk_data_dir)
-    nltk.download("punkt_tab", download_dir=nltk_data_dir)
-    nltk.download("averaged_perceptron_tagger_eng", download_dir=nltk_data_dir)
+    nltk.download("punkt", download_dir=nltk_data_dir, quiet=True)
+    nltk.download("punkt_tab", download_dir=nltk_data_dir, quiet=True)
+    nltk.download("averaged_perceptron_tagger_eng", download_dir=nltk_data_dir, quiet=True)
 
 
 def optional_decode(contents: Union[str, bytes]) -> str:

--- a/airbyte_cdk/sources/file_based/file_types/unstructured_parser.py
+++ b/airbyte_cdk/sources/file_based/file_types/unstructured_parser.py
@@ -44,7 +44,7 @@ unstructured_partition_docx = None
 unstructured_partition_pptx = None
 
 
-def get_ntlk_temp_folder():
+def get_ntlk_temp_folder() -> str:
     """
     For non-root connectors /tmp is not currently writable, but we should allow it in the future.
     It's safe to use /airbyte for now. Fallback to /tmp for local development.

--- a/airbyte_cdk/sources/file_based/stream/default_file_based_stream.py
+++ b/airbyte_cdk/sources/file_based/stream/default_file_based_stream.py
@@ -22,7 +22,6 @@ from airbyte_cdk.sources.file_based.exceptions import (
     RecordParseError,
     SchemaInferenceError,
     StopSyncPerValidationPolicy,
-    format_duplicate_files_error_message,
 )
 from airbyte_cdk.sources.file_based.file_types import FileTransfer
 from airbyte_cdk.sources.file_based.remote_file import RemoteFile
@@ -141,10 +140,7 @@ class DefaultFileBasedStream(AbstractFileBasedStream, IncrementalMixin):
             duplicated_files_names = self._duplicated_files_names(slices)
             if duplicated_files_names:
                 raise DuplicatedFilesError(
-                    format_duplicate_files_error_message(
-                        stream_name=self.name, duplicated_files_names=duplicated_files_names
-                    ),
-                    stream=self.name,
+                    stream=self.name, duplicated_files_names=duplicated_files_names
                 )
         return slices
 

--- a/airbyte_cdk/sources/file_based/stream/default_file_based_stream.py
+++ b/airbyte_cdk/sources/file_based/stream/default_file_based_stream.py
@@ -61,6 +61,7 @@ class DefaultFileBasedStream(AbstractFileBasedStream, IncrementalMixin):
     def __init__(self, **kwargs: Any):
         if self.FILE_TRANSFER_KW in kwargs:
             self.use_file_transfer = kwargs.pop(self.FILE_TRANSFER_KW, False)
+        if self.PRESERVE_SUBDIRECTORIES_KW in kwargs:
             self.preserve_subdirectories_directories = kwargs.pop(
                 self.PRESERVE_SUBDIRECTORIES_KW, True
             )

--- a/airbyte_cdk/sources/file_based/stream/default_file_based_stream.py
+++ b/airbyte_cdk/sources/file_based/stream/default_file_based_stream.py
@@ -111,20 +111,13 @@ class DefaultFileBasedStream(AbstractFileBasedStream, IncrementalMixin):
     def _duplicated_files_names(
         self, slices: List[dict[str, List[RemoteFile]]]
     ) -> List[dict[str, List[str]]]:
-        seen_file_names = set()
-        duplicates_file_names = set()
-        file_paths = defaultdict(list)
+        seen_file_names: Dict[str, List[str]] = defaultdict(list)
         for file_slice in slices:
             for file_found in file_slice[self.FILES_KEY]:
                 file_name = path.basename(file_found.uri)
-                if file_name not in seen_file_names:
-                    seen_file_names.add(file_name)
-                else:
-                    duplicates_file_names.add(file_name)
-                file_paths[file_name].append(file_found.uri)
+                seen_file_names[file_name].append(file_found.uri)
         return [
-            {duplicated_file: file_paths[duplicated_file]}
-            for duplicated_file in duplicates_file_names
+            {file_name: paths} for file_name, paths in seen_file_names.items() if len(paths) > 1
         ]
 
     def compute_slices(self) -> Iterable[Optional[Mapping[str, Any]]]:

--- a/airbyte_cdk/sources/file_based/stream/default_file_based_stream.py
+++ b/airbyte_cdk/sources/file_based/stream/default_file_based_stream.py
@@ -108,7 +108,9 @@ class DefaultFileBasedStream(AbstractFileBasedStream, IncrementalMixin):
         else:
             return super()._filter_schema_invalid_properties(configured_catalog_json_schema)
 
-    def _duplicated_files_names(self, slices: List) -> list[dict]:
+    def _duplicated_files_names(
+        self, slices: List[dict[str, List[RemoteFile]]]
+    ) -> List[dict[str, List[str]]]:
         seen_file_names = set()
         duplicates_file_names = set()
         file_paths = defaultdict(list)

--- a/airbyte_cdk/sources/file_based/stream/default_file_based_stream.py
+++ b/airbyte_cdk/sources/file_based/stream/default_file_based_stream.py
@@ -46,7 +46,7 @@ class DefaultFileBasedStream(AbstractFileBasedStream, IncrementalMixin):
     """
 
     FILE_TRANSFER_KW = "use_file_transfer"
-    PRESERVE_SUBDIRECTORIES_KW = "preserve_subdirectories_directories"
+    PRESERVE_DIRECTORY_STRUCTURE_KW = "preserve_directory_structure"
     FILES_KEY = "files"
     DATE_TIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
     ab_last_mod_col = "_ab_source_file_last_modified"
@@ -55,14 +55,14 @@ class DefaultFileBasedStream(AbstractFileBasedStream, IncrementalMixin):
     source_file_url = "source_file_url"
     airbyte_columns = [ab_last_mod_col, ab_file_name_col]
     use_file_transfer = False
-    preserve_subdirectories_directories = True
+    preserve_directory_structure = True
 
     def __init__(self, **kwargs: Any):
         if self.FILE_TRANSFER_KW in kwargs:
             self.use_file_transfer = kwargs.pop(self.FILE_TRANSFER_KW, False)
-        if self.PRESERVE_SUBDIRECTORIES_KW in kwargs:
-            self.preserve_subdirectories_directories = kwargs.pop(
-                self.PRESERVE_SUBDIRECTORIES_KW, True
+        if self.PRESERVE_DIRECTORY_STRUCTURE_KW in kwargs:
+            self.preserve_directory_structure = kwargs.pop(
+                self.PRESERVE_DIRECTORY_STRUCTURE_KW, True
             )
         super().__init__(**kwargs)
 
@@ -136,7 +136,7 @@ class DefaultFileBasedStream(AbstractFileBasedStream, IncrementalMixin):
             {self.FILES_KEY: list(group[1])}
             for group in itertools.groupby(sorted_files_to_read, lambda f: f.last_modified)
         ]
-        if slices and not self.preserve_subdirectories_directories:
+        if slices and not self.preserve_directory_structure:
             duplicated_files_names = self._duplicated_files_names(slices)
             if duplicated_files_names:
                 raise DuplicatedFilesError(

--- a/airbyte_cdk/sources/file_based/stream/default_file_based_stream.py
+++ b/airbyte_cdk/sources/file_based/stream/default_file_based_stream.py
@@ -5,18 +5,18 @@
 import asyncio
 import itertools
 import traceback
-from copy import deepcopy
 from collections import defaultdict
+from copy import deepcopy
 from functools import cache
 from os import path
-from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional, Set, Union, Tuple
+from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional, Set, Tuple, Union
 
 from airbyte_cdk.models import AirbyteLogMessage, AirbyteMessage, FailureType, Level
 from airbyte_cdk.models import Type as MessageType
 from airbyte_cdk.sources.file_based.config.file_based_stream_config import PrimaryKeyType
 from airbyte_cdk.sources.file_based.exceptions import (
-    FileBasedSourceError,
     DuplicatedFilesError,
+    FileBasedSourceError,
     InvalidSchemaError,
     MissingSchemaError,
     RecordParseError,

--- a/unit_tests/sources/file_based/scenarios/csv_scenarios.py
+++ b/unit_tests/sources/file_based/scenarios/csv_scenarios.py
@@ -527,7 +527,7 @@ single_csv_scenario: TestScenario[InMemoryFilesSource] = (
                                     "preserve_subdirectories_directories": {
                                         "default": True,
                                         "description": "If enabled replicate source folder structure",
-                                        "title": "Preserve Subdirectories in File Paths",
+                                        "title": "Preserve Sub-Directories in File Paths",
                                         "type": "boolean",
                                     },
                                 },

--- a/unit_tests/sources/file_based/scenarios/csv_scenarios.py
+++ b/unit_tests/sources/file_based/scenarios/csv_scenarios.py
@@ -524,7 +524,7 @@ single_csv_scenario: TestScenario[InMemoryFilesSource] = (
                                         "enum": ["use_file_transfer"],
                                         "type": "string",
                                     },
-                                    "preserve_subdirectories_directories": {
+                                    "preserve_directory_structure": {
                                         "default": True,
                                         "description": "If enabled, sends subdirectory folder structure along with source file names to the destination. Otherwise, files will be synced by their names only. This option is ignored when file-based replication is not enabled.",
                                         "title": "Preserve Sub-Directories in File Paths",

--- a/unit_tests/sources/file_based/scenarios/csv_scenarios.py
+++ b/unit_tests/sources/file_based/scenarios/csv_scenarios.py
@@ -526,8 +526,8 @@ single_csv_scenario: TestScenario[InMemoryFilesSource] = (
                                     },
                                     "preserve_subdirectories_directories": {
                                         "default": True,
-                                        "description": "Flag indicating we should preserve subdirectories directories",
-                                        "title": "Preserve Subdirectories Directories",
+                                        "description": "If enabled replicate source folder structure",
+                                        "title": "Preserve Subdirectories in File Paths",
                                         "type": "boolean",
                                     },
                                 },
@@ -535,13 +535,7 @@ single_csv_scenario: TestScenario[InMemoryFilesSource] = (
                                 "required": ["delivery_type"],
                             },
                         ],
-                    },
-                    "preserve_subdirectories_directories": {
-                        "default": True,
-                        "description": "Flag indicating we should preserve subdirectories directories",
-                        "title": "Preserve Subdirectories Directories",
-                        "type": "boolean",
-                    },
+                    }
                 },
                 "required": ["streams"],
             },

--- a/unit_tests/sources/file_based/scenarios/csv_scenarios.py
+++ b/unit_tests/sources/file_based/scenarios/csv_scenarios.py
@@ -517,25 +517,6 @@ single_csv_scenario: TestScenario[InMemoryFilesSource] = (
                                 "title": "Copy Raw Files",
                                 "type": "object",
                                 "properties": {
-                                    "delivery_options": {
-                                        "allOf": [
-                                            {
-                                                "properties": {
-                                                    "preserve_subdirectories_directories": {
-                                                        "default": True,
-                                                        "description": "Flag indicating we should preserve subdirectories directories",
-                                                        "title": "Preserve Subdirectories Directories",
-                                                        "type": "boolean",
-                                                    }
-                                                },
-                                                "title": "DeliveryOptions",
-                                                "type": "object",
-                                            }
-                                        ],
-                                        "order": 2,
-                                        "title": "Delivery Options",
-                                        "type": "object",
-                                    },
                                     "delivery_type": {
                                         "title": "Delivery Type",
                                         "default": "use_file_transfer",
@@ -543,30 +524,23 @@ single_csv_scenario: TestScenario[InMemoryFilesSource] = (
                                         "enum": ["use_file_transfer"],
                                         "type": "string",
                                     },
+                                    "preserve_subdirectories_directories": {
+                                        "default": True,
+                                        "description": "Flag indicating we should preserve subdirectories directories",
+                                        "title": "Preserve Subdirectories Directories",
+                                        "type": "boolean",
+                                    },
                                 },
                                 "description": "Copy raw files without parsing their contents. Bits are copied into the destination exactly as they appeared in the source. Recommended for use with unstructured text data, non-text and compressed files.",
                                 "required": ["delivery_type"],
                             },
                         ],
                     },
-                    "delivery_options": {
-                        "allOf": [
-                            {
-                                "properties": {
-                                    "preserve_subdirectories_directories": {
-                                        "default": True,
-                                        "description": "Flag indicating we should preserve subdirectories directories",
-                                        "title": "Preserve Subdirectories Directories",
-                                        "type": "boolean",
-                                    }
-                                },
-                                "title": "DeliveryOptions",
-                                "type": "object",
-                            }
-                        ],
-                        "order": 8,
-                        "title": "Delivery Options",
-                        "type": "object",
+                    "preserve_subdirectories_directories": {
+                        "default": True,
+                        "description": "Flag indicating we should preserve subdirectories directories",
+                        "title": "Preserve Subdirectories Directories",
+                        "type": "boolean",
                     },
                 },
                 "required": ["streams"],

--- a/unit_tests/sources/file_based/scenarios/csv_scenarios.py
+++ b/unit_tests/sources/file_based/scenarios/csv_scenarios.py
@@ -517,18 +517,56 @@ single_csv_scenario: TestScenario[InMemoryFilesSource] = (
                                 "title": "Copy Raw Files",
                                 "type": "object",
                                 "properties": {
+                                    "delivery_options": {
+                                        "allOf": [
+                                            {
+                                                "properties": {
+                                                    "preserve_subdirectories_directories": {
+                                                        "default": True,
+                                                        "description": "Flag indicating we should preserve subdirectories directories",
+                                                        "title": "Preserve Subdirectories Directories",
+                                                        "type": "boolean",
+                                                    }
+                                                },
+                                                "title": "DeliveryOptions",
+                                                "type": "object",
+                                            }
+                                        ],
+                                        "order": 2,
+                                        "title": "Delivery Options",
+                                        "type": "object",
+                                    },
                                     "delivery_type": {
                                         "title": "Delivery Type",
                                         "default": "use_file_transfer",
                                         "const": "use_file_transfer",
                                         "enum": ["use_file_transfer"],
                                         "type": "string",
-                                    }
+                                    },
                                 },
                                 "description": "Copy raw files without parsing their contents. Bits are copied into the destination exactly as they appeared in the source. Recommended for use with unstructured text data, non-text and compressed files.",
                                 "required": ["delivery_type"],
                             },
                         ],
+                    },
+                    "delivery_options": {
+                        "allOf": [
+                            {
+                                "properties": {
+                                    "preserve_subdirectories_directories": {
+                                        "default": True,
+                                        "description": "Flag indicating we should preserve subdirectories directories",
+                                        "title": "Preserve Subdirectories Directories",
+                                        "type": "boolean",
+                                    }
+                                },
+                                "title": "DeliveryOptions",
+                                "type": "object",
+                            }
+                        ],
+                        "order": 8,
+                        "title": "Delivery Options",
+                        "type": "object",
                     },
                 },
                 "required": ["streams"],

--- a/unit_tests/sources/file_based/scenarios/csv_scenarios.py
+++ b/unit_tests/sources/file_based/scenarios/csv_scenarios.py
@@ -526,7 +526,7 @@ single_csv_scenario: TestScenario[InMemoryFilesSource] = (
                                     },
                                     "preserve_subdirectories_directories": {
                                         "default": True,
-                                        "description": "If enabled replicate source folder structure",
+                                        "description": "If enabled, sends subdirectory folder structure along with source file names to the destination. Otherwise, files will be synced by their names only. This option is ignored when file-based replication is not enabled.",
                                         "title": "Preserve Sub-Directories in File Paths",
                                         "type": "boolean",
                                     },

--- a/unit_tests/sources/file_based/scenarios/csv_scenarios.py
+++ b/unit_tests/sources/file_based/scenarios/csv_scenarios.py
@@ -535,7 +535,7 @@ single_csv_scenario: TestScenario[InMemoryFilesSource] = (
                                 "required": ["delivery_type"],
                             },
                         ],
-                    }
+                    },
                 },
                 "required": ["streams"],
             },

--- a/unit_tests/sources/file_based/stream/test_default_file_based_stream.py
+++ b/unit_tests/sources/file_based/stream/test_default_file_based_stream.py
@@ -19,9 +19,9 @@ from airbyte_cdk.sources.file_based.availability_strategy import (
 )
 from airbyte_cdk.sources.file_based.discovery_policy import AbstractDiscoveryPolicy
 from airbyte_cdk.sources.file_based.exceptions import (
+    DuplicatedFilesError,
     FileBasedErrorsCollector,
     FileBasedSourceError,
-    DuplicatedFilesError,
 )
 from airbyte_cdk.sources.file_based.file_based_stream_reader import AbstractFileBasedStreamReader
 from airbyte_cdk.sources.file_based.file_types import FileTransfer

--- a/unit_tests/sources/file_based/stream/test_default_file_based_stream.py
+++ b/unit_tests/sources/file_based/stream/test_default_file_based_stream.py
@@ -318,7 +318,7 @@ class DefaultFileBasedStreamFileTransferTest(unittest.TestCase):
             cursor=self._cursor,
             errors_collector=FileBasedErrorsCollector(),
             use_file_transfer=True,
-            preserve_subdirectories_directories=False,
+            preserve_directory_structure=False,
         )
 
     def test_when_read_records_from_slice_then_return_records(self) -> None:
@@ -394,7 +394,7 @@ class DefaultFileBasedStreamFileTransferTestNotMirroringDirectories(unittest.Tes
             cursor=self._cursor,
             errors_collector=FileBasedErrorsCollector(),
             use_file_transfer=True,
-            preserve_subdirectories_directories=False,
+            preserve_directory_structure=False,
         )
 
         self._all_files = [

--- a/unit_tests/sources/file_based/stream/test_default_file_based_stream.py
+++ b/unit_tests/sources/file_based/stream/test_default_file_based_stream.py
@@ -4,6 +4,7 @@
 
 import traceback
 import unittest
+from copy import deepcopy
 from datetime import datetime, timezone
 from typing import Any, Iterable, Iterator, Mapping
 from unittest import mock
@@ -17,7 +18,11 @@ from airbyte_cdk.sources.file_based.availability_strategy import (
     AbstractFileBasedAvailabilityStrategy,
 )
 from airbyte_cdk.sources.file_based.discovery_policy import AbstractDiscoveryPolicy
-from airbyte_cdk.sources.file_based.exceptions import FileBasedErrorsCollector, FileBasedSourceError
+from airbyte_cdk.sources.file_based.exceptions import (
+    FileBasedErrorsCollector,
+    FileBasedSourceError,
+    DuplicatedFilesError,
+)
 from airbyte_cdk.sources.file_based.file_based_stream_reader import AbstractFileBasedStreamReader
 from airbyte_cdk.sources.file_based.file_types import FileTransfer
 from airbyte_cdk.sources.file_based.file_types.file_type_parser import FileTypeParser
@@ -302,6 +307,20 @@ class DefaultFileBasedStreamFileTransferTest(unittest.TestCase):
             use_file_transfer=True,
         )
 
+        self._stream_not_mirroring = DefaultFileBasedStream(
+            config=self._stream_config,
+            catalog_schema=self._catalog_schema,
+            stream_reader=self._stream_reader,
+            availability_strategy=self._availability_strategy,
+            discovery_policy=self._discovery_policy,
+            parsers={MockFormat: self._parser},
+            validation_policy=self._validation_policy,
+            cursor=self._cursor,
+            errors_collector=FileBasedErrorsCollector(),
+            use_file_transfer=True,
+            preserve_subdirectories_directories=False,
+        )
+
     def test_when_read_records_from_slice_then_return_records(self) -> None:
         """Verify that we have the new file method and data is empty"""
         with mock.patch.object(FileTransfer, "get_file", return_value=[self._A_RECORD]):
@@ -319,3 +338,132 @@ class DefaultFileBasedStreamFileTransferTest(unittest.TestCase):
         transformed_record = self._stream.transform_record_for_file_transfer(self._A_RECORD, file)
         assert transformed_record[self._stream.modified] == last_updated
         assert transformed_record[self._stream.source_file_url] == file.uri
+
+    def test_when_compute_slices(self) -> None:
+        all_files = [
+            RemoteFile(
+                uri="mirror_paths_testing/not_duplicates/data/jan/monthly-kickoff-202402.mpeg",
+                last_modified=datetime(2025, 1, 9, 11, 27, 20),
+                mime_type=None,
+            ),
+            RemoteFile(
+                uri="mirror_paths_testing/not_duplicates/data/feb/monthly-kickoff-202401.mpeg",
+                last_modified=datetime(2025, 1, 9, 11, 27, 20),
+                mime_type=None,
+            ),
+            RemoteFile(
+                uri="mirror_paths_testing/not_duplicates/data/mar/monthly-kickoff-202403.mpeg",
+                last_modified=datetime(2025, 1, 9, 11, 27, 20),
+                mime_type=None,
+            ),
+        ]
+        with (
+            mock.patch.object(DefaultFileBasedStream, "list_files", return_value=all_files),
+            mock.patch.object(self._stream._cursor, "get_files_to_sync", return_value=all_files),
+        ):
+            returned_slices = self._stream.compute_slices()
+        assert returned_slices == [
+            {"files": sorted(all_files, key=lambda f: (f.last_modified, f.uri))}
+        ]
+
+
+class DefaultFileBasedStreamFileTransferTestNotMirroringDirectories(unittest.TestCase):
+    _NOW = datetime(2022, 10, 22, tzinfo=timezone.utc)
+
+    def setUp(self) -> None:
+        self._stream_config = Mock()
+        self._stream_config.format = MockFormat()
+        self._stream_config.name = "a stream name"
+        self._catalog_schema = Mock()
+        self._stream_reader = Mock(spec=AbstractFileBasedStreamReader)
+        self._availability_strategy = Mock(spec=AbstractFileBasedAvailabilityStrategy)
+        self._discovery_policy = Mock(spec=AbstractDiscoveryPolicy)
+        self._parser = Mock(spec=FileTypeParser)
+        self._validation_policy = Mock(spec=AbstractSchemaValidationPolicy)
+        self._validation_policy.name = "validation policy name"
+        self._cursor = Mock(spec=AbstractFileBasedCursor)
+
+        self._stream = DefaultFileBasedStream(
+            config=self._stream_config,
+            catalog_schema=self._catalog_schema,
+            stream_reader=self._stream_reader,
+            availability_strategy=self._availability_strategy,
+            discovery_policy=self._discovery_policy,
+            parsers={MockFormat: self._parser},
+            validation_policy=self._validation_policy,
+            cursor=self._cursor,
+            errors_collector=FileBasedErrorsCollector(),
+            use_file_transfer=True,
+            preserve_subdirectories_directories=False,
+        )
+
+        self._all_files = [
+            RemoteFile(
+                uri="mirror_paths_testing/not_duplicates/data/jan/monthly-kickoff-202402.mpeg",
+                last_modified=datetime(2025, 1, 9, 11, 27, 20),
+                mime_type=None,
+            ),
+            RemoteFile(
+                uri="mirror_paths_testing/not_duplicates/data/feb/monthly-kickoff-202401.mpeg",
+                last_modified=datetime(2025, 1, 9, 11, 27, 20),
+                mime_type=None,
+            ),
+            RemoteFile(
+                uri="mirror_paths_testing/not_duplicates/data/mar/monthly-kickoff-202403.mpeg",
+                last_modified=datetime(2025, 1, 9, 11, 27, 20),
+                mime_type=None,
+            ),
+        ]
+
+    def test_when_compute_slices_with_not_duplicates(self) -> None:
+        with (
+            mock.patch.object(DefaultFileBasedStream, "list_files", return_value=self._all_files),
+            mock.patch.object(
+                self._stream._cursor, "get_files_to_sync", return_value=self._all_files
+            ),
+        ):
+            returned_slices = self._stream.compute_slices()
+        assert returned_slices == [
+            {"files": sorted(self._all_files, key=lambda f: (f.last_modified, f.uri))}
+        ]
+
+    def test_when_compute_slices_with_duplicates(self) -> None:
+        all_files = deepcopy(self._all_files)
+        all_files.append(
+            RemoteFile(
+                uri="mirror_paths_testing/not_duplicates/data/apr/monthly-kickoff-202402.mpeg",
+                last_modified=datetime(2025, 1, 9, 11, 27, 20),
+                mime_type=None,
+            )
+        )
+        all_files.append(
+            RemoteFile(
+                uri="mirror_paths_testing/not_duplicates/data/may/monthly-kickoff-202401.mpeg",
+                last_modified=datetime(2025, 1, 9, 11, 27, 20),
+                mime_type=None,
+            )
+        )
+        all_files.append(
+            RemoteFile(
+                uri="mirror_paths_testing/not_duplicates/data/jun/monthly-kickoff-202403.mpeg",
+                last_modified=datetime(2025, 1, 9, 11, 27, 20),
+                mime_type=None,
+            )
+        )
+        all_files.append(
+            RemoteFile(
+                uri="mirror_paths_testing/not_duplicates/data/jul/monthly-kickoff-202403.mpeg",
+                last_modified=datetime(2025, 1, 9, 11, 27, 20),
+                mime_type=None,
+            )
+        )
+        with (
+            mock.patch.object(DefaultFileBasedStream, "list_files", return_value=all_files),
+            mock.patch.object(self._stream._cursor, "get_files_to_sync", return_value=all_files),
+        ):
+            with pytest.raises(DuplicatedFilesError) as exc_info:
+                self._stream.compute_slices()
+        assert "Duplicate filenames found for stream" in str(exc_info.value)
+        assert "2 duplicates found for file name monthly-kickoff-202402.mpeg" in str(exc_info.value)
+        assert "2 duplicates found for file name monthly-kickoff-202401.mpeg" in str(exc_info.value)
+        assert "3 duplicates found for file name monthly-kickoff-202403.mpeg" in str(exc_info.value)

--- a/unit_tests/sources/file_based/test_file_based_stream_reader.py
+++ b/unit_tests/sources/file_based/test_file_based_stream_reader.py
@@ -3,6 +3,7 @@
 #
 
 import logging
+from datetime import datetime
 from io import IOBase
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Set
 
@@ -365,3 +366,75 @@ def test_globs_and_prefixes_from_globs(
         == expected_matches
     )
     assert set(reader.get_prefixes_from_globs(globs)) == expected_path_prefixes
+
+
+@pytest.mark.parametrize(
+    "config, source_file, expected_file_relative_path, expected_local_file_path, expected_absolute_file_path",
+    [
+        pytest.param(
+            {
+                "streams": [],
+                "delivery_method": {
+                    "delivery_type": "use_file_transfer",
+                    "preserve_subdirectories_directories": True,
+                },
+            },
+            "mirror_paths_testing/not_duplicates/data/jan/monthly-kickoff-202402.mpeg",
+            "mirror_paths_testing/not_duplicates/data/jan/monthly-kickoff-202402.mpeg",
+            "/tmp/transfer-files/mirror_paths_testing/not_duplicates/data/jan/monthly-kickoff-202402.mpeg",
+            "/tmp/transfer-files/mirror_paths_testing/not_duplicates/data/jan/monthly-kickoff-202402.mpeg",
+            id="preserve_directories_present_and_true",
+        ),
+        pytest.param(
+            {
+                "streams": [],
+                "delivery_method": {
+                    "delivery_type": "use_file_transfer",
+                    "preserve_subdirectories_directories": False,
+                },
+            },
+            "mirror_paths_testing/not_duplicates/data/jan/monthly-kickoff-202402.mpeg",
+            "monthly-kickoff-202402.mpeg",
+            "/tmp/transfer-files/monthly-kickoff-202402.mpeg",
+            "/tmp/transfer-files/monthly-kickoff-202402.mpeg",
+            id="preserve_directories_present_and_false",
+        ),
+        pytest.param(
+            {"streams": [], "delivery_method": {"delivery_type": "use_file_transfer"}},
+            "mirror_paths_testing/not_duplicates/data/jan/monthly-kickoff-202402.mpeg",
+            "mirror_paths_testing/not_duplicates/data/jan/monthly-kickoff-202402.mpeg",
+            "/tmp/transfer-files/mirror_paths_testing/not_duplicates/data/jan/monthly-kickoff-202402.mpeg",
+            "/tmp/transfer-files/mirror_paths_testing/not_duplicates/data/jan/monthly-kickoff-202402.mpeg",
+            id="preserve_directories_not_present_defaults_true",
+        ),
+        pytest.param(
+            {"streams": []},
+            "mirror_paths_testing/not_duplicates/data/jan/monthly-kickoff-202402.mpeg",
+            "mirror_paths_testing/not_duplicates/data/jan/monthly-kickoff-202402.mpeg",
+            "/tmp/transfer-files/mirror_paths_testing/not_duplicates/data/jan/monthly-kickoff-202402.mpeg",
+            "/tmp/transfer-files/mirror_paths_testing/not_duplicates/data/jan/monthly-kickoff-202402.mpeg",
+            id="file_transfer_flag_not_present_defaults_true",
+        ),
+    ],
+)
+def test_preserve_sub_directories_scenarios(
+    config: Mapping[str, Any],
+    source_file: str,
+    expected_file_relative_path: str,
+    expected_local_file_path: str,
+    expected_absolute_file_path: str,
+) -> None:
+    remote_file = RemoteFile(
+        uri=source_file,
+        last_modified=datetime(2025, 1, 9, 11, 27, 20),
+        mime_type=None,
+    )
+    reader = TestStreamReader()
+    reader.config = TestSpec(**config)
+    file_relative_path, local_file_path, absolute_file_path = reader._get_file_transfer_paths(
+        remote_file, "/tmp/transfer-files/"
+    )
+
+    assert file_relative_path == expected_file_relative_path
+    assert local_file_path == expected_local_file_path
+    assert absolute_file_path == expected_absolute_file_path

--- a/unit_tests/sources/file_based/test_file_based_stream_reader.py
+++ b/unit_tests/sources/file_based/test_file_based_stream_reader.py
@@ -376,7 +376,7 @@ def test_globs_and_prefixes_from_globs(
                 "streams": [],
                 "delivery_method": {
                     "delivery_type": "use_file_transfer",
-                    "preserve_subdirectories_directories": True,
+                    "preserve_directory_structure": True,
                 },
             },
             "mirror_paths_testing/not_duplicates/data/jan/monthly-kickoff-202402.mpeg",
@@ -390,7 +390,7 @@ def test_globs_and_prefixes_from_globs(
                 "streams": [],
                 "delivery_method": {
                     "delivery_type": "use_file_transfer",
-                    "preserve_subdirectories_directories": False,
+                    "preserve_directory_structure": False,
                 },
             },
             "mirror_paths_testing/not_duplicates/data/jan/monthly-kickoff-202402.mpeg",


### PR DESCRIPTION
## WHAT

The Source config receives a new option: Preserve Sub-Directories in File Paths. By default this is enabled (the current behavior).
- The new option should only appear when "Copy Raw Files" sync mode is enabled.
When enabled, the sync will:
- Validate uniqueness. During at the start of each read operation, the source will check all files that exist and are defined in the stream. This will be performed once per stream. If any files exist with the same file name, the operation will fail.
- Sync without intermediate subdirectory information. During sync, the source will send relative filenames which exclude any path info between the extract root and the filename. To the destination, each file will appear to exist at the root of the extract location.

[Here is a loom](https://www.loom.com/share/82022510826b433396b6f13b8382467e) explaining functionality.

If Copy Raw files is selected (the default is True but image show when is turned off):

<img width="643" alt="image" src="https://github.com/user-attachments/assets/f252c35c-889f-4612-b1de-3407bd0faa19" />

If replicate records is selected:

<img width="713" alt="image" src="https://github.com/user-attachments/assets/34844f64-b0fc-425a-9719-df3633539e1f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Added configuration options for preserving subdirectories during file transfers.
	- Introduced error handling for duplicate files in file-based sources.

- **Improvements**
	- Enhanced clarity in error messages related to duplicate files.
	- Expanded configuration flexibility for file-based source sync processes.
	- Improved handling of file path logic based on subdirectory preservation settings in tests.
	- Enhanced management of NLTK data by specifying a directory for downloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->