### PR TITLE
fix: Relocates `self._extract_slice_fields(stream_slice=stream_slice)` within conditional codeblock that uses it. 

### DIFF
--- a/airbyte_cdk/sources/streams/http/http.py
+++ b/airbyte_cdk/sources/streams/http/http.py
@@ -423,7 +423,6 @@ class HttpStream(Stream, CheckpointMixin, ABC):
         stream_slice: Optional[Mapping[str, Any]] = None,
         stream_state: Optional[Mapping[str, Any]] = None,
     ) -> Iterable[StreamData]:
-        partition, _, _ = self._extract_slice_fields(stream_slice=stream_slice)
 
         stream_state = stream_state or {}
         pagination_complete = False
@@ -438,6 +437,7 @@ class HttpStream(Stream, CheckpointMixin, ABC):
 
         cursor = self.get_cursor()
         if cursor and isinstance(cursor, SubstreamResumableFullRefreshCursor):
+            partition, _, _ = self._extract_slice_fields(stream_slice=stream_slice)
             # Substreams checkpoint state by marking an entire parent partition as completed so that on the subsequent attempt
             # after a failure, completed parents are skipped and the sync can make progress
             cursor.close_slice(StreamSlice(cursor_slice={}, partition=partition))

--- a/airbyte_cdk/sources/streams/http/http.py
+++ b/airbyte_cdk/sources/streams/http/http.py
@@ -423,7 +423,6 @@ class HttpStream(Stream, CheckpointMixin, ABC):
         stream_slice: Optional[Mapping[str, Any]] = None,
         stream_state: Optional[Mapping[str, Any]] = None,
     ) -> Iterable[StreamData]:
-
         stream_state = stream_state or {}
         pagination_complete = False
         next_page_token = None


### PR DESCRIPTION
## What
- Moves the invocation of self._extract_slice_fields within conditional code block
- Enables steams w/ custom stream slice implementations to still function properly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved stream pagination handling for more robust cursor management during data synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->