### PR TITLE
fix: fallback to `json` if `orjson` cannot serialize value

### DIFF
--- a/airbyte_cdk/entrypoint.py
+++ b/airbyte_cdk/entrypoint.py
@@ -5,6 +5,7 @@
 import argparse
 import importlib
 import ipaddress
+import json
 import logging
 import os.path
 import socket
@@ -291,7 +292,10 @@ class AirbyteEntrypoint(object):
 
     @staticmethod
     def airbyte_message_to_string(airbyte_message: AirbyteMessage) -> str:
-        return orjson.dumps(AirbyteMessageSerializer.dump(airbyte_message)).decode()
+        try:
+            return orjson.dumps(AirbyteMessageSerializer.dump(airbyte_message)).decode()
+        except:
+            return json.dumps(AirbyteMessageSerializer.dump(airbyte_message))
 
     @classmethod
     def extract_state(cls, args: List[str]) -> Optional[Any]:

--- a/airbyte_cdk/entrypoint.py
+++ b/airbyte_cdk/entrypoint.py
@@ -292,10 +292,11 @@ class AirbyteEntrypoint(object):
 
     @staticmethod
     def airbyte_message_to_string(airbyte_message: AirbyteMessage) -> str:
+        serialized_message = AirbyteMessageSerializer.dump(airbyte_message)
         try:
-            return orjson.dumps(AirbyteMessageSerializer.dump(airbyte_message)).decode()
+            return orjson.dumps(serialized_message).decode()
         except:
-            return json.dumps(AirbyteMessageSerializer.dump(airbyte_message))
+            return json.dumps(serialized_message)
 
     @classmethod
     def extract_state(cls, args: List[str]) -> Optional[Any]:


### PR DESCRIPTION
# What

resolve https://github.com/airbytehq/oncall/issues/7226

too big ( >`int64`) values can not be serialized by orjson library: https://github.com/ijl/orjson/issues/116

# How 

fallback to `json` if `orjson` cannot serialize value