### PR TITLE
fix: (CDK) (CsvParser) - Fix the `\\` escaping when passing the `delimiter` from Builder's UI

### DIFF
--- a/airbyte_cdk/sources/declarative/decoders/composite_raw_decoder.py
+++ b/airbyte_cdk/sources/declarative/decoders/composite_raw_decoder.py
@@ -107,6 +107,16 @@ class CsvParser(Parser):
     encoding: Optional[str] = "utf-8"
     delimiter: Optional[str] = ","
 
+    def _get_delimiter(self) -> Optional[str]:
+        """
+        Get delimiter from the configuration. Check for the escape character and decode it.
+        """
+        if self.delimiter is not None:
+            if self.delimiter.startswith("\\"):
+                self.delimiter = self.delimiter.encode("utf-8").decode("unicode_escape")
+
+        return self.delimiter
+
     def parse(
         self,
         data: BufferedIOBase,
@@ -115,7 +125,7 @@ class CsvParser(Parser):
         Parse CSV data from decompressed bytes.
         """
         text_data = TextIOWrapper(data, encoding=self.encoding)  # type: ignore
-        reader = csv.DictReader(text_data, delimiter=self.delimiter or ",")
+        reader = csv.DictReader(text_data, delimiter=self._get_delimiter() or ",")
         yield from reader
 
 

--- a/unit_tests/sources/declarative/decoders/test_composite_decoder.py
+++ b/unit_tests/sources/declarative/decoders/test_composite_decoder.py
@@ -62,7 +62,9 @@ def test_composite_raw_decoder_gzip_csv_parser(requests_mock, encoding: str):
     )
     response = requests.get("https://airbyte.io/", stream=True)
 
-    parser = GzipParser(inner_parser=CsvParser(encoding=encoding, delimiter="\t"))
+    # the delimiter is set to `\\t` intentionally to test the parsing logic here
+    parser = GzipParser(inner_parser=CsvParser(encoding=encoding, delimiter="\\t"))
+
     composite_raw_decoder = CompositeRawDecoder(parser=parser)
     counter = 0
     for _ in composite_raw_decoder.decode(response):


### PR DESCRIPTION
## What
Sometimes there is a case when the `csv` file is encoded with the `\t` or other delimiters supported (basically any character) and should be passed with the `escape` character alongside. This breaks the `CsvParser` implementation when the input goes from the Builder's UI.

More context here: https://airbytehq-team.slack.com/archives/C02U9R3AF37/p1740003282758399

## How
- added pre-parsing for the `delimiter` to decode the `escaping_character` and normalize the input before decoding records.

## User Impact
No impact is expected, this is not a Breaking change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced CSV file parsing to correctly interpret escaped delimiter characters. This improvement provides a more robust approach to processing CSV files, resulting in better data ingestion and compatibility with varied CSV formats.
- **Tests**
  - Updated test cases to validate the new delimiter handling and ensure reliable, consistent CSV data processing. Additional validations were added to safeguard integration performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->