### PR TITLE
chore: use python 3.11 for connector tests in CI

### DIFF
--- a/.github/workflows/connector-tests.yml
+++ b/.github/workflows/connector-tests.yml
@@ -128,7 +128,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       # Create initial pending status for test report
       - name: Create Pending Test Report Status
         if: steps.no_changes.outputs.status != 'cancelled'

--- a/airbyte_cdk/sources/declarative/manifest_declarative_source.py
+++ b/airbyte_cdk/sources/declarative/manifest_declarative_source.py
@@ -78,6 +78,7 @@ class ManifestDeclarativeSource(DeclarativeSource):
         # For ease of use we don't require the type to be specified at the top level manifest, but it should be included during processing
         manifest = dict(source_config)
         if "type" not in manifest:
+            print("I AM NOT A REAL CHANGE. PLEASE DELETE ME BEFORE MERGING :)")
             manifest["type"] = "DeclarativeSource"
 
         # If custom components are needed, locate and/or register them.

--- a/airbyte_cdk/sources/declarative/manifest_declarative_source.py
+++ b/airbyte_cdk/sources/declarative/manifest_declarative_source.py
@@ -78,7 +78,6 @@ class ManifestDeclarativeSource(DeclarativeSource):
         # For ease of use we don't require the type to be specified at the top level manifest, but it should be included during processing
         manifest = dict(source_config)
         if "type" not in manifest:
-            print("I AM NOT A REAL CHANGE. PLEASE DELETE ME BEFORE MERGING :)")
             manifest["type"] = "DeclarativeSource"
 
         # If custom components are needed, locate and/or register them.


### PR DESCRIPTION
## What

We recently bumped airbyte-ci to version 3.11, but the connector tests workflow for this repo still uses 3.10, leading to failures on connector CAT runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the automated testing environment to use Python 3.11 for consistency and improved support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->