### PR TITLE
feat(OAuth): allow for access_token without expiration from the API

### DIFF
--- a/airbyte_cdk/sources/declarative/auth/oauth.py
+++ b/airbyte_cdk/sources/declarative/auth/oauth.py
@@ -3,7 +3,7 @@
 #
 
 from dataclasses import InitVar, dataclass, field
-from datetime import timedelta
+from datetime import datetime, timedelta
 from typing import Any, List, Mapping, MutableMapping, Optional, Union
 
 from airbyte_cdk.sources.declarative.auth.declarative_authenticator import DeclarativeAuthenticator
@@ -232,7 +232,12 @@ class DeclarativeOauth2Authenticator(AbstractOauth2Authenticator, DeclarativeAut
         return self._refresh_request_headers.eval(self.config)
 
     def get_token_expiry_date(self) -> AirbyteDateTime:
+        if not self._has_access_token_been_initialized():
+            return AirbyteDateTime.from_datetime(datetime.min)
         return self._token_expiry_date  # type: ignore # _token_expiry_date is an AirbyteDateTime. It is never None despite what mypy thinks
+
+    def _has_access_token_been_initialized(self) -> bool:
+        return self._access_token is not None
 
     def set_token_expiry_date(self, value: Union[str, int]) -> None:
         self._token_expiry_date = self._parse_token_expiration_date(value)

--- a/airbyte_cdk/sources/streams/http/requests_native_auth/abstract_oauth.py
+++ b/airbyte_cdk/sources/streams/http/requests_native_auth/abstract_oauth.py
@@ -261,6 +261,9 @@ class AbstractOauth2Authenticator(AuthBase):
 
         :return: expiration datetime
         """
+        if not value and not self.token_has_expired():
+            # No expiry token was provided but the previous one is not expired so it's fine
+            return self.get_token_expiry_date()
 
         if self.token_expiry_is_time_of_expiration:
             if not self.token_expiry_date_format:

--- a/unit_tests/sources/declarative/auth/test_oauth.py
+++ b/unit_tests/sources/declarative/auth/test_oauth.py
@@ -301,6 +301,7 @@ class TestOauth2Authenticator:
             client_id="{{ config['client_id'] }}",
             client_secret="{{ config['client_secret'] }}",
             token_expiry_date=timestamp,
+            access_token_value="some_access_token",
             refresh_token="some_refresh_token",
             config={
                 "refresh_endpoint": "refresh_end",
@@ -312,6 +313,33 @@ class TestOauth2Authenticator:
         )
         assert isinstance(oauth._token_expiry_date, AirbyteDateTime)
         assert oauth.get_token_expiry_date() == ab_datetime_parse(expected_date)
+
+    def test_given_no_access_token_but_expiry_in_the_future_when_refresh_token_then_fetch_access_token(self) -> None:
+        expiry_date = ab_datetime_now().add(timedelta(days=1))
+        oauth = DeclarativeOauth2Authenticator(
+            token_refresh_endpoint="https://refresh_endpoint.com/",
+            client_id="some_client_id",
+            client_secret="some_client_secret",
+            token_expiry_date=expiry_date.isoformat(),
+            refresh_token="some_refresh_token",
+            config={},
+            parameters={},
+            grant_type="client",
+        )
+
+
+        with HttpMocker() as http_mocker:
+            http_mocker.post(
+                HttpRequest(
+                    url="https://refresh_endpoint.com/",
+                    body="grant_type=client&client_id=some_client_id&client_secret=some_client_secret&refresh_token=some_refresh_token",
+                ),
+                HttpResponse(body=json.dumps({"access_token": "new_access_token"})),
+            )
+            oauth.get_access_token()
+
+        assert oauth.access_token == "new_access_token"
+        assert oauth._token_expiry_date == expiry_date
 
     @pytest.mark.parametrize(
         "expires_in_response, token_expiry_date_format",

--- a/unit_tests/sources/declarative/auth/test_oauth.py
+++ b/unit_tests/sources/declarative/auth/test_oauth.py
@@ -314,7 +314,9 @@ class TestOauth2Authenticator:
         assert isinstance(oauth._token_expiry_date, AirbyteDateTime)
         assert oauth.get_token_expiry_date() == ab_datetime_parse(expected_date)
 
-    def test_given_no_access_token_but_expiry_in_the_future_when_refresh_token_then_fetch_access_token(self) -> None:
+    def test_given_no_access_token_but_expiry_in_the_future_when_refresh_token_then_fetch_access_token(
+        self,
+    ) -> None:
         expiry_date = ab_datetime_now().add(timedelta(days=1))
         oauth = DeclarativeOauth2Authenticator(
             token_refresh_endpoint="https://refresh_endpoint.com/",
@@ -326,7 +328,6 @@ class TestOauth2Authenticator:
             parameters={},
             grant_type="client",
         )
-
 
         with HttpMocker() as http_mocker:
             http_mocker.post(


### PR DESCRIPTION
## What

See https://github.com/airbytehq/airbyte-enterprise/pull/82#discussion_r1943603994 for more details

## How

Allow for initializing an access_token while provided a date in the future for refresh.

Note that if the token_expiry_date is not far enough in the future, the connector might refresh the token on every call. It is the responsibility of the connector to put a date that is far enough in the future to avoid this.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**  
  - Enhanced the authentication flow to more reliably handle token expiration and refresh scenarios, ensuring smoother and more consistent access.  

- **Tests**  
  - Expanded test coverage to validate the improved token management, including scenarios with no access token but a future expiry date, helping maintain robust and dependable authentication behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->