### PR TITLE
Fix: State handling when passed in read() method

### DIFF
--- a/airbyte_cdk/sources/declarative/concurrent_declarative_source.py
+++ b/airbyte_cdk/sources/declarative/concurrent_declarative_source.py
@@ -135,7 +135,8 @@ class ConcurrentDeclarativeSource(ManifestDeclarativeSource, Generic[TState]):
         catalog: ConfiguredAirbyteCatalog,
         state: Optional[List[AirbyteStateMessage]] = None,
     ) -> Iterator[AirbyteMessage]:
-        self._connector_state_manager = ConnectorStateManager(state=state)
+        if state:
+            self._connector_state_manager = ConnectorStateManager(state=state)
         concurrent_streams, _ = self._group_streams(config=config)
 
         # ConcurrentReadProcessor pops streams that are finished being read so before syncing, the names of

--- a/airbyte_cdk/sources/declarative/concurrent_declarative_source.py
+++ b/airbyte_cdk/sources/declarative/concurrent_declarative_source.py
@@ -135,6 +135,7 @@ class ConcurrentDeclarativeSource(ManifestDeclarativeSource, Generic[TState]):
         catalog: ConfiguredAirbyteCatalog,
         state: Optional[List[AirbyteStateMessage]] = None,
     ) -> Iterator[AirbyteMessage]:
+        self._connector_state_manager = ConnectorStateManager(state=state)
         concurrent_streams, _ = self._group_streams(config=config)
 
         # ConcurrentReadProcessor pops streams that are finished being read so before syncing, the names of
@@ -267,6 +268,7 @@ class ConcurrentDeclarativeSource(ManifestDeclarativeSource, Generic[TState]):
                                 component_definition=incremental_sync_component_definition,  # type: ignore  # Not None because of the if condition above
                                 stream_name=declarative_stream.name,
                                 stream_namespace=declarative_stream.namespace,
+                                stream_state=stream_state,
                                 config=config or {},
                             )
                         else:
@@ -275,6 +277,7 @@ class ConcurrentDeclarativeSource(ManifestDeclarativeSource, Generic[TState]):
                                 component_definition=incremental_sync_component_definition,  # type: ignore  # Not None because of the if condition above
                                 stream_name=declarative_stream.name,
                                 stream_namespace=declarative_stream.namespace,
+                                stream_state=stream_state,
                                 config=config or {},
                             )
                         partition_generator = StreamSlicerPartitionGenerator(

--- a/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -983,7 +983,8 @@ class ModelToComponentFactory:
     ) -> ConcurrentCursor:
         # Per-partition incremental streams can dynamically create child cursors which will pass their current
         # state via the stream_state keyword argument. Incremental syncs without parent streams use the
-        # incoming state and connector_state_manager that is initialized when the component factory is created
+        # incoming state and connector_state_manager that is initialized when the component factory is created.
+        # stream_state is also used in low code connector where the state is passed via the read() method.
         stream_state = (
             self._connector_state_manager.get_stream_state(stream_name, stream_namespace)
             if "stream_state" not in kwargs
@@ -1209,6 +1210,7 @@ class ModelToComponentFactory:
         # Per-partition incremental streams can dynamically create child cursors which will pass their current
         # state via the stream_state keyword argument. Incremental syncs without parent streams use the
         # incoming state and connector_state_manager that is initialized when the component factory is created
+        # stream_state is also used in low code connector where the state is passed via the read() method.
         stream_state = (
             self._connector_state_manager.get_stream_state(stream_name, stream_namespace)
             if "stream_state" not in kwargs

--- a/unit_tests/sources/declarative/test_concurrent_declarative_source.py
+++ b/unit_tests/sources/declarative/test_concurrent_declarative_source.py
@@ -861,12 +861,12 @@ def test_concurrent_cursor_with_state_in_read_method():
     source = ConcurrentDeclarativeSource(
         source_config=_MANIFEST, config=_CONFIG, catalog=catalog, state=[]
     )
-    
+
     with HttpMocker() as http_mocker:
         _mock_party_members_requests(http_mocker, _NO_STATE_PARTY_MEMBERS_SLICES_AND_RESPONSES)
-        messages = list(source.read(
-            logger=source.logger, config=_CONFIG, catalog=catalog, state=state
-        ))
+        messages = list(
+            source.read(logger=source.logger, config=_CONFIG, catalog=catalog, state=state)
+        )
 
     concurrent_streams, _ = source._group_streams(config=_CONFIG)
     party_members_stream = [s for s in concurrent_streams if s.name == "party_members"][0]
@@ -894,7 +894,9 @@ def test_concurrent_cursor_with_state_in_read_method():
     # Emitted state should have the updated_at of the one record read
     states = get_states_for_stream("party_members", messages)
     assert len(states) == 2
-    assert states[1].stream.stream_state == AirbyteStateBlob(updated_at=party_members_records[0].data["updated_at"])
+    assert states[1].stream.stream_state == AirbyteStateBlob(
+        updated_at=party_members_records[0].data["updated_at"]
+    )
 
 
 def test_check():


### PR DESCRIPTION
Low-code connectors instantiate the source without a state and pass the state via the read() method. This PR updates ConcurrentDeclarativeSource to support this behavior.

Changes are:
- Instantiate the ConnectorStateManager with the state passed in read() method.
- Update the ModelToComponentFactory to use the stream_state parameter when creating a cursor.
- Add a test to verify the behavior: instantiate the source without a state and pass the state via the read() method.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced state management during concurrent stream processing to ensure more consistent and reliable data synchronization.
  
- **Documentation**
  - Improved inline explanations to clarify how the `stream_state` variable is utilized in low-code scenarios.
  
- **Tests**
  - Introduced new tests verifying proper state handling during data extraction, reinforcing robust performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->