### PR TITLE
chore: use certified source for manifest-only test

### DIFF
--- a/.github/workflows/connector-tests.yml
+++ b/.github/workflows/connector-tests.yml
@@ -88,7 +88,7 @@ jobs:
           #   cdk_extra: n/a
           # TODO: These are manifest connectors and won't work as expected until we
           #       add `--use-local-cdk` support for manifest connectors.
-          - connector: source-the-guardian-api
+          - connector: source-amplitude
             cdk_extra: n/a
           - connector: source-pokeapi
             cdk_extra: n/a


### PR DESCRIPTION
We expect source-the-guardian-api to be more flaky than source-amplitude as it is a community connector and source-amplitude is actually maintained as a certified connector.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated our automated testing setup by replacing an older connector with a more current integration.
  - Refined integration status notes to reflect reliability improvements without changing overall functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->