### PR TITLE
feat(low-code): added flatten_lists option to FlattenFields transformation

### DIFF
--- a/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -1880,6 +1880,11 @@ definitions:
       type:
         type: string
         enum: [FlattenFields]
+      flatten_lists:
+        title: Flatten Lists
+        description: Whether to flatten lists or leave it as is. Default is True.
+        type: boolean
+        default: true
       $parameters:
         type: object
         additionalProperties: true

--- a/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
+++ b/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
@@ -723,6 +723,11 @@ class KeysToSnakeCase(BaseModel):
 
 class FlattenFields(BaseModel):
     type: Literal["FlattenFields"]
+    flatten_lists: Optional[bool] = Field(
+        True,
+        description="Whether to flatten lists or leave it as is. Default is True.",
+        title="Flatten Lists",
+    )
     parameters: Optional[Dict[str, Any]] = Field(None, alias="$parameters")
 
 

--- a/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -633,7 +633,9 @@ class ModelToComponentFactory:
     def create_flatten_fields(
         self, model: FlattenFieldsModel, config: Config, **kwargs: Any
     ) -> FlattenFields:
-        return FlattenFields(flatten_lists=model.flatten_lists if model.flatten_lists is not None else True)
+        return FlattenFields(
+            flatten_lists=model.flatten_lists if model.flatten_lists is not None else True
+        )
 
     @staticmethod
     def _json_schema_type_name_to_type(value_type: Optional[ValueType]) -> Optional[Type[Any]]:

--- a/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -633,7 +633,7 @@ class ModelToComponentFactory:
     def create_flatten_fields(
         self, model: FlattenFieldsModel, config: Config, **kwargs: Any
     ) -> FlattenFields:
-        return FlattenFields()
+        return FlattenFields(flatten_lists=model.flatten_lists)
 
     @staticmethod
     def _json_schema_type_name_to_type(value_type: Optional[ValueType]) -> Optional[Type[Any]]:

--- a/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -633,7 +633,7 @@ class ModelToComponentFactory:
     def create_flatten_fields(
         self, model: FlattenFieldsModel, config: Config, **kwargs: Any
     ) -> FlattenFields:
-        return FlattenFields(flatten_lists=model.flatten_lists)
+        return FlattenFields(flatten_lists=model.flatten_lists if model.flatten_lists is not None else True)
 
     @staticmethod
     def _json_schema_type_name_to_type(value_type: Optional[ValueType]) -> Optional[Type[Any]]:

--- a/airbyte_cdk/sources/declarative/transformations/flatten_fields.py
+++ b/airbyte_cdk/sources/declarative/transformations/flatten_fields.py
@@ -11,6 +11,8 @@ from airbyte_cdk.sources.types import Config, StreamSlice, StreamState
 
 @dataclass
 class FlattenFields(RecordTransformation):
+    flatten_lists: bool = True
+
     def transform(
         self,
         record: Dict[str, Any],
@@ -39,7 +41,7 @@ class FlattenFields(RecordTransformation):
                     )
                     stack.append((value, new_key))
 
-            elif isinstance(current_record, list):
+            elif isinstance(current_record, list) and self.flatten_lists:
                 for i, item in enumerate(current_record):
                     force_with_parent_name = True
                     stack.append((item, f"{parent_key}.{i}"))

--- a/unit_tests/sources/declarative/transformations/test_flatten_fields.py
+++ b/unit_tests/sources/declarative/transformations/test_flatten_fields.py
@@ -8,14 +8,27 @@ from airbyte_cdk.sources.declarative.transformations.flatten_fields import (
     FlattenFields,
 )
 
+_FLATTEN_LISTS = True
+_DO_NOT_FLATTEN_LISTS = False
+
 
 @pytest.mark.parametrize(
     "flatten_lists, input_record, expected_output",
     [
-        (True, {"FirstName": "John", "LastName": "Doe"}, {"FirstName": "John", "LastName": "Doe"}),
-        (True, {"123Number": 123, "456Another123": 456}, {"123Number": 123, "456Another123": 456}),
-        (
-            True,
+        pytest.param(
+            _FLATTEN_LISTS,
+            {"FirstName": "John", "LastName": "Doe"},
+            {"FirstName": "John", "LastName": "Doe"},
+            id="flatten simple record with string values",
+        ),
+        pytest.param(
+            _FLATTEN_LISTS,
+            {"123Number": 123, "456Another123": 456},
+            {"123Number": 123, "456Another123": 456},
+            id="flatten simple record with int values",
+        ),
+        pytest.param(
+            _FLATTEN_LISTS,
             {
                 "NestedRecord": {"FirstName": "John", "LastName": "Doe"},
                 "456Another123": 456,
@@ -25,14 +38,16 @@ from airbyte_cdk.sources.declarative.transformations.flatten_fields import (
                 "LastName": "Doe",
                 "456Another123": 456,
             },
+            id="flatten record with nested dict",
         ),
-        (
-            True,
+        pytest.param(
+            _FLATTEN_LISTS,
             {"ListExample": [{"A": "a"}, {"A": "b"}]},
             {"ListExample.0.A": "a", "ListExample.1.A": "b"},
+            id="flatten record with list values of dict items",
         ),
-        (
-            True,
+        pytest.param(
+            _FLATTEN_LISTS,
             {
                 "MixedCase123": {
                     "Nested": [{"Key": {"Value": "test1"}}, {"Key": {"Value": "test2"}}]
@@ -44,19 +59,22 @@ from airbyte_cdk.sources.declarative.transformations.flatten_fields import (
                 "Nested.1.Key.Value": "test2",
                 "SimpleKey": "SimpleValue",
             },
+            id="flatten record with nested dict of both list and string values",
         ),
-        (
-            True,
+        pytest.param(
+            _FLATTEN_LISTS,
             {"List": ["Item1", "Item2", "Item3"]},
             {"List.0": "Item1", "List.1": "Item2", "List.2": "Item3"},
+            id="flatten record with list of str values",
         ),
-        (
-            False,
+        pytest.param(
+            _DO_NOT_FLATTEN_LISTS,
             {"List": ["Item1", "Item2", "Item3"]},
             {"List": ["Item1", "Item2", "Item3"]},
+            id="flatten record with dict of list values, flatten_lists=False",
         ),
-        (
-            False,
+        pytest.param(
+            _DO_NOT_FLATTEN_LISTS,
             {
                 "RootField": {
                     "NestedList": [{"Key": {"Value": "test1"}}, {"Key": {"Value": "test2"}}]
@@ -67,9 +85,10 @@ from airbyte_cdk.sources.declarative.transformations.flatten_fields import (
                 "NestedList": [{"Key": {"Value": "test1"}}, {"Key": {"Value": "test2"}}],
                 "SimpleKey": "SimpleValue",
             },
+            id="flatten record with dict of list values and simple key, flatten_lists=False",
         ),
-        (
-            False,
+        pytest.param(
+            _DO_NOT_FLATTEN_LISTS,
             {
                 "RootField": {"List": [{"Key": {"Value": "test1"}}, {"Key": {"Value": "test2"}}]},
                 "List": [1, 3, 6],
@@ -80,6 +99,7 @@ from airbyte_cdk.sources.declarative.transformations.flatten_fields import (
                 "List": [1, 3, 6],
                 "SimpleKey": "SimpleValue",
             },
+            id="flatten record with dict of list values and simple key with duplicated keys, flatten_lists=False",
         ),
     ],
 )

--- a/unit_tests/sources/declarative/transformations/test_flatten_fields.py
+++ b/unit_tests/sources/declarative/transformations/test_flatten_fields.py
@@ -10,11 +10,12 @@ from airbyte_cdk.sources.declarative.transformations.flatten_fields import (
 
 
 @pytest.mark.parametrize(
-    "input_record, expected_output",
+    "flatten_lists, input_record, expected_output",
     [
-        ({"FirstName": "John", "LastName": "Doe"}, {"FirstName": "John", "LastName": "Doe"}),
-        ({"123Number": 123, "456Another123": 456}, {"123Number": 123, "456Another123": 456}),
+        (True, {"FirstName": "John", "LastName": "Doe"}, {"FirstName": "John", "LastName": "Doe"}),
+        (True, {"123Number": 123, "456Another123": 456}, {"123Number": 123, "456Another123": 456}),
         (
+            True,
             {
                 "NestedRecord": {"FirstName": "John", "LastName": "Doe"},
                 "456Another123": 456,
@@ -26,10 +27,12 @@ from airbyte_cdk.sources.declarative.transformations.flatten_fields import (
             },
         ),
         (
+            True,
             {"ListExample": [{"A": "a"}, {"A": "b"}]},
             {"ListExample.0.A": "a", "ListExample.1.A": "b"},
         ),
         (
+            True,
             {
                 "MixedCase123": {
                     "Nested": [{"Key": {"Value": "test1"}}, {"Key": {"Value": "test2"}}]
@@ -43,12 +46,44 @@ from airbyte_cdk.sources.declarative.transformations.flatten_fields import (
             },
         ),
         (
+            True,
             {"List": ["Item1", "Item2", "Item3"]},
             {"List.0": "Item1", "List.1": "Item2", "List.2": "Item3"},
         ),
+        (
+            False,
+            {"List": ["Item1", "Item2", "Item3"]},
+            {"List": ["Item1", "Item2", "Item3"]},
+        ),
+        (
+            False,
+            {
+                "RootField": {
+                    "NestedList": [{"Key": {"Value": "test1"}}, {"Key": {"Value": "test2"}}]
+                },
+                "SimpleKey": "SimpleValue",
+            },
+            {
+                "NestedList": [{"Key": {"Value": "test1"}}, {"Key": {"Value": "test2"}}],
+                "SimpleKey": "SimpleValue",
+            },
+        ),
+        (
+            False,
+            {
+                "RootField": {"List": [{"Key": {"Value": "test1"}}, {"Key": {"Value": "test2"}}]},
+                "List": [1, 3, 6],
+                "SimpleKey": "SimpleValue",
+            },
+            {
+                "RootField.List": [{"Key": {"Value": "test1"}}, {"Key": {"Value": "test2"}}],
+                "List": [1, 3, 6],
+                "SimpleKey": "SimpleValue",
+            },
+        ),
     ],
 )
-def test_flatten_fields(input_record, expected_output):
-    flattener = FlattenFields()
+def test_flatten_fields(flatten_lists, input_record, expected_output):
+    flattener = FlattenFields(flatten_lists=flatten_lists)
     flattener.transform(input_record)
     assert input_record == expected_output


### PR DESCRIPTION
#### Problem
`FlattenFields` transformation updates array fields by default
 from `{"array": [1, 2, 3]}` 
  to `{"array.1": 1, "array.2": 2, "array.3": 3}`
  (for more examples see `unit_tests/sources/declarative/transformations/test_flatten_fields.py`)
  
  Some connectors (e.g `airtable`) don't need such transformation of arrays, we just need to keep it as is.
  
  #### Solution
  Added `flatten_lists` to `FlattenFields`(default is True) to be able to set up needed behavior of the transformation. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced an optional `flatten_lists` configuration to control list flattening behavior during data transformations.
	- Default behavior remains unchanged (lists will be flattened).
	- Users can now choose to preserve original list structures if needed.

- **Tests**
	- Enhanced test cases to verify the new `flatten_lists` configuration option, including scenarios for both `True` and `False` settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->