### PR TITLE
security fix: sanitize transformation error message to hide record values

### DIFF
--- a/airbyte_cdk/sources/utils/transform.py
+++ b/airbyte_cdk/sources/utils/transform.py
@@ -227,7 +227,9 @@ class TypeTransformer:
     def get_error_message(self, e: ValidationError) -> str:
         def _get_type_structure(input_data: Any) -> Any:
             if isinstance(input_data, dict):
-                structure = {key: _get_type_structure(field_value) for key, field_value in input_data.items()}
+                structure = {
+                    key: _get_type_structure(field_value) for key, field_value in input_data.items()
+                }
                 return f"object with structure {structure}"
             elif isinstance(input_data, list):
                 if not input_data:
@@ -240,5 +242,5 @@ class TypeTransformer:
 
         field_path = ".".join(map(str, e.path))
         type_structure = _get_type_structure(e.instance)
-        
+
         return f"Failed to transform value from type '{type_structure}' to type '{e.validator_value}' at path: '{field_path}'"

--- a/airbyte_cdk/sources/utils/transform.py
+++ b/airbyte_cdk/sources/utils/transform.py
@@ -225,6 +225,16 @@ class TypeTransformer:
             logger.warning(self.get_error_message(e))
 
     def get_error_message(self, e: ValidationError) -> str:
-        instance_json_type = python_to_json[type(e.instance)]
+
+        def _get_type_structure(input_data: Any) -> Any:
+            if isinstance(input_data, dict):
+                return {key: _get_type_structure(value) for key, value in input_data.items()}
+            elif isinstance(input_data, list):
+                return [_get_type_structure(value) for value in input_data] if input_data else "array"
+            else:
+                return type(input_data).__name__.lower()
+            
         key_path = "." + ".".join(map(str, e.path))
-        return f"Failed to transform value {repr(e.instance)} of type '{instance_json_type}' to '{e.validator_value}', key path: '{key_path}'"
+        type_structure = _get_type_structure(e.instance)
+
+        return f"Failed to transform value of {type_structure} to '{e.validator_value}'. Key path: '{key_path}'"

--- a/unit_tests/sources/utils/test_transform.py
+++ b/unit_tests/sources/utils/test_transform.py
@@ -104,14 +104,14 @@ VERY_NESTED_SCHEMA = {
             COMPLEX_SCHEMA,
             {"prop": 12, "number_prop": "aa12", "array": [12]},
             {"prop": "12", "number_prop": "aa12", "array": ["12"]},
-            "Failed to transform value 'aa12' of type 'string' to 'number', key path: '.number_prop'",
+            "Failed to transform value of type 'string' to 'number' at path: 'number_prop'",
         ),
         # Field too_many_types have ambigious type, skip formatting
         (
             COMPLEX_SCHEMA,
             {"prop": 12, "too_many_types": 1212, "array": [12]},
             {"prop": "12", "too_many_types": 1212, "array": ["12"]},
-            "Failed to transform value 1212 of type 'integer' to '['boolean', 'null', 'string']', key path: '.too_many_types'",
+            "Failed to transform value of type 'integer' to '['boolean', 'null', 'string']' at path: 'too_many_types'",
         ),
         # Test null field
         (COMPLEX_SCHEMA, {"prop": None, "array": [12]}, {"prop": "None", "array": ["12"]}, None),
@@ -196,7 +196,7 @@ VERY_NESTED_SCHEMA = {
             },
             {"value": "string"},
             {"value": "string"},
-            "Failed to transform value 'string' of type 'string' to 'array', key path: '.value'",
+            "Failed to transform value of type 'string' to 'array' at path: 'value'",
         ),
         (
             {
@@ -205,21 +205,21 @@ VERY_NESTED_SCHEMA = {
             },
             {"value": {"key": "value"}},
             {"value": {"key": "value"}},
-            "Failed to transform value {'key': 'value'} of type 'object' to 'array', key path: '.value'",
+            "Failed to transform value of type '{'key': 'string'}' to 'array' at path: 'value'",
         ),
         (
             # Schema root object is not an object, no convertion should happen
             {"type": "integer"},
             {"value": "12"},
             {"value": "12"},
-            "Failed to transform value {'value': '12'} of type 'object' to 'integer', key path: '.'",
+            "Failed to transform value of type '{'value': 'string'}' to 'integer' at path: ''",
         ),
         (
             # More than one type except null, no conversion should happen
             {"type": "object", "properties": {"value": {"type": ["string", "boolean", "null"]}}},
             {"value": 12},
             {"value": 12},
-            "Failed to transform value 12 of type 'integer' to '['string', 'boolean', 'null']', key path: '.value'",
+            "Failed to transform value of type 'integer' to '['string', 'boolean', 'null']' at path: 'value'",
         ),
         (
             # Oneof not suported, no conversion for one_of_value should happen
@@ -252,7 +252,7 @@ VERY_NESTED_SCHEMA = {
             },
             {"value": {"key": "value"}},
             {"value": {"key": "value"}},
-            "Failed to transform value {'key': 'value'} of type 'object' to 'array', key path: '.value'",
+            "Failed to transform value of type '{'key': 'string'}' to 'array' at path: 'value'",
         ),
         (
             {
@@ -263,7 +263,7 @@ VERY_NESTED_SCHEMA = {
             },
             {"value1": "value2"},
             {"value1": "value2"},
-            "Failed to transform value 'value2' of type 'string' to 'object', key path: '.value1'",
+            "Failed to transform value of type 'string' to 'object' at path: 'value1'",
         ),
         (
             {
@@ -272,7 +272,7 @@ VERY_NESTED_SCHEMA = {
             },
             {"value": ["one", "two"]},
             {"value": ["one", "two"]},
-            "Failed to transform value 'one' of type 'string' to 'object', key path: '.value.0'",
+            "Failed to transform value of type 'string' to 'object' at path: 'value.0'",
         ),
     ],
 )

--- a/unit_tests/sources/utils/test_transform.py
+++ b/unit_tests/sources/utils/test_transform.py
@@ -104,14 +104,14 @@ VERY_NESTED_SCHEMA = {
             COMPLEX_SCHEMA,
             {"prop": 12, "number_prop": "aa12", "array": [12]},
             {"prop": "12", "number_prop": "aa12", "array": ["12"]},
-            "Failed to transform value of type 'string' to 'number' at path: 'number_prop'",
+            "Failed to transform value from type 'string' to type 'number' at path: 'number_prop'",
         ),
         # Field too_many_types have ambigious type, skip formatting
         (
             COMPLEX_SCHEMA,
             {"prop": 12, "too_many_types": 1212, "array": [12]},
             {"prop": "12", "too_many_types": 1212, "array": ["12"]},
-            "Failed to transform value of type 'integer' to '['boolean', 'null', 'string']' at path: 'too_many_types'",
+            "Failed to transform value from type 'integer' to type '['boolean', 'null', 'string']' at path: 'too_many_types'",
         ),
         # Test null field
         (COMPLEX_SCHEMA, {"prop": None, "array": [12]}, {"prop": "None", "array": ["12"]}, None),
@@ -196,7 +196,7 @@ VERY_NESTED_SCHEMA = {
             },
             {"value": "string"},
             {"value": "string"},
-            "Failed to transform value of type 'string' to 'array' at path: 'value'",
+            "Failed to transform value from type 'string' to type 'array' at path: 'value'",
         ),
         (
             {
@@ -205,21 +205,21 @@ VERY_NESTED_SCHEMA = {
             },
             {"value": {"key": "value"}},
             {"value": {"key": "value"}},
-            "Failed to transform value of type '{'key': 'string'}' to 'array' at path: 'value'",
+            "Failed to transform value from type 'object with structure {'key': 'string'}' to type 'array' at path: 'value'",
         ),
         (
             # Schema root object is not an object, no convertion should happen
             {"type": "integer"},
             {"value": "12"},
             {"value": "12"},
-            "Failed to transform value of type '{'value': 'string'}' to 'integer' at path: ''",
+            "Failed to transform value from type 'object with structure {'value': 'string'}' to type 'integer' at path: ''",
         ),
         (
             # More than one type except null, no conversion should happen
             {"type": "object", "properties": {"value": {"type": ["string", "boolean", "null"]}}},
             {"value": 12},
             {"value": 12},
-            "Failed to transform value of type 'integer' to '['string', 'boolean', 'null']' at path: 'value'",
+            "Failed to transform value from type 'integer' to type '['string', 'boolean', 'null']' at path: 'value'",
         ),
         (
             # Oneof not suported, no conversion for one_of_value should happen
@@ -252,7 +252,7 @@ VERY_NESTED_SCHEMA = {
             },
             {"value": {"key": "value"}},
             {"value": {"key": "value"}},
-            "Failed to transform value of type '{'key': 'string'}' to 'array' at path: 'value'",
+            "Failed to transform value from type 'object with structure {'key': 'string'}' to type 'array' at path: 'value'",
         ),
         (
             {
@@ -263,7 +263,7 @@ VERY_NESTED_SCHEMA = {
             },
             {"value1": "value2"},
             {"value1": "value2"},
-            "Failed to transform value of type 'string' to 'object' at path: 'value1'",
+            "Failed to transform value from type 'string' to type 'object' at path: 'value1'",
         ),
         (
             {
@@ -272,7 +272,7 @@ VERY_NESTED_SCHEMA = {
             },
             {"value": ["one", "two"]},
             {"value": ["one", "two"]},
-            "Failed to transform value of type 'string' to 'object' at path: 'value.0'",
+            "Failed to transform value from type 'string' to type 'object' at path: 'value.0'",
         ),
     ],
 )


### PR DESCRIPTION
## What

A Builder user alerted us to a Record transformation error that was exposing sensitive email values in their test reads. This PR updates the error message constructor to sanitize values, only displaying the structure/type of the field causing the failure.