### PR TITLE
feat(low-code): add profile assertion flow to oauth authenticator component

### DIFF
--- a/airbyte_cdk/sources/declarative/auth/oauth.py
+++ b/airbyte_cdk/sources/declarative/auth/oauth.py
@@ -118,6 +118,11 @@ class DeclarativeOauth2Authenticator(AbstractOauth2Authenticator, DeclarativeAut
             if self.token_expiry_date
             else pendulum.now().subtract(days=1)  # type: ignore # substract does not have type hints
         )
+        self.use_profile_assertion = (
+            InterpolatedBoolean(self.use_profile_assertion, parameters=parameters)
+            if isinstance(self.use_profile_assertion, str)
+            else self.use_profile_assertion
+        )
         self.assertion_name = "assertion"
 
         if self.access_token_value is not None:

--- a/airbyte_cdk/sources/declarative/auth/oauth.py
+++ b/airbyte_cdk/sources/declarative/auth/oauth.py
@@ -79,11 +79,11 @@ class DeclarativeOauth2Authenticator(AbstractOauth2Authenticator, DeclarativeAut
         else:
             self._token_refresh_endpoint = None
         self._client_id_name = InterpolatedString.create(self.client_id_name, parameters=parameters)
-        self._client_id = InterpolatedString.create(self.client_id, parameters=parameters)
+        self._client_id = InterpolatedString.create(self.client_id, parameters=parameters) if self.client_id else self.client_id
         self._client_secret_name = InterpolatedString.create(
             self.client_secret_name, parameters=parameters
         )
-        self._client_secret = InterpolatedString.create(self.client_secret, parameters=parameters)
+        self._client_secret = InterpolatedString.create(self.client_secret, parameters=parameters) if self.client_secret else self.client_secret
         self._refresh_token_name = InterpolatedString.create(
             self.refresh_token_name, parameters=parameters
         )
@@ -171,19 +171,19 @@ class DeclarativeOauth2Authenticator(AbstractOauth2Authenticator, DeclarativeAut
         return self._client_id_name.eval(self.config)  # type: ignore # eval returns a string in this context
 
     def get_client_id(self) -> str:
-        client_id: str = self._client_id.eval(self.config)
+        client_id = self._client_id.eval(self.config) if self._client_id else self._client_id
         if not client_id:
             raise ValueError("OAuthAuthenticator was unable to evaluate client_id parameter")
-        return client_id
+        return client_id  # type: ignore # value will be returned as a string, or an error will be raised
 
     def get_client_secret_name(self) -> str:
         return self._client_secret_name.eval(self.config)  # type: ignore # eval returns a string in this context
 
     def get_client_secret(self) -> str:
-        client_secret: str = self._client_secret.eval(self.config)
+        client_secret = self._client_secret.eval(self.config) if self._client_secret else self._client_secret
         if not client_secret:
             raise ValueError("OAuthAuthenticator was unable to evaluate client_secret parameter")
-        return client_secret
+        return client_secret  # type: ignore # value will be returned as a string, or an error will be raised
 
     def get_refresh_token_name(self) -> str:
         return self._refresh_token_name.eval(self.config)  # type: ignore # eval returns a string in this context

--- a/airbyte_cdk/sources/declarative/auth/oauth.py
+++ b/airbyte_cdk/sources/declarative/auth/oauth.py
@@ -232,12 +232,12 @@ class DeclarativeOauth2Authenticator(AbstractOauth2Authenticator, DeclarativeAut
 
         Override to define additional parameters
         """
-        payload: MutableMapping[str, Any] = {
-            self.get_grant_type_name(): self.get_grant_type(),
-            self.get_assertion_name(): self.get_assertion(),
-        }
-
-        return payload if self.use_profile_assertion else super().build_refresh_request_body()
+        if self.use_profile_assertion:
+            return {
+                self.get_grant_type_name(): self.get_grant_type(),
+                self.get_assertion_name(): self.get_assertion(),
+            }
+        return super().build_refresh_request_body()
 
     @property
     def access_token(self) -> str:

--- a/airbyte_cdk/sources/declarative/auth/oauth.py
+++ b/airbyte_cdk/sources/declarative/auth/oauth.py
@@ -218,10 +218,12 @@ class DeclarativeOauth2Authenticator(AbstractOauth2Authenticator, DeclarativeAut
     def set_token_expiry_date(self, value: Union[str, int]) -> None:
         self._token_expiry_date = self._parse_token_expiration_date(value)
 
-    def get_assertion_name(self):
+    def get_assertion_name(self) -> str:
         return self.assertion_name
 
-    def get_assertion(self):
+    def get_assertion(self) -> str:
+        if self.profile_assertion is None:
+            raise ValueError("profile_assertion is not set")
         return self.profile_assertion.token
 
     def build_refresh_request_body(self) -> Mapping[str, Any]:

--- a/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -1058,8 +1058,6 @@ definitions:
     type: object
     required:
       - type
-      - client_id
-      - client_secret
     properties:
       type:
         type: string
@@ -1254,6 +1252,15 @@ definitions:
             default: []
             examples:
               - ["invalid_grant", "invalid_permissions"]
+      profile_assertion:
+        title: Profile Assertion
+        description: The authenticator being used to authenticate the client authenticator.
+        "$ref": "#/definitions/JwtAuthenticator"
+      use_profile_assertion:
+        title: Use Profile Assertion
+        description: Enable using profile assertion as a flow for OAuth authorization.
+        type: boolean
+        default: false
       $parameters:
         type: object
         additionalProperties: true

--- a/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
+++ b/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
@@ -496,8 +496,8 @@ class OAuthAuthenticator(BaseModel):
         examples=["custom_app_id"],
         title="Client ID Property Name",
     )
-    client_id: str = Field(
-        ...,
+    client_id: Optional[str] = Field(
+        None,
         description="The OAuth client ID. Fill it in the user inputs.",
         examples=["{{ config['client_id }}", "{{ config['credentials']['client_id }}"],
         title="Client ID",
@@ -508,8 +508,8 @@ class OAuthAuthenticator(BaseModel):
         examples=["custom_app_secret"],
         title="Client Secret Property Name",
     )
-    client_secret: str = Field(
-        ...,
+    client_secret: Optional[str] = Field(
+        None,
         description="The OAuth client secret. Fill it in the user inputs.",
         examples=[
             "{{ config['client_secret }}",
@@ -594,7 +594,9 @@ class OAuthAuthenticator(BaseModel):
     scopes: Optional[List[str]] = Field(
         None,
         description="List of scopes that should be granted to the access token.",
-        examples=[["crm.list.read", "crm.objects.contacts.read", "crm.schema.contacts.read"]],
+        examples=[
+            ["crm.list.read", "crm.objects.contacts.read", "crm.schema.contacts.read"]
+        ],
         title="Scopes",
     )
     token_expiry_date: Optional[str] = Field(
@@ -613,6 +615,16 @@ class OAuthAuthenticator(BaseModel):
         None,
         description="When the token updater is defined, new refresh tokens, access tokens and the access token expiry date are written back from the authentication response to the config object. This is important if the refresh token can only used once.",
         title="Token Updater",
+    )
+    profile_assertion: Optional[JwtAuthenticator] = Field(
+        None,
+        description="The authenticator being used to authenticate the client authenticator.",
+        title="Profile Assertion",
+    )
+    use_profile_assertion: Optional[bool] = Field(
+        False,
+        description="Enable using profile assertion as a flow for OAuth authorization.",
+        title="Use Profile Assertion",
     )
     parameters: Optional[Dict[str, Any]] = Field(None, alias="$parameters")
 
@@ -719,7 +731,7 @@ class HttpResponseFilter(BaseModel):
 class TypesMap(BaseModel):
     target_type: Union[str, List[str]]
     current_type: Union[str, List[str]]
-    condition: Optional[str]
+    condition: Optional[str] = None
 
 
 class SchemaTypeIdentifier(BaseModel):
@@ -797,14 +809,11 @@ class DpathFlattenFields(BaseModel):
     field_path: List[str] = Field(
         ...,
         description="A path to field that needs to be flattened.",
-        examples=[
-            ["data"],
-            ["data", "*", "field"],
-        ],
+        examples=[["data"], ["data", "*", "field"]],
         title="Field Path",
     )
     delete_origin_value: Optional[bool] = Field(
-        False,
+        None,
         description="Whether to delete the origin value or keep it. Default is False.",
         title="Delete Origin Value",
     )
@@ -1018,24 +1027,28 @@ class OAuthConfigSpecification(BaseModel):
     class Config:
         extra = Extra.allow
 
-    oauth_user_input_from_connector_config_specification: Optional[Dict[str, Any]] = Field(
-        None,
-        description="OAuth specific blob. This is a Json Schema used to validate Json configurations used as input to OAuth.\nMust be a valid non-nested JSON that refers to properties from ConnectorSpecification.connectionSpecification\nusing special annotation 'path_in_connector_config'.\nThese are input values the user is entering through the UI to authenticate to the connector, that might also shared\nas inputs for syncing data via the connector.\nExamples:\nif no connector values is shared during oauth flow, oauth_user_input_from_connector_config_specification=[]\nif connector values such as 'app_id' inside the top level are used to generate the API url for the oauth flow,\n  oauth_user_input_from_connector_config_specification={\n    app_id: {\n      type: string\n      path_in_connector_config: ['app_id']\n    }\n  }\nif connector values such as 'info.app_id' nested inside another object are used to generate the API url for the oauth flow,\n  oauth_user_input_from_connector_config_specification={\n    app_id: {\n      type: string\n      path_in_connector_config: ['info', 'app_id']\n    }\n  }",
-        examples=[
-            {"app_id": {"type": "string", "path_in_connector_config": ["app_id"]}},
-            {
-                "app_id": {
-                    "type": "string",
-                    "path_in_connector_config": ["info", "app_id"],
-                }
-            },
-        ],
-        title="OAuth user input",
+    oauth_user_input_from_connector_config_specification: Optional[Dict[str, Any]] = (
+        Field(
+            None,
+            description="OAuth specific blob. This is a Json Schema used to validate Json configurations used as input to OAuth.\nMust be a valid non-nested JSON that refers to properties from ConnectorSpecification.connectionSpecification\nusing special annotation 'path_in_connector_config'.\nThese are input values the user is entering through the UI to authenticate to the connector, that might also shared\nas inputs for syncing data via the connector.\nExamples:\nif no connector values is shared during oauth flow, oauth_user_input_from_connector_config_specification=[]\nif connector values such as 'app_id' inside the top level are used to generate the API url for the oauth flow,\n  oauth_user_input_from_connector_config_specification={\n    app_id: {\n      type: string\n      path_in_connector_config: ['app_id']\n    }\n  }\nif connector values such as 'info.app_id' nested inside another object are used to generate the API url for the oauth flow,\n  oauth_user_input_from_connector_config_specification={\n    app_id: {\n      type: string\n      path_in_connector_config: ['info', 'app_id']\n    }\n  }",
+            examples=[
+                {"app_id": {"type": "string", "path_in_connector_config": ["app_id"]}},
+                {
+                    "app_id": {
+                        "type": "string",
+                        "path_in_connector_config": ["info", "app_id"],
+                    }
+                },
+            ],
+            title="OAuth user input",
+        )
     )
-    oauth_connector_input_specification: Optional[OauthConnectorInputSpecification] = Field(
-        None,
-        description='The DeclarativeOAuth specific blob.\nPertains to the fields defined by the connector relating to the OAuth flow.\n\nInterpolation capabilities:\n- The variables placeholders are declared as `{{my_var}}`.\n- The nested resolution variables like `{{ {{my_nested_var}} }}` is allowed as well.\n\n- The allowed interpolation context is:\n  + base64Encoder - encode to `base64`, {{ {{my_var_a}}:{{my_var_b}} | base64Encoder }}\n  + base64Decorer - decode from `base64` encoded string, {{ {{my_string_variable_or_string_value}} | base64Decoder }}\n  + urlEncoder - encode the input string to URL-like format, {{ https://test.host.com/endpoint | urlEncoder}}\n  + urlDecorer - decode the input url-encoded string into text format, {{ urlDecoder:https%3A%2F%2Fairbyte.io | urlDecoder}}\n  + codeChallengeS256 - get the `codeChallenge` encoded value to provide additional data-provider specific authorisation values, {{ {{state_value}} | codeChallengeS256 }}\n\nExamples:\n  - The TikTok Marketing DeclarativeOAuth spec:\n  {\n    "oauth_connector_input_specification": {\n      "type": "object",\n      "additionalProperties": false,\n      "properties": {\n          "consent_url": "https://ads.tiktok.com/marketing_api/auth?{{client_id_key}}={{client_id_value}}&{{redirect_uri_key}}={{ {{redirect_uri_value}} | urlEncoder}}&{{state_key}}={{state_value}}",\n          "access_token_url": "https://business-api.tiktok.com/open_api/v1.3/oauth2/access_token/",\n          "access_token_params": {\n              "{{ auth_code_key }}": "{{ auth_code_value }}",\n              "{{ client_id_key }}": "{{ client_id_value }}",\n              "{{ client_secret_key }}": "{{ client_secret_value }}"\n          },\n          "access_token_headers": {\n              "Content-Type": "application/json",\n              "Accept": "application/json"\n          },\n          "extract_output": ["data.access_token"],\n          "client_id_key": "app_id",\n          "client_secret_key": "secret",\n          "auth_code_key": "auth_code"\n      }\n    }\n  }',
-        title="DeclarativeOAuth Connector Specification",
+    oauth_connector_input_specification: Optional[OauthConnectorInputSpecification] = (
+        Field(
+            None,
+            description='The DeclarativeOAuth specific blob.\nPertains to the fields defined by the connector relating to the OAuth flow.\n\nInterpolation capabilities:\n- The variables placeholders are declared as `{{my_var}}`.\n- The nested resolution variables like `{{ {{my_nested_var}} }}` is allowed as well.\n\n- The allowed interpolation context is:\n  + base64Encoder - encode to `base64`, {{ {{my_var_a}}:{{my_var_b}} | base64Encoder }}\n  + base64Decorer - decode from `base64` encoded string, {{ {{my_string_variable_or_string_value}} | base64Decoder }}\n  + urlEncoder - encode the input string to URL-like format, {{ https://test.host.com/endpoint | urlEncoder}}\n  + urlDecorer - decode the input url-encoded string into text format, {{ urlDecoder:https%3A%2F%2Fairbyte.io | urlDecoder}}\n  + codeChallengeS256 - get the `codeChallenge` encoded value to provide additional data-provider specific authorisation values, {{ {{state_value}} | codeChallengeS256 }}\n\nExamples:\n  - The TikTok Marketing DeclarativeOAuth spec:\n  {\n    "oauth_connector_input_specification": {\n      "type": "object",\n      "additionalProperties": false,\n      "properties": {\n          "consent_url": "https://ads.tiktok.com/marketing_api/auth?{{client_id_key}}={{client_id_value}}&{{redirect_uri_key}}={{ {{redirect_uri_value}} | urlEncoder}}&{{state_key}}={{state_value}}",\n          "access_token_url": "https://business-api.tiktok.com/open_api/v1.3/oauth2/access_token/",\n          "access_token_params": {\n              "{{ auth_code_key }}": "{{ auth_code_value }}",\n              "{{ client_id_key }}": "{{ client_id_value }}",\n              "{{ client_secret_key }}": "{{ client_secret_value }}"\n          },\n          "access_token_headers": {\n              "Content-Type": "application/json",\n              "Accept": "application/json"\n          },\n          "extract_output": ["data.access_token"],\n          "client_id_key": "app_id",\n          "client_secret_key": "secret",\n          "auth_code_key": "auth_code"\n      }\n    }\n  }',
+            title="DeclarativeOAuth Connector Specification",
+        )
     )
     complete_oauth_output_specification: Optional[Dict[str, Any]] = Field(
         None,
@@ -1053,7 +1066,9 @@ class OAuthConfigSpecification(BaseModel):
     complete_oauth_server_input_specification: Optional[Dict[str, Any]] = Field(
         None,
         description="OAuth specific blob. This is a Json Schema used to validate Json configurations persisted as Airbyte Server configurations.\nMust be a valid non-nested JSON describing additional fields configured by the Airbyte Instance or Workspace Admins to be used by the\nserver when completing an OAuth flow (typically exchanging an auth code for refresh token).\nExamples:\n    complete_oauth_server_input_specification={\n      client_id: {\n        type: string\n      },\n      client_secret: {\n        type: string\n      }\n    }",
-        examples=[{"client_id": {"type": "string"}, "client_secret": {"type": "string"}}],
+        examples=[
+            {"client_id": {"type": "string"}, "client_secret": {"type": "string"}}
+        ],
         title="OAuth input specification",
     )
     complete_oauth_server_output_specification: Optional[Dict[str, Any]] = Field(
@@ -1634,7 +1649,9 @@ class RecordSelector(BaseModel):
         description="Responsible for filtering records to be emitted by the Source.",
         title="Record Filter",
     )
-    schema_normalization: Optional[Union[SchemaNormalization, CustomSchemaNormalization]] = Field(
+    schema_normalization: Optional[
+        Union[SchemaNormalization, CustomSchemaNormalization]
+    ] = Field(
         SchemaNormalization.None_,
         description="Responsible for normalization according to the schema.",
         title="Schema Normalization",
@@ -1808,12 +1825,16 @@ class DeclarativeStream(BaseModel):
         description="Component used to coordinate how records are extracted across stream slices and request pages.",
         title="Retriever",
     )
-    incremental_sync: Optional[Union[CustomIncrementalSync, DatetimeBasedCursor]] = Field(
-        None,
-        description="Component used to fetch data incrementally based on a time field in the data.",
-        title="Incremental Sync",
+    incremental_sync: Optional[Union[CustomIncrementalSync, DatetimeBasedCursor]] = (
+        Field(
+            None,
+            description="Component used to fetch data incrementally based on a time field in the data.",
+            title="Incremental Sync",
+        )
     )
-    name: Optional[str] = Field("", description="The stream name.", example=["Users"], title="Name")
+    name: Optional[str] = Field(
+        "", description="The stream name.", example=["Users"], title="Name"
+    )
     primary_key: Optional[PrimaryKey] = Field(
         "", description="The primary key of the stream.", title="Primary Key"
     )
@@ -2085,7 +2106,11 @@ class SimpleRetriever(BaseModel):
             CustomPartitionRouter,
             ListPartitionRouter,
             SubstreamPartitionRouter,
-            List[Union[CustomPartitionRouter, ListPartitionRouter, SubstreamPartitionRouter]],
+            List[
+                Union[
+                    CustomPartitionRouter, ListPartitionRouter, SubstreamPartitionRouter
+                ]
+            ],
         ]
     ] = Field(
         [],
@@ -2129,7 +2154,9 @@ class AsyncRetriever(BaseModel):
     )
     download_extractor: Optional[
         Union[CustomRecordExtractor, DpathExtractor, ResponseToFileExtractor]
-    ] = Field(None, description="Responsible for fetching the records from provided urls.")
+    ] = Field(
+        None, description="Responsible for fetching the records from provided urls."
+    )
     creation_requester: Union[CustomRequester, HttpRequester] = Field(
         ...,
         description="Requester component that describes how to prepare HTTP requests to send to the source API to create the async server-side job.",
@@ -2163,7 +2190,11 @@ class AsyncRetriever(BaseModel):
             CustomPartitionRouter,
             ListPartitionRouter,
             SubstreamPartitionRouter,
-            List[Union[CustomPartitionRouter, ListPartitionRouter, SubstreamPartitionRouter]],
+            List[
+                Union[
+                    CustomPartitionRouter, ListPartitionRouter, SubstreamPartitionRouter
+                ]
+            ],
         ]
     ] = Field(
         [],
@@ -2231,10 +2262,12 @@ class DynamicDeclarativeStream(BaseModel):
     stream_template: DeclarativeStream = Field(
         ..., description="Reference to the stream template.", title="Stream Template"
     )
-    components_resolver: Union[HttpComponentsResolver, ConfigComponentsResolver] = Field(
-        ...,
-        description="Component resolve and populates stream templates with components values.",
-        title="Components Resolver",
+    components_resolver: Union[HttpComponentsResolver, ConfigComponentsResolver] = (
+        Field(
+            ...,
+            description="Component resolve and populates stream templates with components values.",
+            title="Components Resolver",
+        )
     )
 
 

--- a/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -2004,6 +2004,7 @@ class ModelToComponentFactory:
             parameters=model.parameters or {},
             message_repository=self._message_repository,
             profile_assertion=profile_assertion,
+            use_profile_assertion=model.use_profile_assertion,
         )
 
     def create_offset_increment(

--- a/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -1951,13 +1951,13 @@ class ModelToComponentFactory:
                 ).eval(config),
                 client_id=InterpolatedString.create(
                     model.client_id, parameters=model.parameters or {}
-                ).eval(config),
+                ).eval(config) if model.client_id else model.client_id,
                 client_secret_name=InterpolatedString.create(
                     model.client_secret_name or "client_secret", parameters=model.parameters or {}
                 ).eval(config),
                 client_secret=InterpolatedString.create(
                     model.client_secret, parameters=model.parameters or {}
-                ).eval(config),
+                ).eval(config) if model.client_secret else model.client_secret,
                 access_token_config_path=model.refresh_token_updater.access_token_config_path,
                 refresh_token_config_path=model.refresh_token_updater.refresh_token_config_path,
                 token_expiry_date_config_path=model.refresh_token_updater.token_expiry_date_config_path,

--- a/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -1925,6 +1925,8 @@ class ModelToComponentFactory:
     def create_oauth_authenticator(
         self, model: OAuthAuthenticatorModel, config: Config, **kwargs: Any
     ) -> DeclarativeOauth2Authenticator:
+        profile_assertion = self._create_component_from_model(model.profile_assertion, config=config) if model.profile_assertion else None
+
         if model.refresh_token_updater:
             # ignore type error because fixing it would have a lot of dependencies, revisit later
             return DeclarativeSingleUseRefreshTokenOauth2Authenticator(  # type: ignore
@@ -1997,6 +1999,7 @@ class ModelToComponentFactory:
             config=config,
             parameters=model.parameters or {},
             message_repository=self._message_repository,
+            profile_assertion=profile_assertion,
         )
 
     def create_offset_increment(

--- a/airbyte_cdk/sources/http_logger.py
+++ b/airbyte_cdk/sources/http_logger.py
@@ -45,7 +45,7 @@ def format_http_message(
         log_message["http"]["is_auxiliary"] = is_auxiliary  # type: ignore [index]
     if stream_name:
         log_message["airbyte_cdk"] = {"stream": {"name": stream_name}}
-    return log_message  # type: ignore [return-value]  # got "dict[str, object]", expected "dict[str, JsonType]"
+    return log_message  # type: ignore[return-value]  # got "dict[str, object]", expected "dict[str, JsonType]"
 
 
 def _normalize_body_string(body_str: Optional[Union[str, bytes]]) -> Optional[str]:

--- a/airbyte_cdk/sources/streams/http/requests_native_auth/oauth.py
+++ b/airbyte_cdk/sources/streams/http/requests_native_auth/oauth.py
@@ -95,16 +95,16 @@ class Oauth2Authenticator(AbstractOauth2Authenticator):
         return self._access_token_name
 
     def get_scopes(self) -> list[str]:
-        return self._scopes  # type: ignore [return-value]
+        return self._scopes  # type: ignore[return-value]
 
     def get_expires_in_name(self) -> str:
         return self._expires_in_name
 
     def get_refresh_request_body(self) -> Mapping[str, Any]:
-        return self._refresh_request_body  # type: ignore [return-value]
+        return self._refresh_request_body  # type: ignore[return-value]
 
     def get_refresh_request_headers(self) -> Mapping[str, Any]:
-        return self._refresh_request_headers  # type: ignore [return-value]
+        return self._refresh_request_headers  # type: ignore[return-value]
 
     def get_grant_type_name(self) -> str:
         return self._grant_type_name
@@ -128,11 +128,11 @@ class Oauth2Authenticator(AbstractOauth2Authenticator):
 
     @property
     def access_token(self) -> str:
-        return self._access_token  # type: ignore [return-value]
+        return self._access_token  # type: ignore[return-value]
 
     @access_token.setter
     def access_token(self, value: str) -> None:
-        self._access_token = value  # type: ignore [assignment]  # Incorrect type for assignment
+        self._access_token = value  # type: ignore[assignment]  # Incorrect type for assignment
 
 
 class SingleUseRefreshTokenOauth2Authenticator(Oauth2Authenticator):
@@ -192,15 +192,15 @@ class SingleUseRefreshTokenOauth2Authenticator(Oauth2Authenticator):
             message_repository (MessageRepository): the message repository used to emit logs on HTTP requests and control message on config update
         """
         self._client_id = (
-            client_id  # type: ignore [assignment]  # Incorrect type for assignment
+            client_id  # type: ignore[assignment]  # Incorrect type for assignment
             if client_id is not None
-            else dpath.get(connector_config, ("credentials", "client_id"))  # type: ignore [arg-type]
+            else dpath.get(connector_config, ("credentials", "client_id"))  # type: ignore[arg-type]
         )
         self._client_secret = (
-            client_secret  # type: ignore [assignment]  # Incorrect type for assignment
+            client_secret  # type: ignore[assignment]  # Incorrect type for assignment
             if client_secret is not None
             else dpath.get(
-                connector_config,  # type: ignore [arg-type]
+                connector_config,  # type: ignore[arg-type]
                 ("credentials", "client_secret"),
             )
         )
@@ -248,8 +248,8 @@ class SingleUseRefreshTokenOauth2Authenticator(Oauth2Authenticator):
 
     @property
     def access_token(self) -> str:
-        return dpath.get(  # type: ignore [return-value]
-            self._connector_config,  # type: ignore [arg-type]
+        return dpath.get(  # type: ignore[return-value]
+            self._connector_config,  # type: ignore[arg-type]
             self._access_token_config_path,
             default="",
         )
@@ -257,39 +257,39 @@ class SingleUseRefreshTokenOauth2Authenticator(Oauth2Authenticator):
     @access_token.setter
     def access_token(self, new_access_token: str) -> None:
         dpath.new(
-            self._connector_config,  # type: ignore [arg-type]
+            self._connector_config,  # type: ignore[arg-type]
             self._access_token_config_path,
             new_access_token,
         )
 
     def get_refresh_token(self) -> str:
-        return dpath.get(  # type: ignore [return-value]
-            self._connector_config,  # type: ignore [arg-type]
+        return dpath.get(  # type: ignore[return-value]
+            self._connector_config,  # type: ignore[arg-type]
             self._refresh_token_config_path,
             default="",
         )
 
     def set_refresh_token(self, new_refresh_token: str) -> None:
         dpath.new(
-            self._connector_config,  # type: ignore [arg-type]
+            self._connector_config,  # type: ignore[arg-type]
             self._refresh_token_config_path,
             new_refresh_token,
         )
 
     def get_token_expiry_date(self) -> pendulum.DateTime:
         expiry_date = dpath.get(
-            self._connector_config,  # type: ignore [arg-type]
+            self._connector_config,  # type: ignore[arg-type]
             self._token_expiry_date_config_path,
             default="",
         )
-        return pendulum.now().subtract(days=1) if expiry_date == "" else pendulum.parse(expiry_date)  # type: ignore [arg-type, return-value, no-untyped-call]
+        return pendulum.now().subtract(days=1) if expiry_date == "" else pendulum.parse(expiry_date)  # type: ignore[arg-type, return-value, no-untyped-call]
 
     def set_token_expiry_date(  # type: ignore[override]
         self,
         new_token_expiry_date: pendulum.DateTime,
     ) -> None:
         dpath.new(
-            self._connector_config,  # type: ignore [arg-type]
+            self._connector_config,  # type: ignore[arg-type]
             self._token_expiry_date_config_path,
             str(new_token_expiry_date),
         )
@@ -329,10 +329,10 @@ class SingleUseRefreshTokenOauth2Authenticator(Oauth2Authenticator):
             #  message directly in the console, this is needed
             if not isinstance(self._message_repository, NoopMessageRepository):
                 self._message_repository.emit_message(
-                    create_connector_config_control_message(self._connector_config)  # type: ignore [arg-type]
+                    create_connector_config_control_message(self._connector_config)  # type: ignore[arg-type]
                 )
             else:
-                emit_configuration_as_airbyte_control_message(self._connector_config)  # type: ignore [arg-type]
+                emit_configuration_as_airbyte_control_message(self._connector_config)  # type: ignore[arg-type]
         return self.access_token
 
     def refresh_access_token(  # type: ignore[override]  # Signature doesn't match base class

--- a/unit_tests/sources/declarative/auth/test_oauth.py
+++ b/unit_tests/sources/declarative/auth/test_oauth.py
@@ -481,7 +481,7 @@ class TestOauth2Authenticator:
 
 
 def mock_request(method, url, data, headers):
-    if url == "refresh_end":
+    if url == "https://refresh_endpoint.com":
         return resp
     raise Exception(
         f"Error while refreshing access token with request: {method}, {url}, {data}, {headers}"

--- a/unit_tests/sources/declarative/auth/test_oauth.py
+++ b/unit_tests/sources/declarative/auth/test_oauth.py
@@ -1,6 +1,8 @@
 #
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
+
+import json
 import base64
 import logging
 from unittest.mock import Mock
@@ -11,6 +13,8 @@ import pytest
 import requests
 from requests import Response
 
+from airbyte_cdk.test.mock_http import HttpMocker, HttpRequest, HttpResponse
+from airbyte_cdk.sources.declarative.auth.jwt import JwtAuthenticator
 from airbyte_cdk.sources.declarative.auth import DeclarativeOauth2Authenticator
 from airbyte_cdk.utils.airbyte_secrets_utils import filter_secrets
 
@@ -19,7 +23,7 @@ LOGGER = logging.getLogger(__name__)
 resp = Response()
 
 config = {
-    "refresh_endpoint": "refresh_end",
+    "refresh_endpoint": "https://refresh_endpoint.com",
     "client_id": "some_client_id",
     "client_secret": "some_client_secret",
     "token_expiry_date": pendulum.now().subtract(days=2).to_rfc3339_string(),
@@ -411,6 +415,39 @@ class TestOauth2Authenticator:
             token = oauth.get_access_token()
             assert "access_token" == token
             assert oauth.get_token_expiry_date() == pendulum.parse(next_day)
+
+    def test_profile_assertion(self, mocker):
+        with HttpMocker() as http_mocker:
+            jwt = JwtAuthenticator(
+                config={},
+                parameters={},
+                secret_key="test",
+                algorithm="HS256",
+                token_duration=1000,
+                typ="JWT",
+                iss="iss",
+            )
+
+            mocker.patch("airbyte_cdk.sources.declarative.auth.jwt.JwtAuthenticator.token", new_callable=lambda: "token")
+
+            oauth = DeclarativeOauth2Authenticator(
+                token_refresh_endpoint="https://refresh_endpoint.com/",
+                config=config,
+                parameters={},
+                profile_assertion=jwt,
+                use_profile_assertion=True,
+            )
+            http_mocker.post(
+                HttpRequest(url="https://refresh_endpoint.com/", body="grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer&assertion=token"),
+                HttpResponse(body=json.dumps({"access_token": "access_token", "expires_in": 1000})),
+            )
+
+            token = oauth.refresh_access_token()
+
+        assert ("access_token", 1000) == token
+
+        filtered = filter_secrets("access_token")
+        assert filtered == "****"
 
     def test_error_handling(self, mocker):
         oauth = DeclarativeOauth2Authenticator(

--- a/unit_tests/sources/streams/http/requests_native_auth/test_requests_native_auth.py
+++ b/unit_tests/sources/streams/http/requests_native_auth/test_requests_native_auth.py
@@ -203,7 +203,7 @@ class TestOauth2Authenticator:
         """
         scopes = ["scope1", "scope2"]
         oauth = Oauth2Authenticator(
-            token_refresh_endpoint="refresh_end",
+            token_refresh_endpoint="https://refresh_endpoint.com",
             client_id_name="custom_client_id_key",
             client_id="some_client_id",
             client_secret_name="custom_client_secret_key",
@@ -234,7 +234,7 @@ class TestOauth2Authenticator:
 
     def test_refresh_access_token(self, mocker):
         oauth = Oauth2Authenticator(
-            token_refresh_endpoint="refresh_end",
+            token_refresh_endpoint="https://refresh_endpoint.com",
             client_id="some_client_id",
             client_secret="some_client_secret",
             refresh_token="some_refresh_token",
@@ -283,7 +283,7 @@ class TestOauth2Authenticator:
             "Content-Type": "application/x-www-form-urlencoded",
         }
         oauth = Oauth2Authenticator(
-            token_refresh_endpoint="refresh_end",
+            token_refresh_endpoint="https://refresh_endpoint.com",
             client_id="some_client_id",
             client_secret="some_client_secret",
             refresh_token="some_refresh_token",
@@ -329,7 +329,7 @@ class TestOauth2Authenticator:
         expected_token_expiry_date: pendulum.DateTime,
     ):
         oauth = Oauth2Authenticator(
-            token_refresh_endpoint="refresh_end",
+            token_refresh_endpoint="https://refresh_endpoint.com",
             client_id="some_client_id",
             client_secret="some_client_secret",
             refresh_token="some_refresh_token",

--- a/unit_tests/sources/streams/http/requests_native_auth/test_requests_native_auth.py
+++ b/unit_tests/sources/streams/http/requests_native_auth/test_requests_native_auth.py
@@ -619,7 +619,7 @@ class TestSingleUseRefreshTokenOauth2Authenticator:
 
 
 def mock_request(method, url, data, headers):
-    if url == "refresh_end":
+    if url == "https://refresh_endpoint.com":
         return resp
     raise Exception(
         f"Error while refreshing access token with request: {method}, {url}, {data}, {headers}"


### PR DESCRIPTION
## What 
To authenticate in some connectors like Google Sheets, we need to pass two-step authentication. Before requesting an access token, the user needs to generate a JWT to authenticate the access token request with it. This is described in RFC 7523 - https://datatracker.ietf.org/doc/html/rfc7523.

## How 
We have extended the current OAuth implementation with new fields (e.g. `profile_assertion`, `use_profile_assertion`) and methods to use OAuth JWT Assertion Profiles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced OAuth2 authentication with optional profile assertion support.
	- Added flexibility for client credentials configuration.
	- Introduced new methods for handling JWT-based token refresh.

- **Improvements**
	- Made `client_id` and `client_secret` optional.
	- Added support for conditional grant type configuration.
	- Improved error handling for authentication scenarios.

- **Tests**
	- Added new test coverage for profile assertion functionality.
	- Updated existing tests to enhance validation of refresh token scenarios.
	- Modified mock request behavior to reflect updated refresh endpoint URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->