### PR TITLE
feat(HttpMocker): adding support for PUT requests and bytes responses

### DIFF
--- a/airbyte_cdk/test/mock_http/mocker.py
+++ b/airbyte_cdk/test/mock_http/mocker.py
@@ -99,9 +99,7 @@ class HttpMocker(contextlib.ContextDecorator):
     ) -> None:
         self._mock_request_method(SupportedHttpMethods.POST, request, responses)
 
-    def put(
-        self, request: HttpRequest, responses: Union[HttpResponse, List[HttpResponse]]
-    ) -> None:
+    def put(self, request: HttpRequest, responses: Union[HttpResponse, List[HttpResponse]]) -> None:
         self._mock_request_method(SupportedHttpMethods.PUT, request, responses)
 
     def delete(

--- a/airbyte_cdk/test/mock_http/mocker.py
+++ b/airbyte_cdk/test/mock_http/mocker.py
@@ -78,13 +78,17 @@ class HttpMocker(contextlib.ContextDecorator):
             additional_matcher=self._matches_wrapper(matcher),
             response_list=[
                 {
-                    "text" if isinstance(response.body, str) else "content": response.body,
+                    self._get_body_field(response): response.body,
                     "status_code": response.status_code,
                     "headers": response.headers,
                 }
                 for response in responses
             ],
         )
+
+    @staticmethod
+    def _get_body_field(response: HttpResponse) -> str:
+        return "text" if isinstance(response.body, str) else "content"
 
     def get(self, request: HttpRequest, responses: Union[HttpResponse, List[HttpResponse]]) -> None:
         self._mock_request_method(SupportedHttpMethods.GET, request, responses)

--- a/airbyte_cdk/test/mock_http/mocker.py
+++ b/airbyte_cdk/test/mock_http/mocker.py
@@ -17,6 +17,7 @@ class SupportedHttpMethods(str, Enum):
     GET = "get"
     PATCH = "patch"
     POST = "post"
+    PUT = "put"
     DELETE = "delete"
 
 
@@ -77,7 +78,7 @@ class HttpMocker(contextlib.ContextDecorator):
             additional_matcher=self._matches_wrapper(matcher),
             response_list=[
                 {
-                    "text": response.body,
+                    "text" if isinstance(response.body, str) else "content": response.body,
                     "status_code": response.status_code,
                     "headers": response.headers,
                 }
@@ -97,6 +98,11 @@ class HttpMocker(contextlib.ContextDecorator):
         self, request: HttpRequest, responses: Union[HttpResponse, List[HttpResponse]]
     ) -> None:
         self._mock_request_method(SupportedHttpMethods.POST, request, responses)
+
+    def put(
+        self, request: HttpRequest, responses: Union[HttpResponse, List[HttpResponse]]
+    ) -> None:
+        self._mock_request_method(SupportedHttpMethods.PUT, request, responses)
 
     def delete(
         self, request: HttpRequest, responses: Union[HttpResponse, List[HttpResponse]]

--- a/airbyte_cdk/test/mock_http/response.py
+++ b/airbyte_cdk/test/mock_http/response.py
@@ -6,7 +6,10 @@ from typing import Mapping, Union
 
 class HttpResponse:
     def __init__(
-        self, body: Union[str, bytes], status_code: int = 200, headers: Mapping[str, str] = MappingProxyType({})
+        self,
+        body: Union[str, bytes],
+        status_code: int = 200,
+        headers: Mapping[str, str] = MappingProxyType({}),
     ):
         self._body = body
         self._status_code = status_code

--- a/airbyte_cdk/test/mock_http/response.py
+++ b/airbyte_cdk/test/mock_http/response.py
@@ -1,19 +1,19 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 
 from types import MappingProxyType
-from typing import Mapping
+from typing import Mapping, Union
 
 
 class HttpResponse:
     def __init__(
-        self, body: str, status_code: int = 200, headers: Mapping[str, str] = MappingProxyType({})
+        self, body: Union[str, bytes], status_code: int = 200, headers: Mapping[str, str] = MappingProxyType({})
     ):
         self._body = body
         self._status_code = status_code
         self._headers = headers
 
     @property
-    def body(self) -> str:
+    def body(self) -> Union[str, bytes]:
         return self._body
 
     @property

--- a/unit_tests/test/mock_http/test_mocker.py
+++ b/unit_tests/test/mock_http/test_mocker.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
-
+import gzip
 from unittest import TestCase
 
 import pytest
@@ -74,6 +74,34 @@ class HttpMockerTest(TestCase):
 
         assert response.text == _A_RESPONSE_BODY
         assert response.status_code == 474
+
+    @HttpMocker()
+    def test_given_put_request_match_when_decorate_then_return_response(self, http_mocker):
+        http_mocker.put(
+            HttpRequest(_A_URL, _SOME_QUERY_PARAMS, _SOME_HEADERS, _SOME_REQUEST_BODY_STR),
+            HttpResponse(_A_RESPONSE_BODY, 474),
+        )
+
+        response = requests.put(
+            _A_URL, params=_SOME_QUERY_PARAMS, headers=_SOME_HEADERS, data=_SOME_REQUEST_BODY_STR
+        )
+
+        assert response.text == _A_RESPONSE_BODY
+        assert response.status_code == 474
+
+    @HttpMocker()
+    def test_given_response_in_bytes_when_decorate_then_match(self, http_mocker):
+        response_content = gzip.compress(bytes("This is the response within the gzip", "utf-8"))
+        http_mocker.put(
+            HttpRequest(_A_URL, _SOME_QUERY_PARAMS, _SOME_HEADERS, _SOME_REQUEST_BODY_STR),
+            HttpResponse(response_content, 474),
+        )
+
+        response = requests.put(
+            _A_URL, params=_SOME_QUERY_PARAMS, headers=_SOME_HEADERS, data=_SOME_REQUEST_BODY_STR
+        )
+
+        assert response.content == response_content
 
     @HttpMocker()
     def test_given_multiple_responses_when_decorate_get_request_then_return_response(


### PR DESCRIPTION
This is needed for the new destination we are currently implementing (the exact PR is not yet up but see https://github.com/airbytehq/airbyte-enterprise/pull/89 for more context)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for handling PUT requests to enhance HTTP interaction simulations.
  - Improved response handling by accommodating both text and binary data for enhanced flexibility.

- **Tests**
  - Expanded test coverage to validate PUT request support and ensure correct responses, including scenarios with compressed content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->