### PR TITLE
feat(low-code cdk): add API Budget

### DIFF
--- a/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -1728,9 +1728,126 @@ definitions:
         description: Enables stream requests caching. This field is automatically set by the CDK.
         type: boolean
         default: false
+      api_budget:
+        title: API Budget
+        description: Defines the call rate policies for an APIs.
+        "$ref": "#/definitions/HttpApiBudget"
       $parameters:
         type: object
         additionalProperties: true
+  HttpApiBudget:
+    type: object
+    title: Http API Budget
+    required:
+      - type
+      - policy
+    properties:
+      type:
+        type: string
+        enum: [HttpApiBudget]
+      policy:
+        "$ref": "#/definitions/MovingWindowCallRatePolicy"
+      maximum_attempts_to_acquire:
+        type: integer
+        default: 100000
+      ratelimit_reset_header:
+        type: string
+        default: "ratelimit-reset"
+      ratelimit_remaining_header:
+        type: string
+        default: "ratelimit-remaining"
+      ratelimit_hit_status_codes:
+        type: array
+        items:
+          type: integer
+        default: [429]
+        examples:
+          - [400, 500]
+  MovingWindowCallRatePolicy:
+    type: object
+    title: Moving Window Call Rate Policy
+    required:
+      - type
+      - matcher
+      - rate
+    properties:
+      type:
+        type: string
+        enum: [MovingWindowCallRatePolicy]
+      matcher:
+        "$ref": "#/definitions/HttpRequestMatcher"
+      rate:
+        "$ref": "#/definitions/CallRateLimit"
+  HttpRequestMatcher:
+    type: object
+    title: Http Request Matcher
+    required:
+      - type
+      - http_method
+      - url
+    properties:
+      type:
+        type: string
+        enum: [HttpRequestMatcher]
+      url:
+        title: API URL
+        description: URL of the API source.
+        type: string
+        interpolation_context:
+          - config
+        examples:
+          - "https://connect.squareup.com/v2/events"
+          - "{{ config['base_url'] + '/names' or 'https://app.posthog.com'}}/api/names"
+      http_method:
+        title: HTTP Method
+        description: The HTTP method used to fetch data from the source (can be GET or POST).
+        type: string
+        enum:
+          - GET
+          - POST
+        default: GET
+        examples:
+          - GET
+          - POST
+      request_headers:
+        title: Request Headers
+        description: Return any non-auth headers. Authentication headers will overwrite any overlapping headers returned from this method.
+        anyOf:
+          - type: string
+          - type: object
+            additionalProperties:
+              type: string
+        examples:
+          - Output-Format: JSON
+      request_parameters:
+        title: Query Parameters
+        description: Specifies the query parameters that should be set on an outgoing HTTP request given the inputs.
+        anyOf:
+          - type: string
+          - type: object
+            additionalProperties:
+              type: string
+        examples:
+          - unit: "day"
+          - sort_by[asc]: updated_at
+  CallRateLimit:
+    type: object
+    title: Call RateLimit
+    required:
+      - type
+      - limit
+      - interval
+    properties:
+      type:
+        type: string
+        enum: [CallRateLimit]
+      limit:
+        type: integer
+      interval:
+        type: string
+        examples:
+          - "PT1H"
+          - "P1D"
   HttpResponseFilter:
     description: A filter that is used to select on properties of the HTTP response received. When used with additional filters, a response will be selected if it matches any of the filter's criteria.
     type: object

--- a/airbyte_cdk/sources/declarative/requesters/http_requester.py
+++ b/airbyte_cdk/sources/declarative/requesters/http_requester.py
@@ -22,6 +22,7 @@ from airbyte_cdk.sources.declarative.requesters.request_options.interpolated_req
 )
 from airbyte_cdk.sources.declarative.requesters.requester import HttpMethod, Requester
 from airbyte_cdk.sources.message import MessageRepository, NoopMessageRepository
+from airbyte_cdk.sources.streams.call_rate import AbstractAPIBudget
 from airbyte_cdk.sources.streams.http import HttpClient
 from airbyte_cdk.sources.streams.http.error_handlers import ErrorHandler
 from airbyte_cdk.sources.types import Config, StreamSlice, StreamState
@@ -55,6 +56,7 @@ class HttpRequester(Requester):
     http_method: Union[str, HttpMethod] = HttpMethod.GET
     request_options_provider: Optional[InterpolatedRequestOptionsProvider] = None
     error_handler: Optional[ErrorHandler] = None
+    api_budget: Optional[AbstractAPIBudget] = None
     disable_retries: bool = False
     message_repository: MessageRepository = NoopMessageRepository()
     use_cache: bool = False
@@ -91,6 +93,7 @@ class HttpRequester(Requester):
             name=self.name,
             logger=self.logger,
             error_handler=self.error_handler,
+            api_budget=self.api_budget,
             authenticator=self._authenticator,
             use_cache=self.use_cache,
             backoff_strategy=backoff_strategies,

--- a/airbyte_cdk/sources/streams/call_rate.py
+++ b/airbyte_cdk/sources/streams/call_rate.py
@@ -9,7 +9,7 @@ import logging
 import time
 from datetime import timedelta
 from threading import RLock
-from typing import TYPE_CHECKING, Any, Mapping, Optional
+from typing import TYPE_CHECKING, Any, Mapping, Optional, Union, Tuple, List
 from urllib import parse
 
 import requests
@@ -143,7 +143,7 @@ class HttpRequestMatcher(RequestMatcher):
             return False
 
         if self._method is not None:
-            if prepared_request.method != self._method:
+            if prepared_request.method.lower() != self._method.lower():
                 return False
         if self._url is not None and prepared_request.url is not None:
             url_without_params = prepared_request.url.split("?")[0]
@@ -496,7 +496,7 @@ class HttpAPIBudget(APIBudget):
         self,
         ratelimit_reset_header: str = "ratelimit-reset",
         ratelimit_remaining_header: str = "ratelimit-remaining",
-        status_codes_for_ratelimit_hit: tuple[int] = (429,),
+        status_codes_for_ratelimit_hit: Union[Tuple[int], List[int]] = (429,),
         **kwargs: Any,
     ):
         """Constructor

--- a/unit_tests/sources/declarative/requesters/test_api_budget.py
+++ b/unit_tests/sources/declarative/requesters/test_api_budget.py
@@ -1,0 +1,119 @@
+#
+# Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+#
+
+import logging
+from copy import deepcopy
+
+import json
+from unittest.mock import MagicMock
+from airbyte_cdk.sources.declarative.concurrent_declarative_source import ConcurrentDeclarativeSource
+from airbyte_cdk.sources.embedded.catalog import (
+    to_configured_catalog,
+    to_configured_stream,
+)
+from airbyte_cdk.test.mock_http import HttpMocker, HttpRequest, HttpResponse
+
+logger = logging.getLogger("test")
+
+_CONFIG = {"start_date": "2024-07-01T00:00:00.000Z"}
+
+_MANIFEST = {
+            "version": "6.7.0",
+            "streams": [
+                {
+                    "type": "DeclarativeStream",
+                    "$parameters": {
+                        "name": "items",
+                        "primary_key": "id",
+                        "url_base": "https://api.test.com",
+                    },
+                    "retriever": {
+                        "paginator": {
+                            "type": "DefaultPaginator",
+                            "page_token_option": {
+                                "type": "RequestOption",
+                                "inject_into": "request_parameter",
+                                "field_name": "page",
+                            },
+                            "pagination_strategy": {
+                                "type": "PageIncrement",
+                                "page_size": 1
+                            },
+                        },
+                        "requester": {
+                            "path": "/items",
+                            "authenticator": {
+                                "type": "BearerAuthenticator",
+                                "api_token": "{{ config.apikey }}",
+                            },
+                            "api_budget": {
+                                "type": "HttpApiBudget",
+                                "policy": {
+                                    "type": "MovingWindowCallRatePolicy",
+                                    "matcher": {
+                                            "type": "HttpRequestMatcher",
+                                            "http_method": "GET",
+                                            "url": "https://api.test.com/items"
+                                    },
+                                    "rate":
+                                        {
+                                            "type": "CallRateLimit",
+                                            "limit": 2,
+                                            "interval": "PT1S"
+                                        }
+                                }
+                            }
+                        },
+                        "record_selector": {"extractor": {"field_path": ["result"]}},
+                    },
+                }
+            ],
+            "check": {"type": "CheckStream", "stream_names": ["lists"]},
+        }
+
+
+def mock_http_requests(http_mocker):
+    """Helper function to mock HTTP requests and responses."""
+    base_url = "https://api.test.com/items"
+
+    http_mocker.get(
+        HttpRequest(url=base_url),
+        HttpResponse(body=json.dumps({"result": [{"id": 1, "name": "item_1"}, {"id": 2, "name": "item_2"}]})),
+    )
+
+    for page in range(1, 2):
+        http_mocker.get(
+            HttpRequest(url=f"{base_url}?page={page}"),
+            HttpResponse(body=json.dumps({"result": [
+                {"id": page + 1, "name": f"item_{page + 1}"},
+                {"id": page + 2, "name": f"item_{page + 2}"}
+            ]}))
+        )
+
+    http_mocker.get(
+        HttpRequest(url=f"{base_url}?page=2"),
+        HttpResponse(body=json.dumps({"result": []})),
+    )
+
+
+def test_declarative_api_budget(caplog):
+    manifest = deepcopy(_MANIFEST)
+
+    with HttpMocker() as http_mocker:
+        mock_http_requests(http_mocker)
+
+        source = ConcurrentDeclarativeSource(
+            source_config=manifest, config=_CONFIG, catalog=None, state=None
+        )
+
+        actual_catalog = source.discover(logger=source.logger, config=_CONFIG)
+        configured_streams = [
+            to_configured_stream(stream, primary_key=stream.source_defined_primary_key)
+            for stream in actual_catalog.streams
+        ]
+        configured_catalog = to_configured_catalog(configured_streams)
+
+        with caplog.at_level(logging.INFO):
+            list(source.read(MagicMock(), _CONFIG, configured_catalog))
+            assert "reached call limit" in caplog.text


### PR DESCRIPTION
## What 

The http client supports API budget handling for call rate limits. However, this is currently implemented only for HTTP streams. As a result, when migrating streams that use this approach, we may lose this functionality. This means the stream might not be fully migrated, potentially impacting its performance.

## How 

Add api budget support for http requester component

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced declarative configuration with options to manage API call budgets and enforce call rate limits using window-based policies.
  - Introduced refined criteria for matching HTTP requests, providing users with more control over API usage.
- **Refactor**
  - Improved consistency and clarity in configuration formatting and type definitions.
- **Tests**
  - Expanded test coverage to validate API budget enforcement and rate limiting functionality, ensuring robust performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->