### PR TITLE
feat: use create_concurrent_cursor_from_perpartition_cursor

### DIFF
--- a/airbyte_cdk/sources/declarative/concurrent_declarative_source.py
+++ b/airbyte_cdk/sources/declarative/concurrent_declarative_source.py
@@ -19,6 +19,7 @@ from airbyte_cdk.sources.declarative.extractors import RecordSelector
 from airbyte_cdk.sources.declarative.extractors.record_filter import (
     ClientSideIncrementalRecordFilterDecorator,
 )
+from airbyte_cdk.sources.declarative.incremental import ConcurrentPerPartitionCursor
 from airbyte_cdk.sources.declarative.incremental.datetime_based_cursor import DatetimeBasedCursor
 from airbyte_cdk.sources.declarative.incremental.per_partition_with_global import (
     PerPartitionWithGlobalCursor,
@@ -231,7 +232,7 @@ class ConcurrentDeclarativeSource(ManifestDeclarativeSource, Generic[TState]):
                     ):
                         cursor = declarative_stream.retriever.stream_slicer.stream_slicer
 
-                        if not isinstance(cursor, ConcurrentCursor):
+                        if not isinstance(cursor, ConcurrentCursor | ConcurrentPerPartitionCursor):
                             # This should never happen since we instantiate ConcurrentCursor in
                             # model_to_component_factory.py
                             raise ValueError(

--- a/airbyte_cdk/sources/declarative/declarative_stream.py
+++ b/airbyte_cdk/sources/declarative/declarative_stream.py
@@ -6,6 +6,7 @@ from dataclasses import InitVar, dataclass, field
 from typing import Any, Iterable, List, Mapping, MutableMapping, Optional, Union
 
 from airbyte_cdk.models import SyncMode
+from airbyte_cdk.sources.declarative.async_job.job_orchestrator import AsyncPartition
 from airbyte_cdk.sources.declarative.incremental import (
     GlobalSubstreamCursor,
     PerPartitionCursor,
@@ -145,7 +146,7 @@ class DeclarativeStream(Stream):
             # As part of the declarative model with custom components, a user that would return a `None` slice would now have the default
             # empty slice which seems to make sense.
             stream_slice = StreamSlice(partition={}, cursor_slice={})
-        if not isinstance(stream_slice, StreamSlice):
+        if not isinstance(stream_slice, StreamSlice | AsyncPartition):
             raise ValueError(
                 f"DeclarativeStream does not support stream_slices that are not StreamSlice. Got {stream_slice}"
             )

--- a/airbyte_cdk/sources/declarative/incremental/concurrent_partition_cursor.py
+++ b/airbyte_cdk/sources/declarative/incremental/concurrent_partition_cursor.py
@@ -11,6 +11,7 @@ from datetime import timedelta
 from typing import Any, Callable, Iterable, Mapping, MutableMapping, Optional
 
 from airbyte_cdk.sources.connector_state_manager import ConnectorStateManager
+from airbyte_cdk.sources.declarative.async_job.job_orchestrator import AsyncPartition
 from airbyte_cdk.sources.declarative.incremental.global_substream_cursor import (
     Timer,
     iterate_with_last_flag_and_state,
@@ -325,7 +326,11 @@ class ConcurrentPerPartitionCursor(Cursor):
                 "Invalid state as stream slices that are emitted should refer to an existing cursor"
             )
         self._cursor_per_partition[
-            self._to_partition_key(record.associated_slice.partition)
+            self._to_partition_key(
+                record.associated_slice.stream_slice.partition
+                if isinstance(record.associated_slice, AsyncPartition)
+                else record.associated_slice.partition
+            )
         ].observe(record)
 
     def _to_partition_key(self, partition: Mapping[str, Any]) -> str:

--- a/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -1631,7 +1631,7 @@ class ModelToComponentFactory:
     ) -> Optional[PartitionRouter]:
         if (
             hasattr(model, "partition_router")
-            and isinstance(model, SimpleRetrieverModel)
+            and isinstance(model, SimpleRetrieverModel | AsyncRetrieverModel)
             and model.partition_router
         ):
             stream_slicer_model = model.partition_router
@@ -1665,6 +1665,31 @@ class ModelToComponentFactory:
         stream_slicer = self._build_stream_slicer_from_partition_router(model.retriever, config)
 
         if model.incremental_sync and stream_slicer:
+            if model.retriever.type == "AsyncRetriever":
+                if model.incremental_sync.type != "DatetimeBasedCursor":
+                    # We are currently in a transition to the Concurrent CDK and AsyncRetriever can only work with the support or unordered slices (for example, when we trigger reports for January and February, the report in February can be completed first). Once we have support for custom concurrent cursor or have a new implementation available in the CDK, we can enable more cursors here.
+                    raise ValueError(
+                        "AsyncRetriever with cursor other than DatetimeBasedCursor is not supported yet"
+                    )
+                if stream_slicer:
+                    return self.create_concurrent_cursor_from_perpartition_cursor(
+                        state_manager=self._connector_state_manager,
+                        model_type=DatetimeBasedCursorModel,
+                        component_definition=model.incremental_sync.__dict__,
+                        stream_name=model.name or "",
+                        stream_namespace=None,
+                        config=config or {},
+                        stream_state={},
+                        partition_router=stream_slicer,
+                    )
+                return self.create_concurrent_cursor_from_datetime_based_cursor(  # type: ignore # This is a known issue that we are creating and returning a ConcurrentCursor which does not technically implement the (low-code) StreamSlicer. However, (low-code) StreamSlicer and ConcurrentCursor both implement StreamSlicer.stream_slices() which is the primary method needed for checkpointing
+                    model_type=DatetimeBasedCursorModel,
+                    component_definition=model.incremental_sync.__dict__,
+                    stream_name=model.name or "",
+                    stream_namespace=None,
+                    config=config or {},
+                )
+
             incremental_sync_model = model.incremental_sync
             if (
                 hasattr(incremental_sync_model, "global_substream_cursor")

--- a/airbyte_cdk/sources/declarative/partition_routers/async_job_partition_router.py
+++ b/airbyte_cdk/sources/declarative/partition_routers/async_job_partition_router.py
@@ -41,11 +41,12 @@ class AsyncJobPartitionRouter(StreamSlicer):
         self._job_orchestrator = self._job_orchestrator_factory(slices)
 
         for completed_partition in self._job_orchestrator.create_and_get_completed_partitions():
-            yield StreamSlice(
-                partition=dict(completed_partition.stream_slice.partition)
-                | {"partition": completed_partition},
-                cursor_slice=completed_partition.stream_slice.cursor_slice,
-            )
+            yield completed_partition
+            # yield StreamSlice(
+            #     partition=dict(completed_partition.stream_slice.partition)
+            #     cursor_slice=completed_partition.stream_slice.cursor_slice,
+            # extra_fields={"jobs": completed_partition.jobs},
+            # )
 
     def fetch_records(self, partition: AsyncPartition) -> Iterable[Mapping[str, Any]]:
         """

--- a/unit_tests/sources/declarative/partition_routers/test_async_job_partition_router.py
+++ b/unit_tests/sources/declarative/partition_routers/test_async_job_partition_router.py
@@ -35,7 +35,7 @@ def test_stream_slices_with_single_partition_router():
 
     slices = list(partition_router.stream_slices())
     assert len(slices) == 1
-    partition = slices[0].partition.get("partition")
+    partition = slices[0]
     assert isinstance(partition, AsyncPartition)
     assert partition.stream_slice == StreamSlice(partition={}, cursor_slice={})
     assert partition.status == AsyncJobStatus.COMPLETED
@@ -68,7 +68,6 @@ def test_stream_slices_with_parent_slicer():
     slices = list(partition_router.stream_slices())
     assert len(slices) == 3
     for i, partition in enumerate(slices):
-        partition = partition.partition.get("partition")
         assert isinstance(partition, AsyncPartition)
         assert partition.stream_slice == StreamSlice(
             partition={"parent_id": str(i)}, cursor_slice={}


### PR DESCRIPTION
## What

resolving https://github.com/airbytehq/airbyte/pull/48449

## How

add concurrent_cursor_from_perpartition_cursor to asyncretriever

## User Impact
No impact is expected. This is not a breaking change. 
