### PR TITLE
fix: (low code)run state migrations for concurrent streams

### DIFF
--- a/airbyte_cdk/sources/declarative/concurrent_declarative_source.py
+++ b/airbyte_cdk/sources/declarative/concurrent_declarative_source.py
@@ -3,7 +3,7 @@
 #
 
 import logging
-from typing import Any, Generic, Iterator, List, Mapping, Optional, Tuple, MutableMapping
+from typing import Any, Generic, Iterator, List, Mapping, MutableMapping, Optional, Tuple
 
 from airbyte_cdk.models import (
     AirbyteCatalog,

--- a/airbyte_cdk/sources/declarative/concurrent_declarative_source.py
+++ b/airbyte_cdk/sources/declarative/concurrent_declarative_source.py
@@ -3,7 +3,7 @@
 #
 
 import logging
-from typing import Any, Generic, Iterator, List, Mapping, Optional, Tuple
+from typing import Any, Generic, Iterator, List, Mapping, Optional, Tuple, MutableMapping
 
 from airbyte_cdk.models import (
     AirbyteCatalog,
@@ -224,10 +224,7 @@ class ConcurrentDeclarativeSource(ManifestDeclarativeSource, Generic[TState]):
                     stream_state = self._connector_state_manager.get_stream_state(
                         stream_name=declarative_stream.name, namespace=declarative_stream.namespace
                     )
-                    for state_migration in declarative_stream.state_migrations:
-                        if state_migration.should_migrate(stream_state):
-                            # The state variable is expected to be mutable but the migrate method returns an immutable mapping.
-                            stream_state = dict(state_migration.migrate(stream_state))
+                    stream_state = self._migrate_state(declarative_stream, stream_state)
 
                     retriever = self._get_retriever(declarative_stream, stream_state)
 
@@ -335,10 +332,7 @@ class ConcurrentDeclarativeSource(ManifestDeclarativeSource, Generic[TState]):
                     stream_state = self._connector_state_manager.get_stream_state(
                         stream_name=declarative_stream.name, namespace=declarative_stream.namespace
                     )
-                    for state_migration in declarative_stream.state_migrations:
-                        if state_migration.should_migrate(stream_state):
-                            # The state variable is expected to be mutable but the migrate method returns an immutable mapping.
-                            stream_state = dict(state_migration.migrate(stream_state))
+                    stream_state = self._migrate_state(declarative_stream, stream_state)
 
                     partition_router = declarative_stream.retriever.stream_slicer._partition_router
 
@@ -530,3 +524,14 @@ class ConcurrentDeclarativeSource(ManifestDeclarativeSource, Generic[TState]):
                 if stream.stream.name not in concurrent_stream_names
             ]
         )
+
+    @staticmethod
+    def _migrate_state(
+        declarative_stream: DeclarativeStream, stream_state: MutableMapping[str, Any]
+    ) -> MutableMapping[str, Any]:
+        for state_migration in declarative_stream.state_migrations:
+            if state_migration.should_migrate(stream_state):
+                # The state variable is expected to be mutable but the migrate method returns an immutable mapping.
+                stream_state = dict(state_migration.migrate(stream_state))
+
+        return stream_state

--- a/airbyte_cdk/sources/declarative/concurrent_declarative_source.py
+++ b/airbyte_cdk/sources/declarative/concurrent_declarative_source.py
@@ -226,7 +226,8 @@ class ConcurrentDeclarativeSource(ManifestDeclarativeSource, Generic[TState]):
                     )
                     for state_migration in declarative_stream.state_migrations:
                         if state_migration.should_migrate(stream_state):
-                            stream_state = state_migration.migrate(stream_state)
+                            # The state variable is expected to be mutable but the migrate method returns an immutable mapping.
+                            stream_state = dict(state_migration.migrate(stream_state))
 
                     retriever = self._get_retriever(declarative_stream, stream_state)
 
@@ -336,7 +337,8 @@ class ConcurrentDeclarativeSource(ManifestDeclarativeSource, Generic[TState]):
                     )
                     for state_migration in declarative_stream.state_migrations:
                         if state_migration.should_migrate(stream_state):
-                            stream_state = state_migration.migrate(stream_state)
+                            # The state variable is expected to be mutable but the migrate method returns an immutable mapping.
+                            stream_state = dict(state_migration.migrate(stream_state))
 
                     partition_router = declarative_stream.retriever.stream_slicer._partition_router
 

--- a/airbyte_cdk/sources/declarative/concurrent_declarative_source.py
+++ b/airbyte_cdk/sources/declarative/concurrent_declarative_source.py
@@ -224,6 +224,9 @@ class ConcurrentDeclarativeSource(ManifestDeclarativeSource, Generic[TState]):
                     stream_state = self._connector_state_manager.get_stream_state(
                         stream_name=declarative_stream.name, namespace=declarative_stream.namespace
                     )
+                    for state_migration in declarative_stream.state_migrations:
+                        if state_migration.should_migrate(stream_state):
+                            stream_state = state_migration.migrate(stream_state)
 
                     retriever = self._get_retriever(declarative_stream, stream_state)
 
@@ -331,6 +334,10 @@ class ConcurrentDeclarativeSource(ManifestDeclarativeSource, Generic[TState]):
                     stream_state = self._connector_state_manager.get_stream_state(
                         stream_name=declarative_stream.name, namespace=declarative_stream.namespace
                     )
+                    for state_migration in declarative_stream.state_migrations:
+                        if state_migration.should_migrate(stream_state):
+                            stream_state = state_migration.migrate(stream_state)
+
                     partition_router = declarative_stream.retriever.stream_slicer._partition_router
 
                     perpartition_cursor = (

--- a/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -936,7 +936,7 @@ class ModelToComponentFactory:
 
     @staticmethod
     def apply_stream_state_migrations(
-        stream_state_migrations: List[Any], stream_state: MutableMapping[str, Any]
+        stream_state_migrations: List[Any] | None, stream_state: MutableMapping[str, Any]
     ) -> MutableMapping[str, Any]:
         if stream_state_migrations:
             for state_migration in stream_state_migrations:

--- a/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -1247,6 +1247,12 @@ class ModelToComponentFactory:
             )
         )
 
+        if stream_state_migrations:
+            for state_migration in stream_state_migrations:
+                if state_migration.should_migrate(stream_state):
+                    # The state variable is expected to be mutable but the migrate method returns an immutable mapping.
+                    stream_state = dict(state_migration.migrate(stream_state))
+
         # Return the concurrent cursor and state converter
         return ConcurrentPerPartitionCursor(
             cursor_factory=cursor_factory,

--- a/unit_tests/sources/declarative/custom_state_migration.py
+++ b/unit_tests/sources/declarative/custom_state_migration.py
@@ -1,0 +1,47 @@
+#
+# Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+#
+
+from typing import Any, Mapping
+
+from airbyte_cdk.sources.declarative.declarative_stream import DeclarativeStream
+from airbyte_cdk.sources.declarative.interpolation.interpolated_string import InterpolatedString
+from airbyte_cdk.sources.declarative.migrations.state_migration import StateMigration
+from airbyte_cdk.sources.types import Config
+
+
+class CustomStateMigration(StateMigration):
+    declarative_stream: DeclarativeStream
+    config: Config
+
+    def __init__(self, declarative_stream: DeclarativeStream, config: Config):
+        self._config = config
+        self.declarative_stream = declarative_stream
+        self._cursor = declarative_stream.incremental_sync
+        self._parameters = declarative_stream.parameters
+        self._cursor_field = InterpolatedString.create(
+            self._cursor.cursor_field, parameters=self._parameters
+        ).eval(self._config)
+
+    def should_migrate(self, stream_state: Mapping[str, Any]) -> bool:
+        return True
+
+    def migrate(self, stream_state: Mapping[str, Any]) -> Mapping[str, Any]:
+        if not self.should_migrate(stream_state):
+            return stream_state
+        updated_at = stream_state[self._cursor.cursor_field]
+
+        migrated_stream_state = {
+            "states": [
+                {
+                    "partition": {"type": "type_1"},
+                    "cursor": {self._cursor.cursor_field: updated_at},
+                },
+                {
+                    "partition": {"type": "type_2"},
+                    "cursor": {self._cursor.cursor_field: updated_at},
+                },
+            ]
+        }
+
+        return migrated_stream_state

--- a/unit_tests/sources/declarative/parsers/test_model_to_component_factory.py
+++ b/unit_tests/sources/declarative/parsers/test_model_to_component_factory.py
@@ -3339,6 +3339,68 @@ def test_create_concurrent_cursor_from_datetime_based_cursor_runs_state_migratio
     ]
 
 
+def test_create_concurrent_cursor_from_perpartition_cursor_runs_state_migrations():
+    class DummyStateMigration:
+        def should_migrate(self, stream_state: Mapping[str, Any]) -> bool:
+            return True
+
+        def migrate(self, stream_state: Mapping[str, Any]) -> Mapping[str, Any]:
+            stream_state["lookback_window"] = 10 * 2
+            return stream_state
+
+    state = {
+        "states": [
+            {
+                "partition": {"type": "typ_1"},
+                "cursor": {"updated_at": "2024-08-01T00:00:00.000000Z"},
+            }
+        ],
+        "state": {"updated_at": "2024-08-01T00:00:00.000000Z"},
+        "lookback_window": 10,
+        "parent_state": {"parent_test": {"last_updated": "2024-08-01T00:00:00.000000Z"}},
+    }
+    config = {
+        "start_time": "2024-08-01T00:00:00.000000Z",
+        "end_time": "2024-09-01T00:00:00.000000Z",
+    }
+    list_partition_router = ListPartitionRouter(
+        cursor_field="id",
+        values=["type_1", "type_2", "type_3"],
+        config=config,
+        parameters={},
+    )
+    connector_state_manager = ConnectorStateManager()
+    stream_name = "test"
+    cursor_component_definition = {
+        "type": "DatetimeBasedCursor",
+        "cursor_field": "updated_at",
+        "datetime_format": "%Y-%m-%dT%H:%M:%S.%fZ",
+        "start_datetime": "{{ config['start_time'] }}",
+        "end_datetime": "{{ config['end_time'] }}",
+        "partition_field_start": "custom_start",
+        "partition_field_end": "custom_end",
+        "step": "P10D",
+        "cursor_granularity": "PT0.000001S",
+        "lookback_window": "P3D",
+    }
+    connector_builder_factory = ModelToComponentFactory(emit_connector_builder_messages=True)
+    cursor = connector_builder_factory.create_concurrent_cursor_from_perpartition_cursor(
+        state_manager=connector_state_manager,
+        model_type=DatetimeBasedCursorModel,
+        component_definition=cursor_component_definition,
+        stream_name=stream_name,
+        stream_namespace=None,
+        config=config,
+        stream_state=state,
+        partition_router=list_partition_router,
+        stream_state_migrations=[DummyStateMigration()],
+    )
+    assert cursor.state["lookback_window"] != 10, "State migration wasn't called"
+    assert (
+        cursor.state["lookback_window"] == 20
+    ), "State migration was called, but actual state don't match expected"
+
+
 def test_create_concurrent_cursor_uses_min_max_datetime_format_if_defined():
     """
     Validates a special case for when the start_time.datetime_format and end_time.datetime_format are defined, the date to

--- a/unit_tests/sources/declarative/test_concurrent_declarative_source.py
+++ b/unit_tests/sources/declarative/test_concurrent_declarative_source.py
@@ -1373,15 +1373,13 @@ def test_concurrent_declarative_source_runs_state_migrations_provided_in_manifes
         source_config=manifest, config=_CONFIG, catalog=_CATALOG, state=state
     )
     concurrent_streams, synchronous_streams = source._group_streams(_CONFIG)
-    assert concurrent_streams[0].cursor.state != state_blob.__dict__
-    assert concurrent_streams[0].cursor.state == {
-        "lookback_window": 0,
-        "states": [
-            {"cursor": {"updated_at": "2024-08-21"}, "partition": {"type": "type_1"}},
-            {"cursor": {"updated_at": "2024-08-21"}, "partition": {"type": "type_2"}},
-        ],
-        "use_global_cursor": False,
-    }
+    assert (
+        concurrent_streams[0].cursor.state.get("state") != state_blob.__dict__
+    ), "State was not migrated."
+    assert concurrent_streams[0].cursor.state.get("states") == [
+        {"cursor": {"updated_at": "2024-08-21"}, "partition": {"type": "type_1"}},
+        {"cursor": {"updated_at": "2024-08-21"}, "partition": {"type": "type_2"}},
+    ], "State was migrated, but actual state don't match expected"
 
 
 @freezegun.freeze_time(_NOW)


### PR DESCRIPTION
### What
related to klaviyo campaigns stream to low code https://github.com/airbytehq/airbyte/pull/51551
Concurrent framework gets the stream_state from the state manager and not the DeclarativeStream, where state migrations are called.
### How
Added `state_migration.migrate(stream_state)` to the concurrent declarative source. Added unit test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced stream state management with automated migration to ensure consistent and up-to-date processing.
  - Introduced a new class for custom state migration, providing structured handling of stream states.
  - Added support for applying state migrations during cursor creation for improved flexibility.

- **Tests**
  - Added new tests to validate the state migration process, ensuring reliable data handling and improved system stability.
  - Introduced additional tests for state migrations during cursor creation from both datetime-based and per-partition streams.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->