### PR TITLE
feat(low-code cdk): remove unnecessary manifest print

### DIFF
--- a/airbyte_cdk/sources/declarative/yaml_declarative_source.py
+++ b/airbyte_cdk/sources/declarative/yaml_declarative_source.py
@@ -50,7 +50,6 @@ class YamlDeclarativeSource(ConcurrentDeclarativeSource[List[AirbyteStateMessage
 
     def _emit_manifest_debug_message(self, extra_args: dict[str, Any]) -> None:
         extra_args["path_to_yaml"] = self._path_to_yaml
-        self.logger.debug("declarative source created from parsed YAML manifest", extra=extra_args)
 
     @staticmethod
     def _parse(connection_definition_str: str) -> ConnectionDefinition:


### PR DESCRIPTION
## Details 

This PR removes an unnecessary manifest print that was being displayed when debug mode was enabled. This helps reduce clutter in the logs and improves readability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed an extraneous debug log message to streamline internal logging. This update cleans up log outputs without affecting end-user functionality, ensuring that only relevant information is recorded during runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->