### PR TITLE
fix: prevent raw decoder from closing before sync completion

### DIFF
--- a/airbyte_cdk/sources/declarative/decoders/composite_raw_decoder.py
+++ b/airbyte_cdk/sources/declarative/decoders/composite_raw_decoder.py
@@ -151,6 +151,8 @@ class CompositeRawDecoder(Decoder):
         self, response: requests.Response
     ) -> Generator[MutableMapping[str, Any], None, None]:
         if self.is_stream_response():
+            # urllib mentions that some interfaces don't play nice with auto_close [here](https://urllib3.readthedocs.io/en/stable/user-guide.html#using-io-wrappers-with-response-content)
+            # We have indeed observed some issues with CSV parsing. Hence, we will manage the closing of the file ourselves until we find a better solution.
             response.raw.auto_close = False
             yield from self.parser.parse(data=response.raw)  # type: ignore[arg-type]
             response.raw.close()

--- a/airbyte_cdk/sources/declarative/decoders/composite_raw_decoder.py
+++ b/airbyte_cdk/sources/declarative/decoders/composite_raw_decoder.py
@@ -5,7 +5,7 @@ import json
 import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from io import BufferedIOBase, BytesIO, TextIOWrapper
+from io import BufferedIOBase, TextIOWrapper
 from typing import Any, Generator, MutableMapping, Optional
 
 import orjson
@@ -124,8 +124,7 @@ class CsvParser(Parser):
         """
         Parse CSV data from decompressed bytes.
         """
-        bytes_data = BytesIO(data.read())
-        text_data = TextIOWrapper(bytes_data, encoding=self.encoding)  # type: ignore
+        text_data = TextIOWrapper(data, encoding=self.encoding)  # type: ignore
         reader = csv.DictReader(text_data, delimiter=self._get_delimiter() or ",")
         for row in reader:
             yield row

--- a/airbyte_cdk/sources/declarative/decoders/composite_raw_decoder.py
+++ b/airbyte_cdk/sources/declarative/decoders/composite_raw_decoder.py
@@ -152,6 +152,8 @@ class CompositeRawDecoder(Decoder):
         self, response: requests.Response
     ) -> Generator[MutableMapping[str, Any], None, None]:
         if self.is_stream_response():
+            response.raw.auto_close = False
             yield from self.parser.parse(data=response.raw)  # type: ignore[arg-type]
+            response.raw.close()
         else:
             yield from self.parser.parse(data=io.BytesIO(response.content))

--- a/airbyte_cdk/sources/declarative/decoders/composite_raw_decoder.py
+++ b/airbyte_cdk/sources/declarative/decoders/composite_raw_decoder.py
@@ -5,7 +5,7 @@ import json
 import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from io import BufferedIOBase, TextIOWrapper
+from io import BufferedIOBase, BytesIO, TextIOWrapper
 from typing import Any, Generator, MutableMapping, Optional
 
 import orjson
@@ -124,7 +124,8 @@ class CsvParser(Parser):
         """
         Parse CSV data from decompressed bytes.
         """
-        text_data = TextIOWrapper(data, encoding=self.encoding)  # type: ignore
+        bytes_data = BytesIO(data.read())
+        text_data = TextIOWrapper(bytes_data, encoding=self.encoding)  # type: ignore
         reader = csv.DictReader(text_data, delimiter=self._get_delimiter() or ",")
         for row in reader:
             yield row

--- a/unit_tests/sources/declarative/decoders/test_composite_decoder.py
+++ b/unit_tests/sources/declarative/decoders/test_composite_decoder.py
@@ -226,9 +226,8 @@ def test_composite_raw_decoder_csv_parser_without_mocked_response():
     httpd = HTTPServer(("localhost", 8080), TestServer)
     thread = Thread(target=httpd.serve_forever, args=())
     thread.start()
-    thread.start()
     try:
-        response = requests.get(f"http://localhost:{port}", stream=True)
+        response = requests.get(f"http://localhost:8080", stream=True)
         result = list(CompositeRawDecoder(parser=CsvParser()).decode(response))
 
         assert len(result) == 1

--- a/unit_tests/sources/declarative/decoders/test_composite_decoder.py
+++ b/unit_tests/sources/declarative/decoders/test_composite_decoder.py
@@ -25,7 +25,7 @@ from airbyte_cdk.utils import AirbyteTracedException
 
 def find_available_port() -> int:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(('localhost', 0))
+        s.bind(("localhost", 0))
         return s.getsockname()[1]  # type: ignore  # this should return a int
 
 

--- a/unit_tests/sources/declarative/decoders/test_composite_decoder.py
+++ b/unit_tests/sources/declarative/decoders/test_composite_decoder.py
@@ -222,7 +222,6 @@ def test_composite_raw_decoder_csv_parser_without_mocked_response():
     """
     # self.wfile.write(bytes('John,Doe,120 jefferson st.,Riverside, NJ, 08075\nJack,McGinnis,220 hobo Av.,Phila, PA,09119\n"John ""Da Man""",Repici,120 Jefferson St.,Riverside, NJ,08075\nStephen,Tyler,"7452 Terrace ""At the Plaza"" road",SomeTown,SD, 91234\n,Blankman,,SomeTown, SD, 00298\n"Joan ""the bone"", Anne",Jet,"9th, at Terrace plc",Desert City,CO,00123\n', "utf-8"))
 
-
     # start server
     httpd = HTTPServer(("localhost", 8080), TestServer)
     thread = Thread(target=httpd.serve_forever, args=())
@@ -231,11 +230,12 @@ def test_composite_raw_decoder_csv_parser_without_mocked_response():
     try:
         response = requests.get(f"http://localhost:{port}", stream=True)
         result = list(CompositeRawDecoder(parser=CsvParser()).decode(response))
-        
+
         assert len(result) == 1
     finally:
         httpd.shutdown()  # release port and kill the thread
         thread.join(timeout=5)  # ensure thread is cleaned up
+
 
 def test_given_response_already_consumed_when_decode_then_no_data_is_returned(requests_mock):
     requests_mock.register_uri(

--- a/unit_tests/sources/declarative/decoders/test_composite_decoder.py
+++ b/unit_tests/sources/declarative/decoders/test_composite_decoder.py
@@ -205,20 +205,19 @@ def test_composite_raw_decoder_csv_parser_values(requests_mock, encoding: str, d
 
 
 class TestServer(BaseHTTPRequestHandler):
-
     def do_GET(self) -> None:
-       self.send_response(200)
-       self.end_headers()
-       self.wfile.write(bytes("col1,col2\nval1,val2", 'utf-8'))
+        self.send_response(200)
+        self.end_headers()
+        self.wfile.write(bytes("col1,col2\nval1,val2", "utf-8"))
 
 
 def test_composite_raw_decoder_csv_parser_without_mocked_response():
     """
-    This test reproduce a `ValueError: I/O operation on closed file` error we had with CSV parsing. We could not catch this with other tests because the closing of the mocked response from requests_mock was not the same as the one in requests.  
+    This test reproduce a `ValueError: I/O operation on closed file` error we had with CSV parsing. We could not catch this with other tests because the closing of the mocked response from requests_mock was not the same as the one in requests.
     """
     # start server
-    httpd = HTTPServer(('localhost', 8080), TestServer)
-    thread = Thread(target=httpd.serve_forever, args = ())
+    httpd = HTTPServer(("localhost", 8080), TestServer)
+    thread = Thread(target=httpd.serve_forever, args=())
     thread.start()
 
     response = requests.get("http://localhost:8080", stream=True)

--- a/unit_tests/sources/declarative/decoders/test_composite_decoder.py
+++ b/unit_tests/sources/declarative/decoders/test_composite_decoder.py
@@ -227,13 +227,15 @@ def test_composite_raw_decoder_csv_parser_without_mocked_response():
     httpd = HTTPServer(("localhost", 8080), TestServer)
     thread = Thread(target=httpd.serve_forever, args=())
     thread.start()
-
-    response = requests.get("http://localhost:8080", stream=True)
-    result = list(CompositeRawDecoder(parser=CsvParser()).decode(response))
-
-    assert len(result) == 1
-    httpd.shutdown()  # release port and kill the thread
-
+    thread.start()
+    try:
+        response = requests.get(f"http://localhost:{port}", stream=True)
+        result = list(CompositeRawDecoder(parser=CsvParser()).decode(response))
+        
+        assert len(result) == 1
+    finally:
+        httpd.shutdown()  # release port and kill the thread
+        thread.join(timeout=5)  # ensure thread is cleaned up
 
 def test_given_response_already_consumed_when_decode_then_no_data_is_returned(requests_mock):
     requests_mock.register_uri(

--- a/unit_tests/sources/declarative/decoders/test_composite_decoder.py
+++ b/unit_tests/sources/declarative/decoders/test_composite_decoder.py
@@ -214,7 +214,15 @@ class TestServer(BaseHTTPRequestHandler):
 def test_composite_raw_decoder_csv_parser_without_mocked_response():
     """
     This test reproduce a `ValueError: I/O operation on closed file` error we had with CSV parsing. We could not catch this with other tests because the closing of the mocked response from requests_mock was not the same as the one in requests.
+
+    We first identified this issue while working with the sample defined https://people.sc.fsu.edu/~jburkardt/data/csv/addresses.csv.
+    This should be reproducible by having the test server return the `self.wfile.write` statement as a comment below but it does not. However, it wasn't reproducible.
+
+    Currently we use `self.wfile.write(bytes("col1,col2\nval1,val2", "utf-8"))` to reproduce which we know is not a valid csv as it does not end with a newline character. However, this is the only we were able to reproduce locally.
     """
+    # self.wfile.write(bytes('John,Doe,120 jefferson st.,Riverside, NJ, 08075\nJack,McGinnis,220 hobo Av.,Phila, PA,09119\n"John ""Da Man""",Repici,120 Jefferson St.,Riverside, NJ,08075\nStephen,Tyler,"7452 Terrace ""At the Plaza"" road",SomeTown,SD, 91234\n,Blankman,,SomeTown, SD, 00298\n"Joan ""the bone"", Anne",Jet,"9th, at Terrace plc",Desert City,CO,00123\n', "utf-8"))
+
+
     # start server
     httpd = HTTPServer(("localhost", 8080), TestServer)
     thread = Thread(target=httpd.serve_forever, args=())
@@ -224,8 +232,7 @@ def test_composite_raw_decoder_csv_parser_without_mocked_response():
     result = list(CompositeRawDecoder(parser=CsvParser()).decode(response))
 
     assert len(result) == 1
-    httpd.shutdown()  # release port
-    thread.join()
+    httpd.shutdown()  # release port and kill the thread
 
 
 def test_given_response_already_consumed_when_decode_then_no_data_is_returned(requests_mock):

--- a/unit_tests/sources/declarative/decoders/test_composite_decoder.py
+++ b/unit_tests/sources/declarative/decoders/test_composite_decoder.py
@@ -212,7 +212,10 @@ class TestServer(BaseHTTPRequestHandler):
        self.wfile.write(bytes("col1,col2\nval1,val2", 'utf-8'))
 
 
-def test_composite_raw_decoder_csv_parser():
+def test_composite_raw_decoder_csv_parser_without_mocked_response():
+    """
+    This test reproduce a `ValueError: I/O operation on closed file` error we had with CSV parsing. We could not catch this with other tests because the closing of the mocked response from requests_mock was not the same as the one in requests.  
+    """
     # start server
     httpd = HTTPServer(('localhost', 8080), TestServer)
     thread = Thread(target=httpd.serve_forever, args = ())


### PR DESCRIPTION
## What

We've run into an issue with the `CsvDecoder` closing files prematurely during syncs, leading to crashes when syncing and/or setting up sources:

```
ValueError: I/O operation on closed file
```

The problem seems to be that the connection is automatically closed once the last chunk is being processed, preventing the process from gracefully completing. By explicitly closing the connection AFTER we have yielded the data, we can ensure that the connection remains until all data has been parsed and read.

Note that not only csv fails with the same error but pandas as well which seems to indicate an issue regarding how urllib3 handles closing of IO rather than an issue with the Python csv standard lib.

>[!NOTE] 
>From [docs](https://urllib3.readthedocs.io/en/stable/user-guide.html#using-io-wrappers-with-response-content)
> Sometimes you want to use [io.TextIOWrapper](https://docs.python.org/3/library/io.html#io.TextIOWrapper) or similar objects like a CSV reader directly with [HTTPResponse](https://urllib3.readthedocs.io/en/stable/reference/urllib3.response.html#urllib3.response.HTTPResponse) data. Making these two interfaces play nice together requires using the [auto_close](https://urllib3.readthedocs.io/en/stable/reference/urllib3.response.html#urllib3.response.HTTPResponse.auto_close) attribute by setting it to False. By default HTTP responses are closed after reading all bytes, this disables that behavior:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved streamed response handling to ensure that the data stream remains available during processing and is properly closed afterward, enhancing overall stability and resource management.

- **New Features**
  - Introduced a new test server class for testing CSV parsing capabilities of the `CompositeRawDecoder`.
  - Added a new test function to validate the CSV parsing functionality in a controlled environment.
  - Added a utility function to find available ports for testing purposes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->