### PR TITLE
Feat: Firejail sandbox for source-declarative-manifest (do not merge)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,12 @@ FROM docker.io/airbyte/python-connector-base:4.0.0@sha256:d9894b6895923b379f3006
 
 WORKDIR /airbyte/integration_code
 
+# Install Firejail
+RUN apt-get update && \
+    apt-get install -y firejail && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
 # Copy project files needed for build
 COPY pyproject.toml poetry.lock README.md ./
 COPY dist/*.whl ./dist/

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ COPY dist/*.whl ./dist/
 
 # Install dependencies - ignore keyring warnings
 RUN poetry config virtualenvs.create false \
-    && poetry install --only main --no-interaction --no-ansi || true
+    && poetry install --only main --no-interaction --no-ansi
 
 # Build and install the package
 RUN pip install dist/*.whl
@@ -40,6 +40,6 @@ RUN rm -rf dist/ pyproject.toml poetry.lock README.md
 RUN chown -R 1000:1000 /airbyte
 
 # Set the entrypoint
-ENV AIRBYTE_ENTRYPOINT="python /airbyte/integration_code/main.py"
-ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
+ENV AIRBYTE_ENTRYPOINT="source-declarative-manifest-sandboxed"
+ENTRYPOINT ["source-declarative-manifest-sandboxed"]
 USER airbyte

--- a/airbyte_cdk/cli/source_declarative_manifest/__init__.py
+++ b/airbyte_cdk/cli/source_declarative_manifest/__init__.py
@@ -1,5 +1,7 @@
 from airbyte_cdk.cli.source_declarative_manifest._run import run
+from airbyte_cdk.cli.source_declarative_manifest._sandboxed_run import sandboxed_run
 
 __all__ = [
     "run",
+    "sandboxed_run",
 ]

--- a/airbyte_cdk/cli/source_declarative_manifest/_sandboxed_run.py
+++ b/airbyte_cdk/cli/source_declarative_manifest/_sandboxed_run.py
@@ -1,0 +1,52 @@
+"""Use Firejail (if installed) to run the source in a sandboxed environment."""
+
+import os
+import subprocess
+import sys
+
+ENV_SANDBOX_MODE = "AIRBYTE_CONNECTOR_SANDBOX_MODE"
+ENV_SANDBOX_MODE_FIREJAIL = "FIREJAIL"
+ENV_SANDBOX_MODE_AUTO = "AUTO"  # Use Firejail if available, otherwise None
+ENV_SANDBOX_MODE_NONE = "NONE"
+
+
+def _wrap_in_sandbox(cmd: list[str]) -> list[str]:
+    """Wrap the given command in Firejail.
+    This function modifies the command to include Firejail options
+    and returns the updated command list.
+    """
+    sb_mode = os.getenv(ENV_SANDBOX_MODE, ENV_SANDBOX_MODE_AUTO).upper()
+    if sb_mode == ENV_SANDBOX_MODE_NONE:
+        print(
+            f"WARNING: Sandboxing disabled due to env variable '{ENV_SANDBOX_MODE}'.  "
+            "Running without Firejail."
+        )
+        return cmd
+
+    # Try Firejail
+    try:
+        subprocess.run(["firejail", "--version"], check=True, stdout=subprocess.PIPE)
+    except FileNotFoundError:
+        if sb_mode == ENV_SANDBOX_MODE_FIREJAIL:
+            raise RuntimeError(
+                "Firejail not found. Set AIRBYTE_CONNECTOR_SANDBOX_MODE=NONE to disable sandboxing."
+            )
+        print("Firejail not found. Running without sandboxing.")
+        return cmd
+
+    # Firejail is available
+    return ["firejail", "--private", "--net=none"] + cmd
+
+
+def sandboxed_run():
+    executable = "source-declarative-manifest"  # Assume base SDM entrypoint is installed and on PATH
+
+    full_cmd = _wrap_in_sandbox([executable] + sys.argv[1:])  # Preserve CLI arguments and wrap in Firejail
+    print(f"Running command: {' '.join(full_cmd)}")
+
+    # Execute the wrapped SDM command
+    os.execvp(full_cmd[0], full_cmd)
+
+
+if __name__ == "__main__":
+    sandboxed_run()

--- a/airbyte_cdk/cli/source_declarative_manifest/_sandboxed_run.py
+++ b/airbyte_cdk/cli/source_declarative_manifest/_sandboxed_run.py
@@ -25,6 +25,7 @@ def _wrap_in_sandbox(cmd: list[str]) -> list[str]:
 
     # Try Firejail
     try:
+        print("Checking for Firejail...")
         subprocess.run(["firejail", "--version"], check=True, stdout=subprocess.PIPE)
     except FileNotFoundError:
         if sb_mode == ENV_SANDBOX_MODE_FIREJAIL:
@@ -35,6 +36,7 @@ def _wrap_in_sandbox(cmd: list[str]) -> list[str]:
         return cmd
 
     # Firejail is available
+    print("Firejail found. Running with Firejail sandboxing.")
     return ["firejail", "--private", "--net=none"] + cmd
 
 

--- a/airbyte_cdk/cli/source_declarative_manifest/_sandboxed_run.py
+++ b/airbyte_cdk/cli/source_declarative_manifest/_sandboxed_run.py
@@ -9,6 +9,21 @@ ENV_SANDBOX_MODE_FIREJAIL = "FIREJAIL"
 ENV_SANDBOX_MODE_AUTO = "AUTO"  # Use Firejail if available, otherwise None
 ENV_SANDBOX_MODE_NONE = "NONE"
 
+USAGE = f"""
+Sandboxed execution of the source-declarative-manifest connector.
+
+Usage: source-declarative-manifest-sandboxed [OPTIONS] [CMD]
+
+Options:
+  --help           Show this help message and exit.
+  --check-sandbox  Check Firejail availability and exit.
+
+CMD:
+  The command to run in the sandboxed environment. This should be the command
+  that would normally be run to start the connector. E.g. "check", "read", etc.
+
+  The command is ignored if specifying --check-sandbox or --help.
+"""
 
 def _wrap_in_sandbox(cmd: list[str]) -> list[str]:
     """Wrap the given command in Firejail.
@@ -18,19 +33,20 @@ def _wrap_in_sandbox(cmd: list[str]) -> list[str]:
     sb_mode = os.getenv(ENV_SANDBOX_MODE, ENV_SANDBOX_MODE_AUTO).upper()
     if sb_mode == ENV_SANDBOX_MODE_NONE:
         print(
-            f"WARNING: Sandboxing disabled due to env variable '{ENV_SANDBOX_MODE}'.  "
+            f"WARNING: Sandboxing disabled because env var '{ENV_SANDBOX_MODE}={sb_mode}'.  "
             "Running without Firejail."
         )
         return cmd
 
     # Try Firejail
     try:
-        print("Checking for Firejail...")
         subprocess.run(["firejail", "--version"], check=True, stdout=subprocess.PIPE)
     except FileNotFoundError:
         if sb_mode == ENV_SANDBOX_MODE_FIREJAIL:
             raise RuntimeError(
-                "Firejail not found. Set AIRBYTE_CONNECTOR_SANDBOX_MODE=NONE to disable sandboxing."
+                f"Firejail required by env var value `{ENV_SANDBOX_MODE}={sb_mode}` but not found. "
+                f"Set {ENV_SANDBOX_MODE} to 'NONE' to disable sandboxing or 'AUTO' to "
+                "only use Firejail when available."
             )
         print("Firejail not found. Running without sandboxing.")
         return cmd
@@ -41,6 +57,18 @@ def _wrap_in_sandbox(cmd: list[str]) -> list[str]:
 
 
 def sandboxed_run():
+    if len(sys.argv) == 1:
+        _print_help()
+        return
+
+    if sys.argv[1] == "--help":
+        _print_help()
+        return
+
+    if sys.argv[1] == "--check-sandbox":
+        _print_sandbox_check()
+        return
+
     executable = "source-declarative-manifest"  # Assume base SDM entrypoint is installed and on PATH
 
     full_cmd = _wrap_in_sandbox([executable] + sys.argv[1:])  # Preserve CLI arguments and wrap in Firejail
@@ -48,6 +76,18 @@ def sandboxed_run():
 
     # Execute the wrapped SDM command
     os.execvp(full_cmd[0], full_cmd)
+
+
+def _print_help() -> None:
+    print(USAGE)
+
+
+def _print_sandbox_check() -> None:
+    try:
+        subprocess.run(["firejail", "--version"], check=True, stdout=subprocess.PIPE)
+        print("Firejail found.")
+    except FileNotFoundError:
+        print("Firejail not found.")
 
 
 if __name__ == "__main__":

--- a/airbyte_cdk/cli/source_declarative_manifest/_sandboxed_run.py
+++ b/airbyte_cdk/cli/source_declarative_manifest/_sandboxed_run.py
@@ -10,20 +10,34 @@ ENV_SANDBOX_MODE_AUTO = "AUTO"  # Use Firejail if available, otherwise None
 ENV_SANDBOX_MODE_NONE = "NONE"
 
 USAGE = f"""
-Sandboxed execution of the source-declarative-manifest connector.
+-------------------------------------------
+-- source-declarative-manifest-sandboxed --
+-------------------------------------------
+
+Sandboxed execution of the source-declarative-manifest connector. By default, this script
+wraps the source-declarative-manifest command in Firejail to run the connector in a sandboxed
+environment. If Firejail is not available, the connector will run without sandboxing.
+
+Environment variable '{ENV_SANDBOX_MODE}' controls the sandboxing behavior. The following values
+are supported:
+    - '{ENV_SANDBOX_MODE_FIREJAIL}': Use Firejail to run the connector in a sandboxed environment.
+    - '{ENV_SANDBOX_MODE_AUTO}': Use Firejail if available, otherwise run without sandboxing.
+    - '{ENV_SANDBOX_MODE_NONE}': Disable sandboxing and run the connector without Firejail.
 
 Usage: source-declarative-manifest-sandboxed [OPTIONS] [CMD]
-
-Options:
-  --help           Show this help message and exit.
-  --check-sandbox  Check Firejail availability and exit.
 
 CMD:
   The command to run in the sandboxed environment. This should be the command
   that would normally be run to start the connector. E.g. "check", "read", etc.
+  The command is passed to the source-declarative-manifest entrypoint.
 
-  The command is ignored if specifying --check-sandbox or --help.
+  The command is ignored if specifying any of the below options.
+
+Options:
+  --help           Show this help message and exit.
+  --check-sandbox  Check Firejail availability and exit.
 """
+
 
 def _wrap_in_sandbox(cmd: list[str]) -> list[str]:
     """Wrap the given command in Firejail.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,7 +111,7 @@ sql = ["sqlalchemy"]
 [tool.poetry.scripts]
 
 source-declarative-manifest = "airbyte_cdk.cli.source_declarative_manifest:run"
-sandboxed-source-declarative-manifest = "airbyte_cdk.cli.source_declarative_manifest:sandboxed_run"
+source-declarative-manifest-sandboxed = "airbyte_cdk.cli.source_declarative_manifest:sandboxed_run"
 
 [tool.isort]
 skip = ["__init__.py"]  # TODO: Remove after this is fixed: https://github.com/airbytehq/airbyte-python-cdk/issues/12

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,7 @@ sql = ["sqlalchemy"]
 [tool.poetry.scripts]
 
 source-declarative-manifest = "airbyte_cdk.cli.source_declarative_manifest:run"
+sandboxed-source-declarative-manifest = "airbyte_cdk.cli.source_declarative_manifest:sandboxed_run"
 
 [tool.isort]
 skip = ["__init__.py"]  # TODO: Remove after this is fixed: https://github.com/airbytehq/airbyte-python-cdk/issues/12


### PR DESCRIPTION
Adds a sandbox wrapper and integrates the Sandboxed runner as the Docker image entrypoint for `source-declarative-manifest` docker image. Optionally, we can consider making this it's own image.

Usage info is available via `source-declarative-manifest-sandboxed --help`.

```
Sandboxed execution of the source-declarative-manifest connector. By default, this script
wraps the source-declarative-manifest command in Firejail to run the connector in a sandboxed
environment. If Firejail is not available, the connector will run without sandboxing.

Environment variable 'AIRBYTE_CONNECTOR_SANDBOX_MODE' controls the sandboxing behavior. The following values
are supported:
    - 'FIREJAIL': Use Firejail to run the connector in a sandboxed environment.
    - 'AUTO': Use Firejail if available, otherwise run without sandboxing.
    - 'NONE': Disable sandboxing and run the connector without Firejail.

Usage: source-declarative-manifest-sandboxed [OPTIONS] [CMD]

Options:
  --help           Show this help message and exit.
  --check-sandbox  Check Firejail availability and exit.

CMD:
  The command to run in the sandboxed environment. This should be the command
  that would normally be run to start the connector. E.g. "check", "read", etc.

  The command is ignored if specifying --check-sandbox or --help.
```

Notes:

- Firejail doesn't run natively on Mac.
- The wrapper script will gracefully fail over to non-sandboxed mode unless you explicitly request it not to by specifying the env var value `AIRBYTE_CONNECTOR_SANDBOX_MODE=FIREJAIL`.
- In theory, we can test when running on Mac by using Docker or another tool, although I haven't succeeded yet in a full test.
- In the `connector-builder-server`, we can invoke via the CLI _instead of_ the Docker image, and by using the `source-declarative-manifest-sandboxed` CLI, the invocation should (in theory) still be properly sandboxed.