### PR TITLE
fix: (DeclarativeOAuthFlow) - add the ability to override the `refresh_token_request_body` key names, updated `oauth_connector_input_specification` tooltips

### DIFF
--- a/airbyte_cdk/sources/declarative/auth/oauth.py
+++ b/airbyte_cdk/sources/declarative/auth/oauth.py
@@ -56,8 +56,12 @@ class DeclarativeOauth2Authenticator(AbstractOauth2Authenticator, DeclarativeAut
     token_expiry_is_time_of_expiration: bool = False
     access_token_name: Union[InterpolatedString, str] = "access_token"
     access_token_value: Optional[Union[InterpolatedString, str]] = None
+    client_id_name: Union[InterpolatedString, str] = "client_id"
+    client_secret_name: Union[InterpolatedString, str] = "client_secret"
     expires_in_name: Union[InterpolatedString, str] = "expires_in"
+    refresh_token_name: Union[InterpolatedString, str] = "refresh_token"
     refresh_request_body: Optional[Mapping[str, Any]] = None
+    grant_type_name: Union[InterpolatedString, str] = "grant_type"
     grant_type: Union[InterpolatedString, str] = "refresh_token"
     message_repository: MessageRepository = NoopMessageRepository()
 
@@ -69,8 +73,15 @@ class DeclarativeOauth2Authenticator(AbstractOauth2Authenticator, DeclarativeAut
             )
         else:
             self._token_refresh_endpoint = None
+        self._client_id_name = InterpolatedString.create(self.client_id_name, parameters=parameters)
         self._client_id = InterpolatedString.create(self.client_id, parameters=parameters)
+        self._client_secret_name = InterpolatedString.create(
+            self.client_secret_name, parameters=parameters
+        )
         self._client_secret = InterpolatedString.create(self.client_secret, parameters=parameters)
+        self._refresh_token_name = InterpolatedString.create(
+            self.refresh_token_name, parameters=parameters
+        )
         if self.refresh_token is not None:
             self._refresh_token: Optional[InterpolatedString] = InterpolatedString.create(
                 self.refresh_token, parameters=parameters
@@ -82,6 +93,9 @@ class DeclarativeOauth2Authenticator(AbstractOauth2Authenticator, DeclarativeAut
         )
         self.expires_in_name = InterpolatedString.create(
             self.expires_in_name, parameters=parameters
+        )
+        self.grant_type_name = InterpolatedString.create(
+            self.grant_type_name, parameters=parameters
         )
         self.grant_type = InterpolatedString.create(self.grant_type, parameters=parameters)
         self._refresh_request_body = InterpolatedMapping(
@@ -122,17 +136,26 @@ class DeclarativeOauth2Authenticator(AbstractOauth2Authenticator, DeclarativeAut
             return refresh_token_endpoint
         return None
 
+    def get_client_id_name(self) -> str:
+        return self._client_id_name.eval(self.config)  # type: ignore # eval returns a string in this context
+
     def get_client_id(self) -> str:
         client_id: str = self._client_id.eval(self.config)
         if not client_id:
             raise ValueError("OAuthAuthenticator was unable to evaluate client_id parameter")
         return client_id
 
+    def get_client_secret_name(self) -> str:
+        return self._client_secret_name.eval(self.config)  # type: ignore # eval returns a string in this context
+
     def get_client_secret(self) -> str:
         client_secret: str = self._client_secret.eval(self.config)
         if not client_secret:
             raise ValueError("OAuthAuthenticator was unable to evaluate client_secret parameter")
         return client_secret
+
+    def get_refresh_token_name(self) -> str:
+        return self._refresh_token_name.eval(self.config)  # type: ignore # eval returns a string in this context
 
     def get_refresh_token(self) -> Optional[str]:
         return None if self._refresh_token is None else str(self._refresh_token.eval(self.config))
@@ -145,6 +168,9 @@ class DeclarativeOauth2Authenticator(AbstractOauth2Authenticator, DeclarativeAut
 
     def get_expires_in_name(self) -> str:
         return self.expires_in_name.eval(self.config)  # type: ignore # eval returns a string in this context
+
+    def get_grant_type_name(self) -> str:
+        return self.grant_type_name.eval(self.config)  # type: ignore # eval returns a string in this context
 
     def get_grant_type(self) -> str:
         return self.grant_type.eval(self.config)  # type: ignore # eval returns a string in this context

--- a/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -1047,6 +1047,13 @@ definitions:
       type:
         type: string
         enum: [OAuthAuthenticator]
+      client_id_name:
+        title: Client ID Property Name
+        description: The name of the property to use to refresh the `access_token`.
+        type: string
+        default: "client_id"
+        examples:
+          - custom_app_id
       client_id:
         title: Client ID
         description: The OAuth client ID. Fill it in the user inputs.
@@ -1054,6 +1061,13 @@ definitions:
         examples:
           - "{{ config['client_id }}"
           - "{{ config['credentials']['client_id }}"
+      client_secret_name:
+        title: Client Secret Property Name
+        description: The name of the property to use to refresh the `access_token`.
+        type: string
+        default: "client_secret"
+        examples:
+          - custom_app_secret
       client_secret:
         title: Client Secret
         description: The OAuth client secret. Fill it in the user inputs.
@@ -1061,6 +1075,13 @@ definitions:
         examples:
           - "{{ config['client_secret }}"
           - "{{ config['credentials']['client_secret }}"
+      refresh_token_name:
+        title: Refresh Token Property Name
+        description: The name of the property to use to refresh the `access_token`.
+        type: string
+        default: "refresh_token"
+        examples:
+          - custom_app_refresh_value
       refresh_token:
         title: Refresh Token
         description: Credential artifact used to get a new access token.
@@ -1094,6 +1115,13 @@ definitions:
         default: "expires_in"
         examples:
           - expires_in
+      grant_type_name:
+        title: Grant Type Property Name
+        description: The name of the property to use to refresh the `access_token`.
+        type: string
+        default: "grant_type"
+        examples:
+          - custom_grant_type
       grant_type:
         title: Grant Type
         description: Specifies the OAuth2 grant type. If set to refresh_token, the refresh_token needs to be provided as well. For client_credentials, only client id and secret are required. Other grant types are not officially supported.
@@ -2204,15 +2232,15 @@ definitions:
           Pertains to the fields defined by the connector relating to the OAuth flow.
 
           Interpolation capabilities:
-          - The variables placeholders are declared as `{my_var}`.
-          - The nested resolution variables like `{{my_nested_var}}` is allowed as well.
+          - The variables placeholders are declared as `{{my_var}}`.
+          - The nested resolution variables like `{{ {{my_nested_var}} }}` is allowed as well.
 
           - The allowed interpolation context is:
-            + base64Encoder - encode to `base64`, {base64Encoder:{my_var_a}:{my_var_b}}
-            + base64Decorer - decode from `base64` encoded string, {base64Decoder:{my_string_variable_or_string_value}}
-            + urlEncoder - encode the input string to URL-like format, {urlEncoder:https://test.host.com/endpoint}
-            + urlDecorer - decode the input url-encoded string into text format, {urlDecoder:https%3A%2F%2Fairbyte.io}
-            + codeChallengeS256 - get the `codeChallenge` encoded value to provide additional data-provider specific authorisation values, {codeChallengeS256:{state_value}}
+            + base64Encoder - encode to `base64`, {{ {{my_var_a}}:{{my_var_b}} | base64Encoder }}
+            + base64Decorer - decode from `base64` encoded string, {{ {{my_string_variable_or_string_value}} | base64Decoder }}
+            + urlEncoder - encode the input string to URL-like format, {{ https://test.host.com/endpoint | urlEncoder}}
+            + urlDecorer - decode the input url-encoded string into text format, {{ urlDecoder:https%3A%2F%2Fairbyte.io | urlDecoder}}
+            + codeChallengeS256 - get the `codeChallenge` encoded value to provide additional data-provider specific authorisation values, {{ {{state_value}} | codeChallengeS256 }}
 
           Examples:
             - The TikTok Marketing DeclarativeOAuth spec:
@@ -2221,12 +2249,12 @@ definitions:
                 "type": "object",
                 "additionalProperties": false,
                 "properties": {
-                    "consent_url": "https://ads.tiktok.com/marketing_api/auth?{client_id_key}={{client_id_key}}&{redirect_uri_key}={urlEncoder:{{redirect_uri_key}}}&{state_key}={{state_key}}",
+                    "consent_url": "https://ads.tiktok.com/marketing_api/auth?{{client_id_key}}={{client_id_value}}&{{redirect_uri_key}}={{ {{redirect_uri_value}} | urlEncoder}}&{{state_key}}={{state_value}}",
                     "access_token_url": "https://business-api.tiktok.com/open_api/v1.3/oauth2/access_token/",
                     "access_token_params": {
-                        "{auth_code_key}": "{{auth_code_key}}",
-                        "{client_id_key}": "{{client_id_key}}",
-                        "{client_secret_key}": "{{client_secret_key}}"
+                        "{{ auth_code_key }}": "{{ auth_code_value }}",
+                        "{{ client_id_key }}": "{{ client_id_value }}",
+                        "{{ client_secret_key }}": "{{ client_secret_value }}"
                     },
                     "access_token_headers": {
                         "Content-Type": "application/json",
@@ -2244,7 +2272,6 @@ definitions:
         required:
           - consent_url
           - access_token_url
-          - extract_output
         properties:
           consent_url:
             title: Consent URL
@@ -2253,8 +2280,8 @@ definitions:
               The DeclarativeOAuth Specific string URL string template to initiate the authentication.
               The placeholders are replaced during the processing to provide neccessary values.
             examples:
-              - https://domain.host.com/marketing_api/auth?{client_id_key}={{client_id_key}}&{redirect_uri_key}={urlEncoder:{{redirect_uri_key}}}&{state_key}={{state_key}}
-              - https://endpoint.host.com/oauth2/authorize?{client_id_key}={{client_id_key}}&{redirect_uri_key}={urlEncoder:{{redirect_uri_key}}}&{scope_key}={urlEncoder:{{scope_key}}}&{state_key}={{state_key}}&subdomain={subdomain}
+              - https://domain.host.com/marketing_api/auth?{{client_id_key}}={{client_id_value}}&{{redirect_uri_key}}={{{{redirect_uri_value}} | urlEncoder}}&{{state_key}}={{state_value}}
+              - https://endpoint.host.com/oauth2/authorize?{{client_id_key}}={{client_id_value}}&{{redirect_uri_key}}={{{{redirect_uri_value}} | urlEncoder}}&{{scope_key}}={{{{scope_value}} | urlEncoder}}&{{state_key}}={{state_value}}&subdomain={{subdomain}}
           scope:
             title: Scopes
             type: string
@@ -2269,7 +2296,7 @@ definitions:
               The DeclarativeOAuth Specific URL templated string to obtain the `access_token`, `refresh_token` etc.
               The placeholders are replaced during the processing to provide neccessary values.
             examples:
-              - https://auth.host.com/oauth2/token?{client_id_key}={{client_id_key}}&{client_secret_key}={{client_secret_key}}&{auth_code_key}={{auth_code_key}}&{redirect_uri_key}={urlEncoder:{{redirect_uri_key}}}
+              - https://auth.host.com/oauth2/token?{{client_id_key}}={{client_id_value}}&{{client_secret_key}}={{client_secret_value}}&{{auth_code_key}}={{auth_code_value}}&{{redirect_uri_key}}={{{{redirect_uri_value}} | urlEncoder}}
           access_token_headers:
             title: Access Token Headers
             type: object
@@ -2278,7 +2305,7 @@ definitions:
               The DeclarativeOAuth Specific optional headers to inject while exchanging the `auth_code` to `access_token` during `completeOAuthFlow` step.
             examples:
               - {
-                  "Authorization": "Basic {base64Encoder:{client_id}:{client_secret}}",
+                  "Authorization": "Basic {{ {{ client_id_value }}:{{ client_secret_value }} | base64Encoder }}",
                 }
           access_token_params:
             title: Access Token Query Params (Json Encoded)
@@ -2289,9 +2316,9 @@ definitions:
               When this property is provided, the query params will be encoded as `Json` and included in the outgoing API request.
             examples:
               - {
-                  "{auth_code_key}": "{{auth_code_key}}",
-                  "{client_id_key}": "{{client_id_key}}",
-                  "{client_secret_key}": "{{client_secret_key}}",
+                  "{{ auth_code_key }}": "{{ auth_code_value }}",
+                  "{{ client_id_key }}": "{{ client_id_value }}",
+                  "{{ client_secret_key }}": "{{ client_secret_value }}",
                 }
           extract_output:
             title: Extract Output

--- a/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -1885,8 +1885,14 @@ class ModelToComponentFactory:
                 expires_in_name=InterpolatedString.create(
                     model.expires_in_name or "expires_in", parameters=model.parameters or {}
                 ).eval(config),
+                client_id_name=InterpolatedString.create(
+                    model.client_id_name or "client_id", parameters=model.parameters or {}
+                ).eval(config),
                 client_id=InterpolatedString.create(
                     model.client_id, parameters=model.parameters or {}
+                ).eval(config),
+                client_secret_name=InterpolatedString.create(
+                    model.client_secret_name or "client_secret", parameters=model.parameters or {}
                 ).eval(config),
                 client_secret=InterpolatedString.create(
                     model.client_secret, parameters=model.parameters or {}
@@ -1894,6 +1900,9 @@ class ModelToComponentFactory:
                 access_token_config_path=model.refresh_token_updater.access_token_config_path,
                 refresh_token_config_path=model.refresh_token_updater.refresh_token_config_path,
                 token_expiry_date_config_path=model.refresh_token_updater.token_expiry_date_config_path,
+                grant_type_name=InterpolatedString.create(
+                    model.grant_type_name or "grant_type", parameters=model.parameters or {}
+                ).eval(config),
                 grant_type=InterpolatedString.create(
                     model.grant_type or "refresh_token", parameters=model.parameters or {}
                 ).eval(config),
@@ -1911,11 +1920,15 @@ class ModelToComponentFactory:
         return DeclarativeOauth2Authenticator(  # type: ignore
             access_token_name=model.access_token_name or "access_token",
             access_token_value=model.access_token_value,
+            client_id_name=model.client_id_name or "client_id",
             client_id=model.client_id,
+            client_secret_name=model.client_secret_name or "client_secret",
             client_secret=model.client_secret,
             expires_in_name=model.expires_in_name or "expires_in",
+            grant_type_name=model.grant_type_name or "grant_type",
             grant_type=model.grant_type or "refresh_token",
             refresh_request_body=model.refresh_request_body,
+            refresh_token_name=model.refresh_token_name or "refresh_token",
             refresh_token=model.refresh_token,
             scopes=model.scopes,
             token_expiry_date=model.token_expiry_date,

--- a/airbyte_cdk/sources/streams/http/requests_native_auth/abstract_oauth.py
+++ b/airbyte_cdk/sources/streams/http/requests_native_auth/abstract_oauth.py
@@ -81,10 +81,10 @@ class AbstractOauth2Authenticator(AuthBase):
         Override to define additional parameters
         """
         payload: MutableMapping[str, Any] = {
-            "grant_type": self.get_grant_type(),
-            "client_id": self.get_client_id(),
-            "client_secret": self.get_client_secret(),
-            "refresh_token": self.get_refresh_token(),
+            self.get_grant_type_name(): self.get_grant_type(),
+            self.get_client_id_name(): self.get_client_id(),
+            self.get_client_secret_name(): self.get_client_secret(),
+            self.get_refresh_token_name(): self.get_refresh_token(),
         }
 
         if self.get_scopes():
@@ -207,12 +207,24 @@ class AbstractOauth2Authenticator(AuthBase):
         """Returns the endpoint to refresh the access token"""
 
     @abstractmethod
+    def get_client_id_name(self) -> str:
+        """The client id name to authenticate"""
+
+    @abstractmethod
     def get_client_id(self) -> str:
         """The client id to authenticate"""
 
     @abstractmethod
+    def get_client_secret_name(self) -> str:
+        """The client secret name to authenticate"""
+
+    @abstractmethod
     def get_client_secret(self) -> str:
         """The client secret to authenticate"""
+
+    @abstractmethod
+    def get_refresh_token_name(self) -> str:
+        """The refresh token name to authenticate"""
 
     @abstractmethod
     def get_refresh_token(self) -> Optional[str]:
@@ -245,6 +257,10 @@ class AbstractOauth2Authenticator(AuthBase):
     @abstractmethod
     def get_grant_type(self) -> str:
         """Returns grant_type specified for requesting access_token"""
+
+    @abstractmethod
+    def get_grant_type_name(self) -> str:
+        """Returns grant_type specified name for requesting access_token"""
 
     @property
     @abstractmethod

--- a/airbyte_cdk/sources/streams/http/requests_native_auth/oauth.py
+++ b/airbyte_cdk/sources/streams/http/requests_native_auth/oauth.py
@@ -30,12 +30,16 @@ class Oauth2Authenticator(AbstractOauth2Authenticator):
         client_id: str,
         client_secret: str,
         refresh_token: str,
+        client_id_name: str = "client_id",
+        client_secret_name: str = "client_secret",
+        refresh_token_name: str = "refresh_token",
         scopes: List[str] | None = None,
         token_expiry_date: pendulum.DateTime | None = None,
         token_expiry_date_format: str | None = None,
         access_token_name: str = "access_token",
         expires_in_name: str = "expires_in",
         refresh_request_body: Mapping[str, Any] | None = None,
+        grant_type_name: str = "grant_type",
         grant_type: str = "refresh_token",
         token_expiry_is_time_of_expiration: bool = False,
         refresh_token_error_status_codes: Tuple[int, ...] = (),
@@ -43,13 +47,17 @@ class Oauth2Authenticator(AbstractOauth2Authenticator):
         refresh_token_error_values: Tuple[str, ...] = (),
     ):
         self._token_refresh_endpoint = token_refresh_endpoint
+        self._client_secret_name = client_secret_name
         self._client_secret = client_secret
+        self._client_id_name = client_id_name
         self._client_id = client_id
+        self._refresh_token_name = refresh_token_name
         self._refresh_token = refresh_token
         self._scopes = scopes
         self._access_token_name = access_token_name
         self._expires_in_name = expires_in_name
         self._refresh_request_body = refresh_request_body
+        self._grant_type_name = grant_type_name
         self._grant_type = grant_type
 
         self._token_expiry_date = token_expiry_date or pendulum.now().subtract(days=1)  # type: ignore [no-untyped-call]
@@ -63,11 +71,20 @@ class Oauth2Authenticator(AbstractOauth2Authenticator):
     def get_token_refresh_endpoint(self) -> str:
         return self._token_refresh_endpoint
 
+    def get_client_id_name(self) -> str:
+        return self._client_id_name
+
     def get_client_id(self) -> str:
         return self._client_id
 
+    def get_client_secret_name(self) -> str:
+        return self._client_secret_name
+
     def get_client_secret(self) -> str:
         return self._client_secret
+
+    def get_refresh_token_name(self) -> str:
+        return self._refresh_token_name
 
     def get_refresh_token(self) -> str:
         return self._refresh_token
@@ -83,6 +100,9 @@ class Oauth2Authenticator(AbstractOauth2Authenticator):
 
     def get_refresh_request_body(self) -> Mapping[str, Any]:
         return self._refresh_request_body  # type: ignore [return-value]
+
+    def get_grant_type_name(self) -> str:
+        return self._grant_type_name
 
     def get_grant_type(self) -> str:
         return self._grant_type
@@ -129,8 +149,11 @@ class SingleUseRefreshTokenOauth2Authenticator(Oauth2Authenticator):
         expires_in_name: str = "expires_in",
         refresh_token_name: str = "refresh_token",
         refresh_request_body: Mapping[str, Any] | None = None,
+        grant_type_name: str = "grant_type",
         grant_type: str = "refresh_token",
+        client_id_name: str = "client_id",
         client_id: Optional[str] = None,
+        client_secret_name: str = "client_secret",
         client_secret: Optional[str] = None,
         access_token_config_path: Sequence[str] = ("credentials", "access_token"),
         refresh_token_config_path: Sequence[str] = ("credentials", "refresh_token"),
@@ -174,23 +197,30 @@ class SingleUseRefreshTokenOauth2Authenticator(Oauth2Authenticator):
                 ("credentials", "client_secret"),
             )
         )
+        self._client_id_name = client_id_name
+        self._client_secret_name = client_secret_name
         self._access_token_config_path = access_token_config_path
         self._refresh_token_config_path = refresh_token_config_path
         self._token_expiry_date_config_path = token_expiry_date_config_path
         self._token_expiry_date_format = token_expiry_date_format
         self._refresh_token_name = refresh_token_name
+        self._grant_type_name = grant_type_name
         self._connector_config = connector_config
         self.__message_repository = message_repository
         super().__init__(
-            token_refresh_endpoint,
-            self.get_client_id(),
-            self.get_client_secret(),
-            self.get_refresh_token(),
+            token_refresh_endpoint=token_refresh_endpoint,
+            client_id_name=self._client_id_name,
+            client_id=self.get_client_id(),
+            client_secret_name=self._client_secret_name,
+            client_secret=self.get_client_secret(),
+            refresh_token=self.get_refresh_token(),
+            refresh_token_name=self._refresh_token_name,
             scopes=scopes,
             token_expiry_date=self.get_token_expiry_date(),
             access_token_name=access_token_name,
             expires_in_name=expires_in_name,
             refresh_request_body=refresh_request_body,
+            grant_type_name=self._grant_type_name,
             grant_type=grant_type,
             token_expiry_date_format=token_expiry_date_format,
             token_expiry_is_time_of_expiration=token_expiry_is_time_of_expiration,

--- a/unit_tests/sources/streams/http/requests_native_auth/test_requests_native_auth.py
+++ b/unit_tests/sources/streams/http/requests_native_auth/test_requests_native_auth.py
@@ -165,9 +165,45 @@ class TestOauth2Authenticator:
         }
         assert body == expected
 
+    def test_refresh_request_body_with_keys_override(self):
+        """
+        Request body should match given configuration.
+        """
+        scopes = ["scope1", "scope2"]
+        oauth = Oauth2Authenticator(
+            token_refresh_endpoint="refresh_end",
+            client_id_name="custom_client_id_key",
+            client_id="some_client_id",
+            client_secret_name="custom_client_secret_key",
+            client_secret="some_client_secret",
+            refresh_token_name="custom_refresh_token_key",
+            refresh_token="some_refresh_token",
+            scopes=["scope1", "scope2"],
+            token_expiry_date=pendulum.now().add(days=3),
+            grant_type_name="custom_grant_type",
+            grant_type="some_grant_type",
+            refresh_request_body={
+                "custom_field": "in_outbound_request",
+                "another_field": "exists_in_body",
+                "scopes": ["no_override"],
+            },
+        )
+        body = oauth.build_refresh_request_body()
+        expected = {
+            "custom_grant_type": "some_grant_type",
+            "custom_client_id_key": "some_client_id",
+            "custom_client_secret_key": "some_client_secret",
+            "custom_refresh_token_key": "some_refresh_token",
+            "scopes": scopes,
+            "custom_field": "in_outbound_request",
+            "another_field": "exists_in_body",
+        }
+        assert body == expected
+
     def test_refresh_access_token(self, mocker):
         oauth = Oauth2Authenticator(
             token_refresh_endpoint="refresh_end",
+            client_id_name="TEST",
             client_id="some_client_id",
             client_secret="some_client_secret",
             refresh_token="some_refresh_token",

--- a/unit_tests/sources/streams/http/requests_native_auth/test_requests_native_auth.py
+++ b/unit_tests/sources/streams/http/requests_native_auth/test_requests_native_auth.py
@@ -203,7 +203,6 @@ class TestOauth2Authenticator:
     def test_refresh_access_token(self, mocker):
         oauth = Oauth2Authenticator(
             token_refresh_endpoint="refresh_end",
-            client_id_name="TEST",
             client_id="some_client_id",
             client_secret="some_client_secret",
             refresh_token="some_refresh_token",


### PR DESCRIPTION
## What
During the QA sessions for `DeclarativeOAuthFlow` in Builder, the following issues were discovered:
- need a way to override the keys inside the `refresh_token_request_body` to provide the custom names as keys to add more flexibility and cover more custom OAuth flows, which have non-default `request_body` to be provided.
- made the `oauth_connector_input_specification.extract_output` field `Optional`, since it's going to be deprecated soon.
- fix the `oauth_connector_input_specification` (DeclarativeOAuthFlow) tooltips to reflect the updated `Jinja2` variables declaration style. Resolving: https://github.com/airbytehq/airbyte-internal-issues/issues/11337

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced OAuth2 authentication configuration
	- Added support for custom key names in OAuth token requests
	- Improved flexibility for specifying client ID, client secret, refresh token, and grant type names

- **Improvements**
	- Updated OAuth authenticator to allow more dynamic parameter naming
	- Expanded configuration options for OAuth token refresh process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->