### PR TITLE
ci: skip py3.12 in test matrix

### DIFF
--- a/.github/workflows/pytest_matrix.yml
+++ b/.github/workflows/pytest_matrix.yml
@@ -30,7 +30,7 @@ jobs:
         python-version: [
             "3.10",
             "3.11",
-            "3.12",
+            # "3.12",  # `requests-cache` blocker: https://github.com/airbytehq/airbyte-python-cdk/issues/299
           ]
         os: [
             Ubuntu,


### PR DESCRIPTION
- https://github.com/airbytehq/airbyte-python-cdk/issues/299
- 