### PR TITLE
ci: use binary of airbyte-ci instead of dev version that requires python10

### DIFF
--- a/.github/workflows/connector-tests.yml
+++ b/.github/workflows/connector-tests.yml
@@ -132,7 +132,7 @@ jobs:
         run: |
           cd airbyte
           make tools.airbyte-ci-binary.install
-          airbyte-ci-dev \
+          airbyte-ci \
           --ci-report-bucket-name=airbyte-ci-reports-multi \
           connectors \
           --name ${{matrix.connector}} \

--- a/.github/workflows/connector-tests.yml
+++ b/.github/workflows/connector-tests.yml
@@ -129,10 +129,9 @@ jobs:
         env:
           GCP_GSM_CREDENTIALS: ${{ secrets.GCP_GSM_CREDENTIALS }}
           POETRY_DYNAMIC_VERSIONING_BYPASS: "0.0.0"
-        # TODO: Revert below to use `tools.airbyte-ci-binary.install` after Airbyte CI released:
         run: |
           cd airbyte
-          make tools.airbyte-ci-dev.install
+          make tools.airbyte-ci-binary.install
           airbyte-ci-dev \
           --ci-report-bucket-name=airbyte-ci-reports-multi \
           connectors \

--- a/airbyte_cdk/logger.py
+++ b/airbyte_cdk/logger.py
@@ -80,7 +80,6 @@ class AirbyteLogFormatter(logging.Formatter):
             )
             return orjson.dumps(AirbyteMessageSerializer.dump(log_message)).decode()
 
-
     @staticmethod
     def extract_extra_args_from_record(record: logging.LogRecord) -> Mapping[str, Any]:
         """

--- a/airbyte_cdk/logger.py
+++ b/airbyte_cdk/logger.py
@@ -80,6 +80,7 @@ class AirbyteLogFormatter(logging.Formatter):
             )
             return orjson.dumps(AirbyteMessageSerializer.dump(log_message)).decode()
 
+
     @staticmethod
     def extract_extra_args_from_record(record: logging.LogRecord) -> Mapping[str, Any]:
         """


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated GitHub Actions workflow configuration for Airbyte CI tools installation
  - Modified command for installing CI tools from development to binary method
AirbyteLogFormatter class
<!-- end of auto-generated comment: release notes by coderabbit.ai -->