### PR TITLE
fix: (CDK) (ConnectorBuilder) - Add `auxiliary requests` to slice; support `TestRead` for AsyncRetriever (part 1/2)

### DIFF
--- a/airbyte_cdk/connector_builder/models.py
+++ b/airbyte_cdk/connector_builder/models.py
@@ -22,6 +22,23 @@ class HttpRequest:
 
 
 @dataclass
+class LogMessage:
+    message: str
+    level: str
+    internal_message: Optional[str] = None
+    stacktrace: Optional[str] = None
+
+
+@dataclass
+class AuxiliaryRequest:
+    title: str
+    type: str
+    description: str
+    request: HttpRequest
+    response: HttpResponse
+
+
+@dataclass
 class StreamReadPages:
     records: List[object]
     request: Optional[HttpRequest] = None
@@ -33,22 +50,7 @@ class StreamReadSlices:
     pages: List[StreamReadPages]
     slice_descriptor: Optional[Dict[str, Any]]
     state: Optional[List[Dict[str, Any]]] = None
-
-
-@dataclass
-class LogMessage:
-    message: str
-    level: str
-    internal_message: Optional[str] = None
-    stacktrace: Optional[str] = None
-
-
-@dataclass
-class AuxiliaryRequest:
-    title: str
-    description: str
-    request: HttpRequest
-    response: HttpResponse
+    auxiliary_requests: Optional[List[AuxiliaryRequest]] = None
 
 
 @dataclass

--- a/airbyte_cdk/connector_builder/test_reader/helpers.py
+++ b/airbyte_cdk/connector_builder/test_reader/helpers.py
@@ -600,7 +600,7 @@ def handle_record_message(
 # -------
 
 
-def get_airbyte_cdk_from_message(json_message: Dict[str, JsonType]) -> dict:
+def get_airbyte_cdk_from_message(json_message: Dict[str, JsonType]) -> dict:  # type: ignore
     """
     Retrieves the "airbyte_cdk" dictionary from the provided JSON message.
 
@@ -626,7 +626,7 @@ def get_airbyte_cdk_from_message(json_message: Dict[str, JsonType]) -> dict:
     return airbyte_cdk
 
 
-def get_stream_from_airbyte_cdk(airbyte_cdk: dict) -> dict:
+def get_stream_from_airbyte_cdk(airbyte_cdk: dict) -> dict:  # type: ignore
     """
     Retrieves the "stream" dictionary from the provided "airbyte_cdk" dictionary.
 
@@ -651,14 +651,14 @@ def get_stream_from_airbyte_cdk(airbyte_cdk: dict) -> dict:
     return stream
 
 
-def get_auxiliary_request_title_prefix(stream: dict) -> str:
+def get_auxiliary_request_title_prefix(stream: dict) -> str:  # type: ignore
     """
     Generates a title prefix based on the stream type.
     """
     return "Parent stream: " if stream.get("is_substream", False) else ""
 
 
-def get_http_property_from_message(json_message: Dict[str, JsonType]) -> dict:
+def get_http_property_from_message(json_message: Dict[str, JsonType]) -> dict:  # type: ignore
     """
     Retrieves the "http" dictionary from the provided JSON message.
 
@@ -682,7 +682,7 @@ def get_http_property_from_message(json_message: Dict[str, JsonType]) -> dict:
     return http
 
 
-def get_auxiliary_request_type(stream: dict, http: dict) -> str:
+def get_auxiliary_request_type(stream: dict, http: dict) -> str:  # type: ignore
     """
     Determines the type of the auxiliary request based on the stream and HTTP properties.
     """

--- a/airbyte_cdk/connector_builder/test_reader/helpers.py
+++ b/airbyte_cdk/connector_builder/test_reader/helpers.py
@@ -28,7 +28,7 @@ from airbyte_cdk.utils.schema_inferrer import (
     SchemaInferrer,
 )
 
-from .types import LOG_MESSAGES_OUTPUT_TYPE
+from .types import ASYNC_AUXILIARY_REQUEST_TYPES, LOG_MESSAGES_OUTPUT_TYPE
 
 # -------
 # Parsers
@@ -226,7 +226,8 @@ def should_close_page(
         at_least_one_page_in_group
         and is_log_message(message)
         and (
-            is_page_http_request(json_message) or message.log.message.startswith("slice:")  # type: ignore[union-attr] # AirbyteMessage with MessageType.LOG has log.message
+            is_page_http_request(json_message)
+            or message.log.message.startswith(SliceLogger.SLICE_LOG_PREFIX)  # type: ignore[union-attr] # AirbyteMessage with MessageType.LOG has log.message
         )
     )
 
@@ -330,6 +331,10 @@ def is_auxiliary_http_request(message: Optional[Dict[str, Any]]) -> bool:
     return is_http_log(message) and message.get("http", {}).get("is_auxiliary", False)
 
 
+def is_async_auxiliary_request(message: AuxiliaryRequest) -> bool:
+    return message.type in ASYNC_AUXILIARY_REQUEST_TYPES
+
+
 def is_log_message(message: AirbyteMessage) -> bool:
     """
     Determines whether the provided message is of type LOG.
@@ -413,6 +418,7 @@ def handle_current_slice(
     current_slice_pages: List[StreamReadPages],
     current_slice_descriptor: Optional[Dict[str, Any]] = None,
     latest_state_message: Optional[Dict[str, Any]] = None,
+    auxiliary_requests: Optional[List[AuxiliaryRequest]] = None,
 ) -> StreamReadSlices:
     """
     Handles the current slice by packaging its pages, descriptor, and state into a StreamReadSlices instance.
@@ -421,6 +427,7 @@ def handle_current_slice(
         current_slice_pages (List[StreamReadPages]): The pages to be included in the slice.
         current_slice_descriptor (Optional[Dict[str, Any]]): Descriptor for the current slice, optional.
         latest_state_message (Optional[Dict[str, Any]]): The latest state message, optional.
+        auxiliary_requests (Optional[List[AuxiliaryRequest]]): The auxiliary requests to include, optional.
 
     Returns:
         StreamReadSlices: An object containing the current slice's pages, descriptor, and state.
@@ -429,6 +436,7 @@ def handle_current_slice(
         pages=current_slice_pages,
         slice_descriptor=current_slice_descriptor,
         state=[latest_state_message] if latest_state_message else [],
+        auxiliary_requests=auxiliary_requests if auxiliary_requests else [],
     )
 
 
@@ -486,29 +494,24 @@ def handle_auxiliary_request(json_message: Dict[str, JsonType]) -> AuxiliaryRequ
     Raises:
         ValueError: If any of the "airbyte_cdk", "stream", or "http" fields is not a dictionary.
     """
-    airbyte_cdk = json_message.get("airbyte_cdk", {})
 
-    if not isinstance(airbyte_cdk, dict):
-        raise ValueError(
-            f"Expected airbyte_cdk to be a dict, got {airbyte_cdk} of type {type(airbyte_cdk)}"
-        )
+    airbyte_cdk = get_airbyte_cdk_from_message(json_message)
+    stream = get_stream_from_airbyte_cdk(airbyte_cdk)
+    title_prefix = get_auxiliary_request_title_prefix(stream)
+    http = get_http_property_from_message(json_message)
+    request_type = get_auxiliary_request_type(stream, http)
 
-    stream = airbyte_cdk.get("stream", {})
-
-    if not isinstance(stream, dict):
-        raise ValueError(f"Expected stream to be a dict, got {stream} of type {type(stream)}")
-
-    title_prefix = "Parent stream: " if stream.get("is_substream", False) else ""
-    http = json_message.get("http", {})
-
-    if not isinstance(http, dict):
-        raise ValueError(f"Expected http to be a dict, got {http} of type {type(http)}")
+    title = title_prefix + str(http.get("title", None))
+    description = str(http.get("description", None))
+    request = create_request_from_log_message(json_message)
+    response = create_response_from_log_message(json_message)
 
     return AuxiliaryRequest(
-        title=title_prefix + str(http.get("title", None)),
-        description=str(http.get("description", None)),
-        request=create_request_from_log_message(json_message),
-        response=create_response_from_log_message(json_message),
+        title=title,
+        type=request_type,
+        description=description,
+        request=request,
+        response=response,
     )
 
 
@@ -558,7 +561,8 @@ def handle_log_message(
         at_least_one_page_in_group,
         current_page_request,
         current_page_response,
-        auxiliary_request or log_message,
+        auxiliary_request,
+        log_message,
     )
 
 
@@ -589,3 +593,97 @@ def handle_record_message(
         datetime_format_inferrer.accumulate(message.record)  # type: ignore
 
     return records_count
+
+
+# -------
+# Reusable Getters
+# -------
+
+
+def get_airbyte_cdk_from_message(json_message: Dict[str, JsonType]) -> dict:
+    """
+    Retrieves the "airbyte_cdk" dictionary from the provided JSON message.
+
+    This function validates that the extracted "airbyte_cdk" is of type dict,
+    raising a ValueError if the validation fails.
+
+    Parameters:
+        json_message (Dict[str, JsonType]): A dictionary representing the JSON message.
+
+    Returns:
+        dict: The "airbyte_cdk" dictionary extracted from the JSON message.
+
+    Raises:
+        ValueError: If the "airbyte_cdk" field is not a dictionary.
+    """
+    airbyte_cdk = json_message.get("airbyte_cdk", {})
+
+    if not isinstance(airbyte_cdk, dict):
+        raise ValueError(
+            f"Expected airbyte_cdk to be a dict, got {airbyte_cdk} of type {type(airbyte_cdk)}"
+        )
+
+    return airbyte_cdk
+
+
+def get_stream_from_airbyte_cdk(airbyte_cdk: dict) -> dict:
+    """
+    Retrieves the "stream" dictionary from the provided "airbyte_cdk" dictionary.
+
+    This function ensures that the extracted "stream" is of type dict,
+    raising a ValueError if the validation fails.
+
+    Parameters:
+        airbyte_cdk (dict): The dictionary representing the Airbyte CDK data.
+
+    Returns:
+        dict: The "stream" dictionary extracted from the Airbyte CDK data.
+
+    Raises:
+        ValueError: If the "stream" field is not a dictionary.
+    """
+
+    stream = airbyte_cdk.get("stream", {})
+
+    if not isinstance(stream, dict):
+        raise ValueError(f"Expected stream to be a dict, got {stream} of type {type(stream)}")
+
+    return stream
+
+
+def get_auxiliary_request_title_prefix(stream: dict) -> str:
+    """
+    Generates a title prefix based on the stream type.
+    """
+    return "Parent stream: " if stream.get("is_substream", False) else ""
+
+
+def get_http_property_from_message(json_message: Dict[str, JsonType]) -> dict:
+    """
+    Retrieves the "http" dictionary from the provided JSON message.
+
+    This function validates that the extracted "http" is of type dict,
+    raising a ValueError if the validation fails.
+
+    Parameters:
+        json_message (Dict[str, JsonType]): A dictionary representing the JSON message.
+
+    Returns:
+        dict: The "http" dictionary extracted from the JSON message.
+
+    Raises:
+        ValueError: If the "http" field is not a dictionary.
+    """
+    http = json_message.get("http", {})
+
+    if not isinstance(http, dict):
+        raise ValueError(f"Expected http to be a dict, got {http} of type {type(http)}")
+
+    return http
+
+
+def get_auxiliary_request_type(stream: dict, http: dict) -> str:
+    """
+    Determines the type of the auxiliary request based on the stream and HTTP properties.
+    """
+    return "PARENT_STREAM" if stream.get("is_substream", False) else str(http.get("type", None))

--- a/airbyte_cdk/connector_builder/test_reader/message_grouper.py
+++ b/airbyte_cdk/connector_builder/test_reader/message_grouper.py
@@ -91,7 +91,7 @@ def get_message_groups(
     current_page_request: Optional[HttpRequest] = None
     current_page_response: Optional[HttpResponse] = None
     latest_state_message: Optional[Dict[str, Any]] = None
-    slice_auxiliary_requests: Optional[List[AuxiliaryRequest]] = []
+    slice_auxiliary_requests: List[AuxiliaryRequest] = []
 
     while records_count < limit and (message := next(messages, None)):
         json_message = airbyte_message_to_json(message)

--- a/airbyte_cdk/connector_builder/test_reader/message_grouper.py
+++ b/airbyte_cdk/connector_builder/test_reader/message_grouper.py
@@ -6,6 +6,7 @@
 from typing import Any, Dict, Iterator, List, Mapping, Optional
 
 from airbyte_cdk.connector_builder.models import (
+    AuxiliaryRequest,
     HttpRequest,
     HttpResponse,
     StreamReadPages,
@@ -24,6 +25,7 @@ from .helpers import (
     handle_current_slice,
     handle_log_message,
     handle_record_message,
+    is_async_auxiliary_request,
     is_config_update_message,
     is_log_message,
     is_record_message,
@@ -89,6 +91,7 @@ def get_message_groups(
     current_page_request: Optional[HttpRequest] = None
     current_page_response: Optional[HttpResponse] = None
     latest_state_message: Optional[Dict[str, Any]] = None
+    slice_auxiliary_requests: Optional[List[AuxiliaryRequest]] = []
 
     while records_count < limit and (message := next(messages, None)):
         json_message = airbyte_message_to_json(message)
@@ -106,6 +109,7 @@ def get_message_groups(
                 current_slice_pages,
                 current_slice_descriptor,
                 latest_state_message,
+                slice_auxiliary_requests,
             )
             current_slice_descriptor = parse_slice_description(message.log.message)  # type: ignore
             current_slice_pages = []
@@ -118,7 +122,8 @@ def get_message_groups(
                 at_least_one_page_in_group,
                 current_page_request,
                 current_page_response,
-                log_or_auxiliary_request,
+                auxiliary_request,
+                log_message,
             ) = handle_log_message(
                 message,
                 json_message,
@@ -126,8 +131,15 @@ def get_message_groups(
                 current_page_request,
                 current_page_response,
             )
-            if log_or_auxiliary_request:
-                yield log_or_auxiliary_request
+
+            if auxiliary_request:
+                if is_async_auxiliary_request(auxiliary_request):
+                    slice_auxiliary_requests.append(auxiliary_request)
+                else:
+                    yield auxiliary_request
+
+            if log_message:
+                yield log_message
         elif is_trace_with_error(message):
             if message.trace is not None:
                 yield message.trace
@@ -157,4 +169,5 @@ def get_message_groups(
                 current_slice_pages,
                 current_slice_descriptor,
                 latest_state_message,
+                slice_auxiliary_requests,
             )

--- a/airbyte_cdk/connector_builder/test_reader/types.py
+++ b/airbyte_cdk/connector_builder/test_reader/types.py
@@ -71,5 +71,13 @@ LOG_MESSAGES_OUTPUT_TYPE = tuple[
     bool,
     HttpRequest | None,
     HttpResponse | None,
-    AuxiliaryRequest | AirbyteLogMessage | None,
+    AuxiliaryRequest | None,
+    AirbyteLogMessage | None,
+]
+
+ASYNC_AUXILIARY_REQUEST_TYPES = [
+    "ASYNC_CREATE",
+    "ASYNC_POLL",
+    "ASYNC_ABORT",
+    "ASYNC_DELETE",
 ]

--- a/airbyte_cdk/sources/declarative/auth/token_provider.py
+++ b/airbyte_cdk/sources/declarative/auth/token_provider.py
@@ -58,6 +58,7 @@ class SessionTokenProvider(TokenProvider):
                 "Obtains session token",
                 None,
                 is_auxiliary=True,
+                type="AUTH",
             ),
         )
         if response is None:

--- a/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -2627,6 +2627,47 @@ class ModelToComponentFactory:
         transformations: List[RecordTransformation],
         **kwargs: Any,
     ) -> AsyncRetriever:
+        def _get_download_retriever() -> SimpleRetrieverTestReadDecorator | SimpleRetriever:
+            record_selector = RecordSelector(
+                extractor=download_extractor,
+                name=name,
+                record_filter=None,
+                transformations=transformations,
+                schema_normalization=TypeTransformer(TransformConfig.NoTransform),
+                config=config,
+                parameters={},
+            )
+            paginator = (
+                self._create_component_from_model(
+                    model=model.download_paginator, decoder=decoder, config=config, url_base=""
+                )
+                if model.download_paginator
+                else NoPagination(parameters={})
+            )
+            maximum_number_of_slices = self._limit_slices_fetched or 5
+
+            if self._limit_slices_fetched or self._emit_connector_builder_messages:
+                return SimpleRetrieverTestReadDecorator(
+                    requester=download_requester,
+                    record_selector=record_selector,
+                    primary_key=None,
+                    name=job_download_components_name,
+                    paginator=paginator,
+                    config=config,
+                    parameters={},
+                    maximum_number_of_slices=maximum_number_of_slices,
+                )
+
+            return SimpleRetriever(
+                requester=download_requester,
+                record_selector=record_selector,
+                primary_key=None,
+                name=job_download_components_name,
+                paginator=paginator,
+                config=config,
+                parameters={},
+            )
+
         decoder = (
             self._create_component_from_model(model=model.decoder, config=config)
             if model.decoder
@@ -2680,29 +2721,7 @@ class ModelToComponentFactory:
             config=config,
             name=job_download_components_name,
         )
-        download_retriever = SimpleRetriever(
-            requester=download_requester,
-            record_selector=RecordSelector(
-                extractor=download_extractor,
-                name=name,
-                record_filter=None,
-                transformations=transformations,
-                schema_normalization=TypeTransformer(TransformConfig.NoTransform),
-                config=config,
-                parameters={},
-            ),
-            primary_key=None,
-            name=job_download_components_name,
-            paginator=(
-                self._create_component_from_model(
-                    model=model.download_paginator, decoder=decoder, config=config, url_base=""
-                )
-                if model.download_paginator
-                else NoPagination(parameters={})
-            ),
-            config=config,
-            parameters={},
-        )
+        download_retriever = _get_download_retriever()
         abort_requester = (
             self._create_component_from_model(
                 model=model.abort_requester,

--- a/airbyte_cdk/sources/http_logger.py
+++ b/airbyte_cdk/sources/http_logger.py
@@ -15,11 +15,14 @@ def format_http_message(
     description: str,
     stream_name: Optional[str],
     is_auxiliary: bool | None = None,
+    type: Optional[str] = None,
 ) -> LogMessage:
+    request_type: str = type if type else "HTTP"
     request = response.request
     log_message = {
         "http": {
             "title": title,
+            "type": request_type,
             "description": description,
             "request": {
                 "method": request.method,

--- a/airbyte_cdk/sources/streams/http/requests_native_auth/abstract_oauth.py
+++ b/airbyte_cdk/sources/streams/http/requests_native_auth/abstract_oauth.py
@@ -396,6 +396,7 @@ class AbstractOauth2Authenticator(AuthBase):
                     "Obtains access token",
                     self._NO_STREAM_NAME,
                     is_auxiliary=True,
+                    type="AUTH",
                 ),
             )
 

--- a/unit_tests/connector_builder/test_connector_builder_handler.py
+++ b/unit_tests/connector_builder/test_connector_builder_handler.py
@@ -537,6 +537,7 @@ def test_read():
                         "pages": [{"records": [real_record], "request": None, "response": None}],
                         "slice_descriptor": None,
                         "state": None,
+                        "auxiliary_requests": None,
                     }
                 ],
                 "test_read_limit_reached": False,

--- a/unit_tests/sources/test_http_logger.py
+++ b/unit_tests/sources/test_http_logger.py
@@ -65,6 +65,7 @@ EMPTY_RESPONSE = {"body": {"content": ""}, "headers": {}, "status_code": 100}
                 "airbyte_cdk": {"stream": {"name": A_STREAM_NAME}},
                 "http": {
                     "title": A_TITLE,
+                    "type": "HTTP",
                     "description": A_DESCRIPTION,
                     "request": {"method": "GET", "body": {"content": None}, "headers": {}},
                     "response": EMPTY_RESPONSE,
@@ -85,6 +86,7 @@ EMPTY_RESPONSE = {"body": {"content": ""}, "headers": {}, "status_code": 100}
                 "airbyte_cdk": {"stream": {"name": A_STREAM_NAME}},
                 "http": {
                     "title": A_TITLE,
+                    "type": "HTTP",
                     "description": A_DESCRIPTION,
                     "request": {
                         "method": "GET",
@@ -109,6 +111,7 @@ EMPTY_RESPONSE = {"body": {"content": ""}, "headers": {}, "status_code": 100}
                 "airbyte_cdk": {"stream": {"name": A_STREAM_NAME}},
                 "http": {
                     "title": A_TITLE,
+                    "type": "HTTP",
                     "description": A_DESCRIPTION,
                     "request": {"method": "GET", "body": {"content": None}, "headers": {}},
                     "response": EMPTY_RESPONSE,
@@ -129,6 +132,7 @@ EMPTY_RESPONSE = {"body": {"content": ""}, "headers": {}, "status_code": 100}
                 "airbyte_cdk": {"stream": {"name": A_STREAM_NAME}},
                 "http": {
                     "title": A_TITLE,
+                    "type": "HTTP",
                     "description": A_DESCRIPTION,
                     "request": {
                         "method": "GET",
@@ -153,6 +157,7 @@ EMPTY_RESPONSE = {"body": {"content": ""}, "headers": {}, "status_code": 100}
                 "airbyte_cdk": {"stream": {"name": A_STREAM_NAME}},
                 "http": {
                     "title": A_TITLE,
+                    "type": "HTTP",
                     "description": A_DESCRIPTION,
                     "request": {
                         "method": "GET",
@@ -181,6 +186,7 @@ EMPTY_RESPONSE = {"body": {"content": ""}, "headers": {}, "status_code": 100}
                 "airbyte_cdk": {"stream": {"name": A_STREAM_NAME}},
                 "http": {
                     "title": A_TITLE,
+                    "type": "HTTP",
                     "description": A_DESCRIPTION,
                     "request": {
                         "method": "GET",
@@ -208,6 +214,7 @@ EMPTY_RESPONSE = {"body": {"content": ""}, "headers": {}, "status_code": 100}
                 "airbyte_cdk": {"stream": {"name": A_STREAM_NAME}},
                 "http": {
                     "title": A_TITLE,
+                    "type": "HTTP",
                     "description": A_DESCRIPTION,
                     "request": {
                         "method": "POST",


### PR DESCRIPTION
## What
Resolving:
- https://github.com/airbytehq/airbyte-internal-issues/issues/11459 (1/2)
- [part 2/2](https://github.com/airbytehq/airbyte-platform-internal/pull/15324)

## How
This PR introduces several enhancements and refactorings:

- New Features:
   - Improved handling of async requests with enriched metadata in stream slices.
   - Added `auxiliary_requests` to `StreamReadSlices` to include auxiliary requests along with pages and states.
   - Upgraded logging for HTTP and authentication events, now clearly identifying request types.
   - Introduced new utility functions for extracting and processing message components.

- Refactor
   - Message Handling and Grouping: Streamlined handling and grouping of auxiliary and log messages for more consistent outputs.
   - Data Structure Refinement: Refined data structures to better support enhanced message processing.
Details
   - Modified existing functions to support the new auxiliary request handling.
   - Updated test cases to cover the new functionalities and changes.

## User Impact
No impact is expected, this is not a Breaking Change

## Loom Demo
- [Link](https://www.loom.com/share/cd7cb1bf7d3b435fae26f03f697b8ddd?sid=eaf01435-e1cb-4b43-84cd-575a9ff1fabb)

Before:
- no `auxiliary_requests` under the `slices`
```json
{
    "logs": [],
    "slices": [
        {
            "pages": [
                {
                    "records": [
                        {"example_record_csv": "value"},
                        {"more_record_examples_from_csv": "more_values"}
                    ],
                }
            ],
            "slice_descriptor": {},
            "state": []
        }
    ],
    "test_read_limit_reached": false,
    "auxiliary_requests": [],
    "inferred_schema": {},
    "inferred_datetime_formats": {}
}
```

After:
- the `auxiliary_requests` are now visible under the `slices` for each slice processed.
- the `pages` hold the result of the processed result data `url` for `COMPLETED` async job.
```json
{
    "logs": [],
    "slices": [
        {
            "pages": [
                {
                    "records": [
                        {"example_record_csv": "value"},
                        {"more_record_examples_from_csv": "more_values"}
                    ],
                    "request": {
                        "url": "https://some_link_to_download_the_file",
                        "headers": {
                            "User-Agent": "python-requests/2.32.3",
                            "Accept-Encoding": "gzip, deflate",
                            "Accept": "*/*",
                            "Connection": "keep-alive"
                        },
                        "http_method": "GET"
                    },
                    "response": {
                        "status": 200,
                        "body": "data_goes_here!",
                        "headers": {
                            "Content-Disposition": "attachment;filename=20207253_bb2314f1-b9ab-4876-ac48-366ae706a31e.csv",
                            "Content-Encoding": "x-gzip",
                            "Accept-Ranges": "bytes",
                            "Content-Type": "binary/octet-stream",
                            "Content-Length": "1155",
                            "Server": "AmazonS3"
                        }
                    }
                }
            ],
            "slice_descriptor": {},
            "state": [],
            "auxiliary_requests": [
                {
                    "description": "Create the server-side async job.",
                    "request": {
                        "url": "https://api.sendgrid.com/v3/marketing/contacts/exports",
                        "headers": {
                            "User-Agent": "python-requests/2.32.3",
                            "Accept-Encoding": "gzip, deflate",
                            "Accept": "*/*",
                            "Connection": "keep-alive",
                            "Authorization": "Bearer ****",
                            "Content-Length": "0"
                        },
                        "http_method": "POST"
                    },
                    "response": {
                        "status": 202,
                        "body": "{\"id\":\"bb2314f1-b9ab-4876-ac48-366ae706a31e\",\"_metadata\":{\"self\":\"https://api.sendgrid.com/v3/mc/contacts/exports/bb2314f1-b9ab-4876-ac48-366ae706a31e\"}}\n",
                        "headers": {
                            "Server": "nginx",
                            "Date": "Thu, 20 Feb 2025 14:04:42 GMT",
                            "Content-Type": "application/json",
                            "Content-Length": "154",
                            "Connection": "keep-alive",
                            "x-amzn-requestid": "23799445-d20b-4de6-86b2-249d06b9581c",
                            "x-amzn-remapped-x-amzn-requestid": "100cea76-3360-41f1-a135-2ce3b620c19e",
                            "access-control-allow-origin": "*",
                            "access-control-allow-headers": "AUTHORIZATION, Content-Type, On-behalf-of, x-sg-elas-acl, X-Recaptcha, X-Request-Source, x-sendgrid-mc-version",
                            "x-amzn-remapped-content-length": "154",
                            "x-sendgrid-pod-id": "0",
                            "x-amz-apigw-id": "GSVzLETMIAMEq_A=",
                            "access-control-allow-methods": "POST,OPTIONS,GET,OPTIONS",
                            "access-control-expose-headers": "Link, Location",
                            "x-amzn-trace-id": "Root=1-67b7367a-106f6f672455aaf1609e82ae;Parent=628aedad0e2144f7;Sampled=0;Lineage=1:38c8337a:0",
                            "x-amzn-remapped-date": "Thu, 20 Feb 2025 14:04:42 GMT",
                            "x-sendgrid-podrouter-region": "us-east-1",
                            "x-envoy-upstream-service-time": "404",
                            "strict-transport-security": "max-age=31536000; includeSubDomains",
                            "content-security-policy": "frame-ancestors 'none'",
                            "cache-control": "no-store",
                            "referrer-policy": "strict-origin-when-cross-origin",
                            "x-content-type-options": "nosniff",
                            "x-ratelimit-remaining": "9",
                            "x-ratelimit-reset": "18",
                            "x-ratelimit-limit": "10"
                        }
                    },
                    "title": "Async Job -- Create",
                    "type": "ASYNC_CREATE"
                },
                {
                    "description": "Poll the status of the server-side async job.",
                    "request": {
                        "url": "https://api.sendgrid.com/v3/marketing/contacts/exports/bb2314f1-b9ab-4876-ac48-366ae706a31e",
                        "headers": {
                            "User-Agent": "python-requests/2.32.3",
                            "Accept-Encoding": "gzip, deflate",
                            "Accept": "*/*",
                            "Connection": "keep-alive",
                            "Authorization": "Bearer ****"
                        },
                        "http_method": "GET"
                    },
                    "response": {
                        "status": 200,
                        "body": "{\"id\":\"bb2314f1-b9ab-4876-ac48-366ae706a31e\",\"status\":\"pending\",\"created_at\":\"2025-02-20T14:04:42Z\",\"updated_at\":\"2025-02-20T14:04:42Z\",\"completed_at\":\"1970-01-01T00:00:00Z\",\"expires_at\":\"2025-02-21T02:04:42Z\",\"urls\":[],\"user_id\":20207253,\"export_type\":\"contacts_export\",\"segments\":null,\"lists\":null,\"_metadata\":{\"self\":\"https://api.sendgrid.com/v3/mc/contacts/export/bb2314f1-b9ab-4876-ac48-366ae706a31e\"}}\n",
                        "headers": {
                            "Server": "nginx",
                            "Date": "Thu, 20 Feb 2025 14:04:43 GMT",
                            "Content-Type": "application/json",
                            "Content-Length": "408",
                            "Connection": "keep-alive",
                            "x-amzn-requestid": "93aefdb7-0cf4-469c-a774-ca61613fd739",
                            "x-amzn-remapped-x-amzn-requestid": "4a2ee46d-a952-4d68-a393-e61157a1bd86",
                            "access-control-allow-origin": "*",
                            "access-control-allow-headers": "AUTHORIZATION, Content-Type, On-behalf-of, x-sg-elas-acl, X-Recaptcha, X-Request-Source, x-sendgrid-mc-version",
                            "x-amzn-remapped-content-length": "408",
                            "x-sendgrid-pod-id": "0",
                            "x-amz-apigw-id": "GSVzTFRmoAMEgWQ=",
                            "access-control-allow-methods": "GET,OPTIONS,DELETE,OPTIONS",
                            "access-control-expose-headers": "Link, Location",
                            "x-amzn-trace-id": "Root=1-67b7367b-1700fd882e97ca4d02ec0185;Parent=5955e8ff7f1beb9a;Sampled=0;Lineage=1:38c8337a:0",
                            "x-amzn-remapped-date": "Thu, 20 Feb 2025 14:04:43 GMT",
                            "x-sendgrid-podrouter-region": "us-east-1",
                            "x-envoy-upstream-service-time": "261",
                            "strict-transport-security": "max-age=31536000; includeSubDomains",
                            "content-security-policy": "frame-ancestors 'none'",
                            "cache-control": "no-store",
                            "referrer-policy": "strict-origin-when-cross-origin",
                            "x-content-type-options": "nosniff",
                            "x-ratelimit-remaining": "599",
                            "x-ratelimit-reset": "17",
                            "x-ratelimit-limit": "600",
                            "Powered-By": "SGGateway"
                        }
                    },
                    "title": "Async Job -- Polling",
                    "type": "ASYNC_POLL"
                },
                {
                    "description": "Poll the status of the server-side async job.",
                    "request": {
                        "url": "https://api.sendgrid.com/v3/marketing/contacts/exports/bb2314f1-b9ab-4876-ac48-366ae706a31e",
                        "headers": {
                            "User-Agent": "python-requests/2.32.3",
                            "Accept-Encoding": "gzip, deflate",
                            "Accept": "*/*",
                            "Connection": "keep-alive",
                            "Authorization": "Bearer ****"
                        },
                        "http_method": "GET"
                    },
                    "response": {
                        "status": 200,
                        "body": "{\"id\":\"bb2314f1-b9ab-4876-ac48-366ae706a31e\",\"status\":\"ready\",\"contact_count\":24,\"created_at\":\"2025-02-20T14:04:42Z\",\"updated_at\":\"2025-02-20T14:04:44Z\",\"completed_at\":\"2025-02-20T14:04:44Z\",\"expires_at\":\"2025-02-21T02:04:42Z\",\"urls\":[\"https://mcd-contacts-export-productionprod.s3.us-west-2.amazonaws.com/20207253_bb2314f1-b9ab-4876-ac48-366ae706a31e.csv.gzip?X-Amz-Algorithm=AWS4-HMAC-SHA256\\u0026X-Amz-Credential=ASIAVCSGC5XH7P4VC2UA%2F20250220%2Fus-west-2%2Fs3%2Faws4_request\\u0026X-Amz-Date=20250220T140448Z\\u0026X-Amz-Expires=300\\u0026X-Amz-Security-Token=IQoJb3JpZ2luX2VjEJb%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEaCXVzLXdlc3QtMiJGMEQCIHicrFFd3AVXCGe%2B28ciRyjB6bzMkyKx39KXt8HYV04kAiAeH%2Bvs1CkOSvJvdTUFVfKhKZV7OfeSiFnr78GxxVx3GyqWAwi%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F8BEAMaDDM0OTExMzA4NTM5MSIM3t%2BBytUYYnGeQC6CKuoC3oRJNrlsHOY5LHKS%2FMtBGxWjC1M57NDeJILY0wg5%2BWo7TbKkul0qbrR3mGI5m3PHjtDRG3rMr0w7KKhqYLc5VBJ7l4YxDxBFo8XqMzJ2TXSXE%2FxQdxSDx5d0jbId0qMILqlnjfWvokHD0YSWaOZcPC3hWhJhRMGkJA5p%2F2ZErgHpbFv58DuLsssFTxCVHH2%2BhIKrgBXBySLIjkA3ykBHSzkRJ2LAlz13AWAeOZzR7tBHwdMYZBNNY7n49CbLIxUZxqSY4nVZ%2BkTPS7MNEmj%2FNYBiO5LwXiSSpZHuu7Squu4g13a%2FolJY8xoADYxMzh2jadpiopOz1qcTrsQ1TzU6AMyW6M3TXMWZ92cKaVrBJJqciqbCtSYWg6rYuo5Zgo26jNirRuNOsy%2FfcQN%2FENM9zxMywB8TKXlyYx9LJbTImxdTEE4gcAPRzjtg3zuodTNIDElqI46RR432V8FrhKxtgkEhHFddYY6cx30wq%2BPcvQY6ngFneLxr5sTHzOsj53Mu9cddLjdAnRHoR1tZddoSFxQMpmOW7ewu3mL9SVq7Mci%2FyDmV9LSuIAaxdZqEt6hc6mCuoeEtxqP3aFy4il46ETJjtpc2YrNRVyM8jVaGjlqDd1C%2FLbv00Lqta9ka2WhtMle0HmNCVXgLYzUb4evrZVUfuJDQSxxD4oL%2BrNB8pS4k7%2BO4P9Smf6Rl%2Bqo%2FFO%2FCGA%3D%3D\\u0026X-Amz-SignedHeaders=host\\u0026response-content-disposition=attachment%3Bfilename%3D20207253_bb2314f1-b9ab-4876-ac48-366ae706a31e.csv\\u0026response-content-encoding=x-gzip\\u0026X-Amz-Signature=b7c4ebb020d3edd66ea863c0da34074f8ecddcc409afaa09d346ea86f1cef0dd\"],\"user_id\":20207253,\"export_type\":\"contacts_export\",\"segments\":null,\"lists\":null,\"_metadata\":{\"self\":\"https://api.sendgrid.com/v3/mc/contacts/export/bb2314f1-b9ab-4876-ac48-366ae706a31e\"}}\n",
                        "headers": {
                            "Server": "nginx",
                            "Date": "Thu, 20 Feb 2025 14:04:48 GMT",
                            "Content-Type": "application/json",
                            "Transfer-Encoding": "chunked",
                            "Connection": "keep-alive",
                            "x-amzn-requestid": "0ed22ae5-3206-4112-a5ad-ed4adc5ac161",
                            "x-amzn-remapped-x-amzn-requestid": "b04913cc-91b2-4a3e-b902-d8de1e55b212",
                            "access-control-allow-origin": "*",
                            "access-control-allow-headers": "AUTHORIZATION, Content-Type, On-behalf-of, x-sg-elas-acl, X-Recaptcha, X-Request-Source, x-sendgrid-mc-version",
                            "x-amzn-remapped-content-length": "2015",
                            "x-sendgrid-pod-id": "0",
                            "x-amz-apigw-id": "GSV0JEHioAMEDSA=",
                            "access-control-allow-methods": "GET,OPTIONS,DELETE,OPTIONS",
                            "access-control-expose-headers": "Link, Location",
                            "x-amzn-trace-id": "Root=1-67b73680-5dab1b7024963bed5e464722;Parent=6f8ca9ea28e8ca22;Sampled=0;Lineage=1:38c8337a:0",
                            "x-amzn-remapped-date": "Thu, 20 Feb 2025 14:04:48 GMT",
                            "x-sendgrid-podrouter-region": "us-east-1",
                            "x-envoy-upstream-service-time": "237",
                            "strict-transport-security": "max-age=31536000; includeSubDomains",
                            "content-security-policy": "frame-ancestors 'none'",
                            "cache-control": "no-store",
                            "referrer-policy": "strict-origin-when-cross-origin",
                            "x-content-type-options": "nosniff",
                            "x-ratelimit-remaining": "599",
                            "x-ratelimit-reset": "12",
                            "x-ratelimit-limit": "600",
                            "Powered-By": "SGGateway",
                            "Content-Encoding": "gzip"
                        }
                    },
                    "title": "Async Job -- Polling",
                    "type": "ASYNC_POLL"
                }
            ]
        }
    ],
    "test_read_limit_reached": false,
    "auxiliary_requests": [],
    "inferred_schema": {},
    "inferred_datetime_formats": {}
}
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Improved asynchronous request processing with enriched metadata in stream slices.
  - Upgraded logging for HTTP and authentication events, now clearly identifying request types.

- **Refactor**
  - Streamlined handling and grouping of auxiliary and log messages for more consistent outputs.
  - Refined data structures to better support enhanced message processing.
  - Enhanced code organization and readability in the retrieval processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->