### PR TITLE
feat: `Async Retriever` add url_requester

### DIFF
--- a/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -2972,6 +2972,11 @@ definitions:
         anyOf:
           - "$ref": "#/definitions/CustomRequester"
           - "$ref": "#/definitions/HttpRequester"
+      url_requester:
+        description: Requester component that describes how to prepare HTTP requests to send to the source API to extract the url from polling response by the completed async job.
+        anyOf:
+          - "$ref": "#/definitions/CustomRequester"
+          - "$ref": "#/definitions/HttpRequester"
       download_requester:
         description: Requester component that describes how to prepare HTTP requests to send to the source API to download the data provided by the completed async job.
         anyOf:

--- a/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
+++ b/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
@@ -737,25 +737,35 @@ class KeysToSnakeCase(BaseModel):
     parameters: Optional[Dict[str, Any]] = Field(None, alias="$parameters")
 
 
+class FlattenFields(BaseModel):
+    type: Literal["FlattenFields"]
+    parameters: Optional[Dict[str, Any]] = Field(None, alias="$parameters")
+
+
 class KeysReplace(BaseModel):
     type: Literal["KeysReplace"]
     old: str = Field(
         ...,
         description="Old value to replace.",
-        examples=[" ", "{{ record.id }}", "{{ config['id'] }}", "{{ stream_slice['id'] }}"],
+        examples=[
+            " ",
+            "{{ record.id }}",
+            "{{ config['id'] }}",
+            "{{ stream_slice['id'] }}",
+        ],
         title="Old value",
     )
     new: str = Field(
         ...,
         description="New value to set.",
-        examples=["_", "{{ record.id }}", "{{ config['id'] }}", "{{ stream_slice['id'] }}"],
+        examples=[
+            "_",
+            "{{ record.id }}",
+            "{{ config['id'] }}",
+            "{{ stream_slice['id'] }}",
+        ],
         title="New value",
     )
-    parameters: Optional[Dict[str, Any]] = Field(None, alias="$parameters")
-
-
-class FlattenFields(BaseModel):
-    type: Literal["FlattenFields"]
     parameters: Optional[Dict[str, Any]] = Field(None, alias="$parameters")
 
 
@@ -2034,6 +2044,10 @@ class AsyncRetriever(BaseModel):
     polling_requester: Union[CustomRequester, HttpRequester] = Field(
         ...,
         description="Requester component that describes how to prepare HTTP requests to send to the source API to fetch the status of the running async job.",
+    )
+    url_requester: Optional[Union[CustomRequester, HttpRequester]] = Field(
+        None,
+        description="Requester component that describes how to prepare HTTP requests to send to the source API to extract the url from polling response by the completed async job.",
     )
     download_requester: Union[CustomRequester, HttpRequester] = Field(
         ...,

--- a/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
+++ b/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
@@ -739,6 +739,11 @@ class KeysToSnakeCase(BaseModel):
 
 class FlattenFields(BaseModel):
     type: Literal["FlattenFields"]
+    flatten_lists: Optional[bool] = Field(
+        True,
+        description="Whether to flatten lists or leave it as is. Default is True.",
+        title="Flatten Lists",
+    )
     parameters: Optional[Dict[str, Any]] = Field(None, alias="$parameters")
 
 

--- a/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -2322,6 +2322,16 @@ class ModelToComponentFactory:
             if model.delete_requester
             else None
         )
+        url_requester = (
+            self._create_component_from_model(
+                model=model.url_requester,
+                decoder=decoder,
+                config=config,
+                name=f"job extract_url - {name}",
+            )
+            if model.url_requester
+            else None
+        )
         status_extractor = self._create_component_from_model(
             model=model.status_extractor, decoder=decoder, config=config, name=name
         )
@@ -2332,6 +2342,7 @@ class ModelToComponentFactory:
             creation_requester=creation_requester,
             polling_requester=polling_requester,
             download_retriever=download_retriever,
+            url_requester=url_requester,
             abort_requester=abort_requester,
             delete_requester=delete_requester,
             status_extractor=status_extractor,

--- a/airbyte_cdk/sources/declarative/requesters/README.md
+++ b/airbyte_cdk/sources/declarative/requesters/README.md
@@ -1,0 +1,57 @@
+# AsyncHttpJobRepository sequence diagram
+
+- Components marked as optional are not required and can be ignored.
+- if `url_requester` is not provided, `urls_extractor` will get urls from the `polling_job_response`
+- interpolation_context, e.g. `create_job_response` or `polling_job_response` can be obtained from stream_slice
+ 
+
+```mermaid
+---
+title: AsyncHttpJobRepository Sequence Diagram
+---
+sequenceDiagram 
+    participant AsyncHttpJobRepository as AsyncOrchestrator
+    participant CreationRequester as creation_requester
+    participant PollingRequester as polling_requester
+    participant UrlRequester as url_requester (Optional)
+    participant DownloadRetriever as download_retriever
+    participant AbortRequester as abort_requester (Optional)
+    participant DeleteRequester as delete_requester (Optional)
+    participant Reporting Server as Async Reporting Server
+
+    AsyncHttpJobRepository ->> CreationRequester: Initiate job creation
+    CreationRequester ->> Reporting Server: Create job request
+    Reporting Server -->> CreationRequester: Job ID response
+    CreationRequester -->> AsyncHttpJobRepository: Job ID
+
+    loop Poll for job status
+        AsyncHttpJobRepository ->> PollingRequester: Check job status
+        PollingRequester ->> Reporting Server: Status request (interpolation_context: `create_job_response`)
+        Reporting Server -->> PollingRequester: Status response
+        PollingRequester -->> AsyncHttpJobRepository: Job status
+    end
+
+    alt Status: Ready
+        AsyncHttpJobRepository ->> UrlRequester: Request download URLs (if applicable)
+        UrlRequester ->> Reporting Server: URL request (interpolation_context: `polling_job_response`)
+        Reporting Server -->> UrlRequester: Download URLs
+        UrlRequester -->> AsyncHttpJobRepository: Download URLs
+
+        AsyncHttpJobRepository ->> DownloadRetriever: Download reports
+        DownloadRetriever ->> Reporting Server: Retrieve report data (interpolation_context: `url`)
+        Reporting Server -->> DownloadRetriever: Report data
+        DownloadRetriever -->> AsyncHttpJobRepository: Report data
+    else Status: Failed
+        AsyncHttpJobRepository ->> AbortRequester: Send abort request
+        AbortRequester ->> Reporting Server: Abort job
+        Reporting Server -->> AbortRequester: Abort confirmation
+        AbortRequester -->> AsyncHttpJobRepository: Confirmation
+    end
+
+    AsyncHttpJobRepository ->> DeleteRequester: Send delete job request
+    DeleteRequester ->> Reporting Server: Delete job
+    Reporting Server -->> DeleteRequester: Deletion confirmation
+    DeleteRequester -->> AsyncHttpJobRepository: Confirmation
+
+
+```

--- a/airbyte_cdk/sources/declarative/requesters/http_job_repository.py
+++ b/airbyte_cdk/sources/declarative/requesters/http_job_repository.py
@@ -243,5 +243,11 @@ class AsyncHttpJobRepository(AsyncJobRepository):
                 },
                 cursor_slice={},
             )
-            url_response = self.url_requester.send_request(stream_slice=stream_slice)
-        yield from self.urls_extractor.extract_records(url_response)
+            url_response = self.url_requester.send_request(stream_slice=stream_slice)  # type: ignore # we expect url_requester to always be presented, otherwise raise an exception as we cannot proceed with the report
+            if not url_response:
+                raise AirbyteTracedException(
+                    internal_message="Always expect a response or an exception from url_requester",
+                    failure_type=FailureType.system_error,
+                )
+
+        yield from self.urls_extractor.extract_records(url_response)  # type: ignore # we expect urls_extractor to always return list of strings

--- a/airbyte_cdk/sources/declarative/requesters/http_job_repository.py
+++ b/airbyte_cdk/sources/declarative/requesters/http_job_repository.py
@@ -238,7 +238,5 @@ class AsyncHttpJobRepository(AsyncJobRepository):
                 },
                 cursor_slice={},
             )
-            url_response = self.url_requester.send_request(
-                stream_slice=stream_slice
-            )
+            url_response = self.url_requester.send_request(stream_slice=stream_slice)
         yield from self.urls_extractor.extract_records(url_response)

--- a/airbyte_cdk/sources/declarative/requesters/http_job_repository.py
+++ b/airbyte_cdk/sources/declarative/requesters/http_job_repository.py
@@ -34,9 +34,6 @@ class AsyncHttpJobRepository(AsyncJobRepository):
     creation_requester: Requester
     polling_requester: Requester
     download_retriever: SimpleRetriever
-    url_requester: Optional[
-        Requester
-    ]  # use it in case polling_requester provides some <id> and extra request is needed to obtain list of urls to download from
     abort_requester: Optional[Requester]
     delete_requester: Optional[Requester]
     status_extractor: DpathExtractor
@@ -46,6 +43,9 @@ class AsyncHttpJobRepository(AsyncJobRepository):
     job_timeout: Optional[timedelta] = None
     record_extractor: RecordExtractor = field(
         init=False, repr=False, default_factory=lambda: ResponseToFileExtractor({})
+    )
+    url_requester: Optional[Requester] = (
+        None  # use it in case polling_requester provides some <id> and extra request is needed to obtain list of urls to download from
     )
 
     def __post_init__(self) -> None:

--- a/airbyte_cdk/sources/declarative/requesters/http_job_repository.py
+++ b/airbyte_cdk/sources/declarative/requesters/http_job_repository.py
@@ -31,6 +31,10 @@ LOGGER = logging.getLogger("airbyte")
 
 @dataclass
 class AsyncHttpJobRepository(AsyncJobRepository):
+    """
+    See Readme file for more details about flow.
+    """
+
     creation_requester: Requester
     polling_requester: Requester
     download_retriever: SimpleRetriever


### PR DESCRIPTION
# What

Resolving https://github.com/airbytehq/airbyte-internal-issues/issues/11144

# How

In amazon-seller-partner list of urls to download the report should be obtained from another url:
1. polling response after status -> `DONE`: 
```
{
        "reportType": report_name,
        "processingStatus": DONE,
        "reportId": _REPORT_ID,
        "reportDocumentId": report_document_id,
    }
```
2. another request to get_url is needed with `report_document_id` from step1, response:
```
response_body = {"reportDocumentId": report_document_id, "url": document_download_url}
```

possible solution:

add url_requester to AsyncRetriever 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced asynchronous job retrieval with optional URL requester functionality.
	- Added support for flattening nested data fields.

- **Improvements**
	- Updated example formatting for better readability.
	- Improved URL extraction during async job processing.
	- Added sequence diagram for better understanding of `AsyncHttpJobRepository` interactions. 

- **Technical Enhancements**
	- Extended `AsyncRetriever` capabilities.
	- Introduced more flexible URL handling in job repositories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->