### PR TITLE
feat(test): Allow mock server tests for manifest only sources

### DIFF
--- a/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -1405,7 +1405,16 @@ class ModelToComponentFactory:
         try:
             module_ref = importlib.import_module(module_name_full)
         except ModuleNotFoundError as e:
-            raise ValueError(f"Could not load module `{module_name_full}`.") from e
+            if split[0] == "source_declarative_manifest":
+                # During testing, the modules containing the custom components are not moved to source_declarative_manifest. In order to run the test, add the source folder to your PYTHONPATH or add it runtime using sys.path.append
+                try:
+                    import os
+                    module_name_with_source_declarative_manifest = ".".join(split[1:-1])
+                    module_ref = importlib.import_module(module_name_with_source_declarative_manifest)
+                except ModuleNotFoundError:
+                    raise ValueError(f"Could not load module `{module_name_full}`.") from e
+            else:
+                raise ValueError(f"Could not load module `{module_name_full}`.") from e
 
         try:
             return getattr(module_ref, class_name)

--- a/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -1409,8 +1409,11 @@ class ModelToComponentFactory:
                 # During testing, the modules containing the custom components are not moved to source_declarative_manifest. In order to run the test, add the source folder to your PYTHONPATH or add it runtime using sys.path.append
                 try:
                     import os
+
                     module_name_with_source_declarative_manifest = ".".join(split[1:-1])
-                    module_ref = importlib.import_module(module_name_with_source_declarative_manifest)
+                    module_ref = importlib.import_module(
+                        module_name_with_source_declarative_manifest
+                    )
                 except ModuleNotFoundError:
                     raise ValueError(f"Could not load module `{module_name_full}`.") from e
             else:

--- a/airbyte_cdk/sources/declarative/yaml_declarative_source.py
+++ b/airbyte_cdk/sources/declarative/yaml_declarative_source.py
@@ -40,7 +40,7 @@ class YamlDeclarativeSource(ConcurrentDeclarativeSource[List[AirbyteStateMessage
 
     def _read_and_parse_yaml_file(self, path_to_yaml_file: str) -> ConnectionDefinition:
         try:
-            # For testing purposes, we want to allow to just pass a file. However, this
+            # For testing purposes, we want to allow to just pass a file
             with open(path_to_yaml_file, "r") as f:
                 return yaml.safe_load(f)  # type: ignore  # we assume the yaml represents a ConnectionDefinition
         except FileNotFoundError:

--- a/airbyte_cdk/sources/declarative/yaml_declarative_source.py
+++ b/airbyte_cdk/sources/declarative/yaml_declarative_source.py
@@ -39,13 +39,18 @@ class YamlDeclarativeSource(ConcurrentDeclarativeSource[List[AirbyteStateMessage
         )
 
     def _read_and_parse_yaml_file(self, path_to_yaml_file: str) -> ConnectionDefinition:
-        package = self.__class__.__module__.split(".")[0]
+        try:
+            # For testing purposes, we want to allow to just pass a file. However, this
+            with open(path_to_yaml_file, "r") as f:
+                return yaml.safe_load(f)  # type: ignore  # we assume the yaml represents a ConnectionDefinition
+        except FileNotFoundError:
+            # Running inside the container, the working directory during an operation is not structured the same as the static files
+            package = self.__class__.__module__.split(".")[0]
 
-        yaml_config = pkgutil.get_data(package, path_to_yaml_file)
-        if yaml_config:
-            decoded_yaml = yaml_config.decode()
-            return self._parse(decoded_yaml)
-        else:
+            yaml_config = pkgutil.get_data(package, path_to_yaml_file)
+            if yaml_config:
+                decoded_yaml = yaml_config.decode()
+                return self._parse(decoded_yaml)
             return {}
 
     def _emit_manifest_debug_message(self, extra_args: dict[str, Any]) -> None:


### PR DESCRIPTION
## What

Currently, it is really hard to debug manifest only connectors and it is impossible to add a safety net using mock server tests

## How

Allowing for yaml files to be provided not as part of the package
Removing `source_declarative_manifest` from the package for custom components


## More context
Demo: https://airbytehq-team.slack.com/archives/C02U9R3AF37/p1740701852255509?thread_ts=1740697205.997469&cid=C02U9R3AF37
Example of usage: https://github.com/airbytehq/airbyte/pull/54715

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced error handling during dynamic module loading, providing a more graceful fallback in case of missing modules.
  - Improved configuration file reading with a primary direct file access approach and backup retrieval, ensuring smoother operation across various environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->