### PR TITLE
fix: update csv parser for builder compatibility

### DIFF
--- a/airbyte_cdk/sources/declarative/decoders/composite_raw_decoder.py
+++ b/airbyte_cdk/sources/declarative/decoders/composite_raw_decoder.py
@@ -126,7 +126,8 @@ class CsvParser(Parser):
         """
         text_data = TextIOWrapper(data, encoding=self.encoding)  # type: ignore
         reader = csv.DictReader(text_data, delimiter=self._get_delimiter() or ",")
-        yield from reader
+        for row in reader:
+            yield row
 
 
 @dataclass

--- a/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -2103,10 +2103,12 @@ class ModelToComponentFactory:
             parser=ModelToComponentFactory._get_parser(model, config), stream_response=True
         )
 
-    @staticmethod
-    def create_gzip_decoder(model: GzipDecoderModel, config: Config, **kwargs: Any) -> Decoder:
+    def create_gzip_decoder(
+        self, model: GzipDecoderModel, config: Config, **kwargs: Any
+    ) -> Decoder:
         return CompositeRawDecoder(
-            parser=ModelToComponentFactory._get_parser(model, config), stream_response=True
+            parser=ModelToComponentFactory._get_parser(model, config),
+            stream_response=False if self._emit_connector_builder_messages else True,
         )
 
     @staticmethod

--- a/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -2091,10 +2091,10 @@ class ModelToComponentFactory:
     def create_json_decoder(model: JsonDecoderModel, config: Config, **kwargs: Any) -> Decoder:
         return JsonDecoder(parameters={})
 
-    @staticmethod
-    def create_csv_decoder(model: CsvDecoderModel, config: Config, **kwargs: Any) -> Decoder:
+    def create_csv_decoder(self, model: CsvDecoderModel, config: Config, **kwargs: Any) -> Decoder:
         return CompositeRawDecoder(
-            parser=ModelToComponentFactory._get_parser(model, config), stream_response=True
+            parser=ModelToComponentFactory._get_parser(model, config),
+            stream_response=False if self._emit_connector_builder_messages else True,
         )
 
     @staticmethod


### PR DESCRIPTION
## What

Addresses a couple issues related to enabling the `CsvParser` in the Builder UI.

1. When trying to parse a CSV file using the declarative `CsvParser`, the following error gets thrown:

```
ValueError: I/O operation on closed file.
```

This seems to be because when we `yield from reader`, the file handle is somehow closed before the data has been read. Iterating and yielding each row seems to resolve the issue.

2. Specifically when running a test read in the builder, even when getting a successful response with the CSV data included, 0 records are being read:

<img width="556" alt="Screenshot 2025-02-20 at 3 33 38 PM" src="https://github.com/user-attachments/assets/960beaaa-03a3-4c1f-8894-ccca913c9e3c" />

The issue appears to be because the contents of the record generator are consumed when the records are emitted during read. So no data is subsequently passed to the Builder to be displayed in the testing panel. By flagging the component to specifically not emit messages when in the Builder environment, we can get accurate test results again.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Updated the CSV processing logic to use explicit iteration, enhancing clarity while maintaining the same end results.
	- Modified the component creation process to support dynamic behavior based on instance state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->