### PR TITLE
fix: update CDK migration for 6.34.0

### DIFF
--- a/cdk-migrations.md
+++ b/cdk-migrations.md
@@ -1,8 +1,8 @@
 # CDK Migration Guide
 
-## Upgrading to 6.X.X
+## Upgrading to 6.34.0
 
-Version 6.X.X of the CDK removes support for `stream_state` in the Jinja interpolation context. This change is breaking for any low-code connectors that use `stream_state` in the interpolation context.
+[Version 6.34.0](https://github.com/airbytehq/airbyte-python-cdk/releases/tag/v6.34.0) of the CDK removes support for `stream_state` in the Jinja interpolation context. This change is breaking for any low-code connectors that use `stream_state` in the interpolation context.
 
 The following components are impacted by this change:
 


### PR DESCRIPTION
## What
- Updated CDK migration to include correct version number (6.34.0) as well as add link to release for additional information.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the migration guide to clearly indicate the upgrade to version 6.34.0.
	- Clarified the breaking change regarding the removal of support for "stream_state" with recommendations to use "stream_interval".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->