### PR TITLE
docs: comments on what the `Dockerfile` is for

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # This Dockerfile is used to build `airbyte/source-declarative-manifest` image that in turn is used
-# to build Manifest-only connectors themselves, and is used to run manifest (Builder) connectors
+# 1. to build Manifest-only connectors themselves
 # published into a particular user's workspace in Airbyte.
 #
 # A new version of source-declarative-manifest is built for every new Airbyte CDK release, and their versions are kept in sync.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # This Dockerfile is used to build `airbyte/source-declarative-manifest` image that in turn is used
 # 1. to build Manifest-only connectors themselves
-# published into a particular user's workspace in Airbyte.
+# 2. to run manifest (Builder) connectors published into a particular user's workspace in Airbyte
 #
 # A new version of source-declarative-manifest is built for every new Airbyte CDK release, and their versions are kept in sync.
 #

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,10 @@
+# This Dockerfile is used to build `airbyte/source-declarative-manifest` image that in turn is used
+# to build Manifest-only connectors themselves, and is used to run manifest (Builder) connectors
+# published into a particular user's workspace in Airbyte.
+#
+# A new version of source-declarative-manifest is built for every new Airbyte CDK release, and their versions are kept in sync.
+#
+
 FROM docker.io/airbyte/python-connector-base:3.0.0@sha256:1a0845ff2b30eafa793c6eee4e8f4283c2e52e1bbd44eed6cb9e9abd5d34d844
 
 WORKDIR /airbyte/integration_code


### PR DESCRIPTION
@ChristoGrab if this is correct, let's merge it so newcomers are not panicking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Added descriptive comments to the Dockerfile explaining its purpose and functionality for the `airbyte/source-declarative-manifest` image.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->