### PR TITLE
fix: Update DEFAULT_ERROR_MAPPING for InvalidURL to RETRY

### DIFF
--- a/airbyte_cdk/sources/streams/http/error_handlers/default_error_mapping.py
+++ b/airbyte_cdk/sources/streams/http/error_handlers/default_error_mapping.py
@@ -19,9 +19,9 @@ DEFAULT_ERROR_MAPPING: Mapping[Union[int, str, Type[Exception]], ErrorResolution
         error_message="Invalid Protocol Schema: The endpoint that data is being requested from is using an invalid or insecure. Exception: requests.exceptions.InvalidSchema",
     ),
     InvalidURL: ErrorResolution(
-        response_action=ResponseAction.FAIL,
-        failure_type=FailureType.config_error,
-        error_message="Invalid URL specified: The endpoint that data is being requested from is not a valid URL. Exception: requests.exceptions.InvalidURL",
+        response_action=ResponseAction.RETRY,
+        failure_type=FailureType.transient_error,
+        error_message="Invalid URL specified or DNS error occurred: The endpoint that data is being requested from is not a valid URL. Exception: requests.exceptions.InvalidURL",
     ),
     RequestException: ErrorResolution(
         response_action=ResponseAction.RETRY,


### PR DESCRIPTION
Solves: https://github.com/airbytehq/airbyte-internal-issues/issues/11320

Updating action to retry should have no adverse effect since the stream will still fail once it exceeds the retry amounts. The retry should allow the sync to continue if it is an actual DNS error. If it is an actual URL error, the stream will fail after it exceeds the maximum retry amount.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated error handling for URL-related and DNS issues, so the system now retries operations instead of failing immediately.

- **Tests**
  - Added comprehensive tests to confirm the new behavior, ensuring improved resilience when temporary connectivity challenges occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->