### PR TITLE
feat(low-code): add default type to dynamic schema loader

### DIFF
--- a/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -2047,6 +2047,10 @@ definitions:
         type: array
         items:
           - "$ref": "#/definitions/TypesMap"
+      default_type:
+        title: Default Type
+        description: Default to be set if field type wasn't found in the types_mapping.
+        type: string
       $parameters:
         type: object
         additionalProperties: true

--- a/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
+++ b/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
@@ -812,6 +812,11 @@ class SchemaTypeIdentifier(BaseModel):
         title="Type Path",
     )
     types_mapping: Optional[List[TypesMap]] = None
+    default_type: Optional[str] = Field(
+        None,
+        description="Default to be set if field type wasn't found in the types_mapping.",
+        title="Default Type"
+    )
     parameters: Optional[Dict[str, Any]] = Field(None, alias="$parameters")
 
 

--- a/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -2050,6 +2050,7 @@ class ModelToComponentFactory:
             key_pointer=model_key_pointer,
             type_pointer=model_type_pointer,
             types_mapping=types_mapping,
+            default_type=model.default_type if model.default_type else None,
             parameters=model.parameters or {},
         )
 

--- a/airbyte_cdk/sources/declarative/schema/dynamic_schema_loader.py
+++ b/airbyte_cdk/sources/declarative/schema/dynamic_schema_loader.py
@@ -87,6 +87,7 @@ class SchemaTypeIdentifier:
     parameters: InitVar[Mapping[str, Any]]
     type_pointer: Optional[List[Union[InterpolatedString, str]]] = None
     types_mapping: Optional[List[TypesMap]] = None
+    default_type: Optional[str] = None
     schema_pointer: Optional[List[Union[InterpolatedString, str]]] = None
 
     def __post_init__(self, parameters: Mapping[str, Any]) -> None:
@@ -252,6 +253,8 @@ class DynamicSchemaLoader(SchemaLoader):
 
                 if field_type == types_map.current_type and condition:
                     return types_map.target_type
+        if self.schema_type_identifier.default_type and field_type not in AIRBYTE_DATA_TYPES:
+            return self.schema_type_identifier.default_type
         return field_type
 
     @staticmethod


### PR DESCRIPTION
### What
For source airtable we already have types mapping, but airtable also have types that "unknown" and python airtable version handled it as strings. but Dynamic Schema loader fails with value error if type of field not in airbyte types map or in schema identifier types map.
### How
Added `default_type` to `schema_type_identifier`, When provided default type will be used if field not it airbyte types map or in schema identifier types map.