### PR TITLE
Maxi297/fix simple retriever request headers

### DIFF
--- a/unit_tests/sources/declarative/retrievers/test_simple_retriever.py
+++ b/unit_tests/sources/declarative/retrievers/test_simple_retriever.py
@@ -491,8 +491,8 @@ def test_get_request_headers(test_name, paginator_mapping, expected_mapping):
     paginator.get_request_headers.return_value = paginator_mapping
     requester = MagicMock(use_cache=False)
 
-    stream_slicer = MagicMock()
-    stream_slicer.get_request_headers.return_value = {"key": "value"}
+    request_option_provider = MagicMock()
+    request_option_provider.get_request_headers.return_value = {"key": "value"}
 
     record_selector = MagicMock()
     retriever = SimpleRetriever(
@@ -500,7 +500,7 @@ def test_get_request_headers(test_name, paginator_mapping, expected_mapping):
         primary_key=primary_key,
         requester=requester,
         record_selector=record_selector,
-        stream_slicer=stream_slicer,
+        request_option_provider=request_option_provider,
         paginator=paginator,
         parameters={},
         config={},
@@ -555,7 +555,7 @@ def test_get_request_headers(test_name, paginator_mapping, expected_mapping):
         ),
     ],
 )
-def test_ignore_stream_slicer_parameters_on_paginated_requests(
+def test_ignore_request_option_provider_parameters_on_paginated_requests(
     test_name,
     paginator_mapping,
     ignore_stream_slicer_parameters_on_paginated_requests,
@@ -567,8 +567,8 @@ def test_ignore_stream_slicer_parameters_on_paginated_requests(
     paginator.get_request_headers.return_value = paginator_mapping
     requester = MagicMock(use_cache=False)
 
-    stream_slicer = MagicMock()
-    stream_slicer.get_request_headers.return_value = {"key_from_slicer": "value"}
+    request_option_provider = MagicMock()
+    request_option_provider.get_request_headers.return_value = {"key_from_slicer": "value"}
 
     record_selector = MagicMock()
     retriever = SimpleRetriever(
@@ -576,7 +576,7 @@ def test_ignore_stream_slicer_parameters_on_paginated_requests(
         primary_key=primary_key,
         requester=requester,
         record_selector=record_selector,
-        stream_slicer=stream_slicer,
+        request_option_provider=request_option_provider,
         paginator=paginator,
         ignore_stream_slicer_parameters_on_paginated_requests=ignore_stream_slicer_parameters_on_paginated_requests,
         parameters={},


### PR DESCRIPTION
## What

Fixing tests for SimpleRetriever following the change from using `self.stream_slicer.get_request_headers` to using `self.request_option_provider.get_request_headers`

## How

Just by swapping `stream_slicer` to `request_option_provider` when initializing the SimpleRetriever. This is a breaking change but the reason this is fine is because:
* Within the CDK, we only instantiate the SimpleRetriever in the model_to_component_factory
* Outside the CDK, we assume that we don't really expose this concept. So if I search for `SimpleRetriever` in the airbytehq/airbyte repository, I only find the following case:
    * source-linkedin-ads: Headers do not seem to be used
    * source-posthog: Headers do not seem to be used
        * Side note: Deprecating the RequestOptionsProvider as part of the StreamSlice interface will cause this to be breaking but until we remove `self.stream_slicer.get_request_params`, this should be backward compatible as the implementation is the same
    * source-salesforce: those retrievers are used within `AsyncRetriever` and do not really rely on stream_slicing
    * source-slack: the stream slicer is a `SinglePartitionRouter` which does not yield anything on `get_request_headers`
