### PR TITLE
feat(AsyncRetriever): Allow for streams using AsyncRetriever and DatetimeBasedCursor to perform checkpointing

### DIFF
--- a/airbyte_cdk/sources/declarative/declarative_stream.py
+++ b/airbyte_cdk/sources/declarative/declarative_stream.py
@@ -1,6 +1,7 @@
 #
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
+
 import logging
 from dataclasses import InitVar, dataclass, field
 from typing import Any, Iterable, List, Mapping, MutableMapping, Optional, Union
@@ -13,7 +14,7 @@ from airbyte_cdk.sources.declarative.incremental import (
 )
 from airbyte_cdk.sources.declarative.interpolation import InterpolatedString
 from airbyte_cdk.sources.declarative.migrations.state_migration import StateMigration
-from airbyte_cdk.sources.declarative.retrievers import SimpleRetriever
+from airbyte_cdk.sources.declarative.retrievers import AsyncRetriever, SimpleRetriever
 from airbyte_cdk.sources.declarative.retrievers.retriever import Retriever
 from airbyte_cdk.sources.declarative.schema import DefaultSchemaLoader
 from airbyte_cdk.sources.declarative.schema.schema_loader import SchemaLoader
@@ -189,7 +190,10 @@ class DeclarativeStream(Stream):
         return None
 
     def get_cursor(self) -> Optional[Cursor]:
-        if self.retriever and isinstance(self.retriever, SimpleRetriever):
+        if self.retriever and (
+            isinstance(self.retriever, SimpleRetriever)
+            or isinstance(self.retriever, AsyncRetriever)
+        ):
             return self.retriever.cursor
         return None
 

--- a/airbyte_cdk/sources/declarative/partition_routers/async_job_partition_router.py
+++ b/airbyte_cdk/sources/declarative/partition_routers/async_job_partition_router.py
@@ -8,6 +8,8 @@ from airbyte_cdk.sources.declarative.async_job.job_orchestrator import (
     AsyncJobOrchestrator,
     AsyncPartition,
 )
+from airbyte_cdk.sources.declarative.incremental import DatetimeBasedCursor
+from airbyte_cdk.sources.declarative.incremental.declarative_cursor import DeclarativeCursor
 from airbyte_cdk.sources.declarative.partition_routers.single_partition_router import (
     SinglePartitionRouter,
 )
@@ -35,6 +37,14 @@ class AsyncJobPartitionRouter(StreamSlicer):
         self._job_orchestrator_factory = self.job_orchestrator_factory
         self._job_orchestrator: Optional[AsyncJobOrchestrator] = None
         self._parameters = parameters
+        if isinstance(self.stream_slicer, DatetimeBasedCursor):
+            self._cursor: Optional[DeclarativeCursor] = self.stream_slicer
+        else:
+            self._cursor = None
+
+    @property
+    def cursor(self) -> Optional[DeclarativeCursor]:
+        return self._cursor
 
     def stream_slices(self) -> Iterable[StreamSlice]:
         slices = self.stream_slicer.stream_slices()

--- a/airbyte_cdk/sources/declarative/retrievers/async_retriever.py
+++ b/airbyte_cdk/sources/declarative/retrievers/async_retriever.py
@@ -9,13 +9,14 @@ from typing_extensions import deprecated
 from airbyte_cdk.models import FailureType
 from airbyte_cdk.sources.declarative.async_job.job_orchestrator import AsyncPartition
 from airbyte_cdk.sources.declarative.extractors.record_selector import RecordSelector
+from airbyte_cdk.sources.declarative.incremental.declarative_cursor import DeclarativeCursor
 from airbyte_cdk.sources.declarative.partition_routers.async_job_partition_router import (
     AsyncJobPartitionRouter,
 )
 from airbyte_cdk.sources.declarative.retrievers.retriever import Retriever
 from airbyte_cdk.sources.source import ExperimentalClassWarning
 from airbyte_cdk.sources.streams.core import StreamData
-from airbyte_cdk.sources.types import Config, StreamSlice, StreamState
+from airbyte_cdk.sources.types import Config, Record, StreamSlice, StreamState
 from airbyte_cdk.utils.traced_exception import AirbyteTracedException
 
 
@@ -36,26 +37,22 @@ class AsyncRetriever(Retriever):
     @property
     def state(self) -> StreamState:
         """
-        As a first iteration for sendgrid, there is no state to be managed
-        """
-        return {}
-
-    @state.setter
-    def state(self, value: StreamState) -> None:
-        """
-        As a first iteration for sendgrid, there is no state to be managed
-        """
-        pass
-
-    def _get_stream_state(self) -> StreamState:
-        """
         Gets the current state of the stream.
 
         Returns:
             StreamState: Mapping[str, Any]
         """
+        return self.stream_slicer.cursor.get_stream_state() if self.stream_slicer.cursor else {}
 
-        return self.state
+    @state.setter
+    def state(self, value: StreamState) -> None:
+        """State setter, accept state serialized by state getter."""
+        if self.stream_slicer.cursor:
+            self.stream_slicer.cursor.set_initial_state(value)
+
+    @property
+    def cursor(self) -> Optional[DeclarativeCursor]:
+        return self.stream_slicer.cursor
 
     def _validate_and_get_stream_slice_partition(
         self, stream_slice: Optional[StreamSlice] = None
@@ -88,13 +85,47 @@ class AsyncRetriever(Retriever):
         records_schema: Mapping[str, Any],
         stream_slice: Optional[StreamSlice] = None,
     ) -> Iterable[StreamData]:
-        stream_state: StreamState = self._get_stream_state()
+        _slice = stream_slice or StreamSlice(partition={}, cursor_slice={})  # None-check
+
+        stream_state: StreamState = self.state
         partition: AsyncPartition = self._validate_and_get_stream_slice_partition(stream_slice)
         records: Iterable[Mapping[str, Any]] = self.stream_slicer.fetch_records(partition)
+        most_recent_record_from_slice = None
 
-        yield from self.record_selector.filter_and_transform(
+        for stream_data in self.record_selector.filter_and_transform(
             all_data=records,
             stream_state=stream_state,
             records_schema=records_schema,
-            stream_slice=stream_slice,
-        )
+            stream_slice=_slice,
+        ):
+            if self.cursor and stream_data:
+                self.cursor.observe(_slice, stream_data)
+
+            most_recent_record_from_slice = self._get_most_recent_record(
+                most_recent_record_from_slice, stream_data, _slice
+            )
+            yield stream_data
+
+        if self.cursor:
+            # DatetimeBasedCursor doesn't expect a partition field, but for AsyncRetriever streams this will
+            # be the slice range
+            slice_no_partition = StreamSlice(cursor_slice=_slice.cursor_slice, partition={})
+            self.cursor.close_slice(slice_no_partition, most_recent_record_from_slice)
+
+    def _get_most_recent_record(
+        self,
+        current_most_recent: Optional[Record],
+        current_record: Optional[Record],
+        stream_slice: StreamSlice,
+    ) -> Optional[Record]:
+        if self.cursor and current_record:
+            if not current_most_recent:
+                return current_record
+            else:
+                return (
+                    current_most_recent
+                    if self.cursor.is_greater_than_or_equal(current_most_recent, current_record)
+                    else current_record
+                )
+        else:
+            return None


### PR DESCRIPTION
## What

Add the ability for streams that define an AsyncRetriever and a DatetimeBasedCursor to perform periodic checkpointing when the date time window of a stream slice is synced successfully.

This is needed to unblock `source-amazon-seller-partner` which supports incremental async jobs.

## How

It's worth noting that this PR goes a bit in the opposite direction where we want to deprecate the existing `DatetimeBasedCursor` because now its more closely integrated into the `AsyncRetriever` stream slicing mechanism. However, due to the short time frame to deliver Amazon Seller Partner, trying to inject the `ConcurrentCursor` into the low-code `AsyncJobPartitionRouter` felt like the more difficult path.

The tradeoff in the short term here is that our Async + Incremental streams will run synchronously (worth noting that this was already the existing behavior based on how we construct the `concurrent_declarative_source.py`) So we incur a little bit of tech debt in exchange for simplicity to implement



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced async retriever functionality with improved cursor management
	- Added support for more flexible stream state handling in async data processing
	- Introduced new cursor-related methods for better stream slice management

- **Improvements**
	- Updated stream processing logic to handle different retriever types
	- Improved state tracking and record processing in async retrievers

- **Technical Enhancements**
	- Added new methods for cursor and record tracking
	- Expanded support for datetime-based cursors in partition routing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->