### PR TITLE
feat(low-code): added condition to TypesMap of DynamicSchemaLoader

### DIFF
--- a/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -1764,9 +1764,7 @@ definitions:
             items:
               type: string
       condition:
-        anyOf:
-          - type: string
-          - type: boolean
+        type: string
         interpolation_context:
           - raw_schema
   SchemaTypeIdentifier:

--- a/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -1763,6 +1763,12 @@ definitions:
           - type: array
             items:
               type: string
+      condition:
+        anyOf:
+          - type: string
+          - type: boolean
+        interpolation_context:
+          - raw_schema
   SchemaTypeIdentifier:
     title: Schema Type Identifier
     description: (This component is experimental. Use at your own risk.) Identifies schema details for dynamic schema extraction and processing.

--- a/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
+++ b/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
@@ -699,7 +699,7 @@ class HttpResponseFilter(BaseModel):
 class TypesMap(BaseModel):
     target_type: Union[str, List[str]]
     current_type: Union[str, List[str]]
-    condition: Optional[Union[str, bool]]
+    condition: Optional[str]
 
 
 class SchemaTypeIdentifier(BaseModel):

--- a/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
+++ b/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
@@ -699,6 +699,7 @@ class HttpResponseFilter(BaseModel):
 class TypesMap(BaseModel):
     target_type: Union[str, List[str]]
     current_type: Union[str, List[str]]
+    condition: Optional[Union[str, bool]]
 
 
 class SchemaTypeIdentifier(BaseModel):

--- a/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -1689,7 +1689,7 @@ class ModelToComponentFactory:
         return TypesMap(
             target_type=model.target_type,
             current_type=model.current_type,
-            condition=model.condition if model.condition is not None else True,
+            condition=model.condition if model.condition is not None else "true",
         )
 
     def create_schema_type_identifier(

--- a/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -1689,7 +1689,7 @@ class ModelToComponentFactory:
         return TypesMap(
             target_type=model.target_type,
             current_type=model.current_type,
-            condition=model.condition if model.condition is not None else "true",
+            condition=model.condition if model.condition is not None else "True",
         )
 
     def create_schema_type_identifier(

--- a/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -1686,7 +1686,11 @@ class ModelToComponentFactory:
 
     @staticmethod
     def create_types_map(model: TypesMapModel, **kwargs: Any) -> TypesMap:
-        return TypesMap(target_type=model.target_type, current_type=model.current_type)
+        return TypesMap(
+            target_type=model.target_type,
+            current_type=model.current_type,
+            condition=model.condition if model.condition is not None else True,
+        )
 
     def create_schema_type_identifier(
         self, model: SchemaTypeIdentifierModel, config: Config, **kwargs: Any

--- a/airbyte_cdk/sources/declarative/schema/dynamic_schema_loader.py
+++ b/airbyte_cdk/sources/declarative/schema/dynamic_schema_loader.py
@@ -207,7 +207,7 @@ class DynamicSchemaLoader(SchemaLoader):
             for types_map in self.schema_type_identifier.types_mapping:
                 # conditional is optional param, setting to true if not provided
                 condition = InterpolatedBoolean(
-                    condition=types_map.condition if types_map.condition is not None else "true",
+                    condition=types_map.condition if types_map.condition is not None else "True",
                     parameters={},
                 ).eval(config=self.config, raw_schema=raw_schema)
 

--- a/airbyte_cdk/sources/declarative/schema/dynamic_schema_loader.py
+++ b/airbyte_cdk/sources/declarative/schema/dynamic_schema_loader.py
@@ -10,8 +10,8 @@ from typing import Any, List, Mapping, MutableMapping, Optional, Union
 import dpath
 from typing_extensions import deprecated
 
-from airbyte_cdk.sources.declarative.interpolation.interpolated_string import InterpolatedString
 from airbyte_cdk.sources.declarative.interpolation.interpolated_boolean import InterpolatedBoolean
+from airbyte_cdk.sources.declarative.interpolation.interpolated_string import InterpolatedString
 from airbyte_cdk.sources.declarative.retrievers.retriever import Retriever
 from airbyte_cdk.sources.declarative.schema.schema_loader import SchemaLoader
 from airbyte_cdk.sources.declarative.transformations import RecordTransformation

--- a/airbyte_cdk/sources/declarative/schema/dynamic_schema_loader.py
+++ b/airbyte_cdk/sources/declarative/schema/dynamic_schema_loader.py
@@ -205,9 +205,12 @@ class DynamicSchemaLoader(SchemaLoader):
         """
         if self.schema_type_identifier.types_mapping:
             for types_map in self.schema_type_identifier.types_mapping:
-                condition = InterpolatedBoolean(condition=types_map.condition, parameters={}).eval(
-                    config={}, raw_schema=raw_schema
-                )
+                # conditional is optional param, setting to true if not provided
+                condition = InterpolatedBoolean(
+                    condition=types_map.condition if types_map.condition is not None else "true",
+                    parameters={},
+                ).eval(config=self.config, raw_schema=raw_schema)
+
                 if field_type == types_map.current_type and condition:
                     return types_map.target_type
         return field_type

--- a/airbyte_cdk/sources/declarative/schema/dynamic_schema_loader.py
+++ b/airbyte_cdk/sources/declarative/schema/dynamic_schema_loader.py
@@ -54,7 +54,7 @@ class TypesMap:
 
     target_type: Union[List[str], str]
     current_type: Union[List[str], str]
-    condition: Optional[Union[str, bool]]
+    condition: Optional[str]
 
 
 @deprecated("This class is experimental. Use at your own risk.", category=ExperimentalClassWarning)

--- a/unit_tests/sources/declarative/schema/test_dynamic_schema_loader.py
+++ b/unit_tests/sources/declarative/schema/test_dynamic_schema_loader.py
@@ -286,3 +286,92 @@ def test_dynamic_schema_loader_manifest_flow():
 
     assert len(actual_catalog.streams) == 1
     assert actual_catalog.streams[0].json_schema == expected_schema
+
+
+def test_dynamic_schema_loader_with_type_conditions():
+    _MANIFEST["definitions"]["party_members_stream"]["schema_loader"]["schema_type_identifier"][
+        "types_mapping"
+    ].append(
+        {
+            "target_type": "number",
+            "current_type": "formula",
+            "condition": "{{ raw_schema['result']['type'] == 'number' }}",
+        }
+    )
+    _MANIFEST["definitions"]["party_members_stream"]["schema_loader"]["schema_type_identifier"][
+        "types_mapping"
+    ].append(
+        {
+            "target_type": "number",
+            "current_type": "formula",
+            "condition": "{{ raw_schema['result']['type'] == 'currency' }}",
+        }
+    )
+    _MANIFEST["definitions"]["party_members_stream"]["schema_loader"]["schema_type_identifier"][
+        "types_mapping"
+    ].append({"target_type": "array", "current_type": "formula"})
+
+    expected_schema = {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+            "id": {"type": ["null", "integer"]},
+            "first_name": {"type": ["null", "string"]},
+            "description": {"type": ["null", "string"]},
+            "static_field": {"type": ["null", "string"]},
+            "currency": {"type": ["null", "number"]},
+            "salary": {"type": ["null", "number"]},
+            "working_days": {"type": ["null", "array"]},
+        },
+    }
+    source = ConcurrentDeclarativeSource(
+        source_config=_MANIFEST, config=_CONFIG, catalog=None, state=None
+    )
+    with HttpMocker() as http_mocker:
+        http_mocker.get(
+            HttpRequest(url="https://api.test.com/party_members"),
+            HttpResponse(
+                body=json.dumps(
+                    [
+                        {
+                            "id": 1,
+                            "first_name": "member_1",
+                            "description": "First member",
+                            "salary": 20000,
+                            "currency": 10.4,
+                            "working_days": ["Monday", "Tuesday"],
+                        },
+                        {
+                            "id": 2,
+                            "first_name": "member_2",
+                            "description": "Second member",
+                            "salary": 22000,
+                            "currency": 10.4,
+                            "working_days": ["Tuesday", "Wednesday"],
+                        },
+                    ]
+                )
+            ),
+        )
+        http_mocker.get(
+            HttpRequest(url="https://api.test.com/party_members/schema"),
+            HttpResponse(
+                body=json.dumps(
+                    {
+                        "fields": [
+                            {"name": "Id", "type": "integer"},
+                            {"name": "FirstName", "type": "string"},
+                            {"name": "Description", "type": "singleLineText"},
+                            {"name": "Salary", "type": "formula", "result": {"type": "number"}},
+                            {"name": "Currency", "type": "formula", "result": {"type": "currency"}},
+                            {"name": "WorkingDays", "type": "formula"},
+                        ]
+                    }
+                )
+            ),
+        )
+
+        actual_catalog = source.discover(logger=source.logger, config=_CONFIG)
+
+    assert len(actual_catalog.streams) == 1
+    assert actual_catalog.streams[0].json_schema == expected_schema

--- a/unit_tests/sources/declarative/schema/test_dynamic_schema_loader.py
+++ b/unit_tests/sources/declarative/schema/test_dynamic_schema_loader.py
@@ -3,6 +3,7 @@
 #
 
 import json
+from copy import deepcopy
 from unittest.mock import MagicMock
 
 import pytest
@@ -289,27 +290,28 @@ def test_dynamic_schema_loader_manifest_flow():
 
 
 def test_dynamic_schema_loader_with_type_conditions():
-    _MANIFEST["definitions"]["party_members_stream"]["schema_loader"]["schema_type_identifier"][
-        "types_mapping"
-    ].append(
+    _MANIFEST_WITH_TYPE_CONDITIONS = deepcopy(_MANIFEST)
+    _MANIFEST_WITH_TYPE_CONDITIONS["definitions"]["party_members_stream"]["schema_loader"][
+        "schema_type_identifier"
+    ]["types_mapping"].append(
         {
             "target_type": "number",
             "current_type": "formula",
             "condition": "{{ raw_schema['result']['type'] == 'number' }}",
         }
     )
-    _MANIFEST["definitions"]["party_members_stream"]["schema_loader"]["schema_type_identifier"][
-        "types_mapping"
-    ].append(
+    _MANIFEST_WITH_TYPE_CONDITIONS["definitions"]["party_members_stream"]["schema_loader"][
+        "schema_type_identifier"
+    ]["types_mapping"].append(
         {
             "target_type": "number",
             "current_type": "formula",
             "condition": "{{ raw_schema['result']['type'] == 'currency' }}",
         }
     )
-    _MANIFEST["definitions"]["party_members_stream"]["schema_loader"]["schema_type_identifier"][
-        "types_mapping"
-    ].append({"target_type": "array", "current_type": "formula"})
+    _MANIFEST_WITH_TYPE_CONDITIONS["definitions"]["party_members_stream"]["schema_loader"][
+        "schema_type_identifier"
+    ]["types_mapping"].append({"target_type": "array", "current_type": "formula"})
 
     expected_schema = {
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -325,7 +327,7 @@ def test_dynamic_schema_loader_with_type_conditions():
         },
     }
     source = ConcurrentDeclarativeSource(
-        source_config=_MANIFEST, config=_CONFIG, catalog=None, state=None
+        source_config=_MANIFEST_WITH_TYPE_CONDITIONS, config=_CONFIG, catalog=None, state=None
     )
     with HttpMocker() as http_mocker:
         http_mocker.get(


### PR DESCRIPTION
### What
Dynamic schema loader: there can be a case when type of the field doesn't depend on "type" field value only. Example: `source airtable`.
field_1
```
{
"type": "formula"
"result": {"type": "number"}
}
```
field_2
```
{
"type": "formula"
"result": {"type": "singleLineText"}
}
```
### How
To properly identify field type in cases like above `condition` option was added to `TypesMap` object. Now providing TypesMap object condition we can create 2 separate cases for string values and number values.
See `unit_tests/sources/declarative/schema/test_dynamic_schema_loader.py` for more examples.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a `condition` property to support more flexible type mapping and record filtering in declarative components.
	- Enhanced schema loader to support conditional type validation and replacement.

- **Improvements**
	- Expanded type mapping capabilities to allow string conditions.
	- Improved dynamic schema generation with context-aware type validation.

- **Tests**
	- Added a new test case to validate the dynamic schema loader with type conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->