### PR TITLE
feat: Enable JobTracker limit configurability

### DIFF
--- a/airbyte_cdk/sources/declarative/async_job/job_tracker.py
+++ b/airbyte_cdk/sources/declarative/async_job/job_tracker.py
@@ -17,10 +17,6 @@ class ConcurrentJobLimitReached(Exception):
 class JobTracker:
     def __init__(self, limit: int):
         self._jobs: Set[str] = set()
-        if limit < 1:
-            LOGGER.warning(
-                f"The `max_concurrent_async_job_count` property is less than 1: {limit}. Setting to 1. Please update the source manifest to set a valid value."
-            )
         self._limit = 1 if limit < 1 else limit
         self._lock = threading.Lock()
 

--- a/airbyte_cdk/sources/declarative/async_job/job_tracker.py
+++ b/airbyte_cdk/sources/declarative/async_job/job_tracker.py
@@ -3,7 +3,7 @@
 import logging
 import threading
 import uuid
-from typing import Set
+from typing import Optional, Set
 
 from airbyte_cdk.logger import lazy_log
 
@@ -15,9 +15,9 @@ class ConcurrentJobLimitReached(Exception):
 
 
 class JobTracker:
-    def __init__(self, limit: int):
+    def __init__(self, limit: Optional[int]):
         self._jobs: Set[str] = set()
-        self._limit = limit
+        self._limit = limit if isinstance(limit, int) and limit >= 1 else 1
         self._lock = threading.Lock()
 
     def try_to_get_intent(self) -> str:

--- a/airbyte_cdk/sources/declarative/async_job/job_tracker.py
+++ b/airbyte_cdk/sources/declarative/async_job/job_tracker.py
@@ -17,6 +17,10 @@ class ConcurrentJobLimitReached(Exception):
 class JobTracker:
     def __init__(self, limit: int):
         self._jobs: Set[str] = set()
+        if limit < 1:
+            LOGGER.warning(
+                f"The `max_concurrent_async_job_count` property is less than 1: {limit}. Setting to 1. Please update the source manifest to set a valid value."
+            )
         self._limit = 1 if limit < 1 else limit
         self._lock = threading.Lock()
 

--- a/airbyte_cdk/sources/declarative/async_job/job_tracker.py
+++ b/airbyte_cdk/sources/declarative/async_job/job_tracker.py
@@ -3,7 +3,7 @@
 import logging
 import threading
 import uuid
-from typing import Optional, Set
+from typing import Set
 
 from airbyte_cdk.logger import lazy_log
 

--- a/airbyte_cdk/sources/declarative/async_job/job_tracker.py
+++ b/airbyte_cdk/sources/declarative/async_job/job_tracker.py
@@ -15,9 +15,9 @@ class ConcurrentJobLimitReached(Exception):
 
 
 class JobTracker:
-    def __init__(self, limit: Optional[int]):
+    def __init__(self, limit: int):
         self._jobs: Set[str] = set()
-        self._limit = limit if isinstance(limit, int) and limit >= 1 else 1
+        self._limit = 1 if limit < 1 else limit
         self._lock = threading.Lock()
 
     def try_to_get_intent(self) -> str:

--- a/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -43,8 +43,8 @@ properties:
   api_budget:
     "$ref": "#/definitions/HTTPAPIBudget"
   max_concurrent_async_job_count:
-    title: Maximum Concurrent Async Jobs
-    description: Maximum number of concurrent async jobs to run. This property is only relevant for sources/streams that support asynchronous job execution (e.g. a Report stream that requires that initiates a job, polls the job status, and then fetches the job results). This is often set by the API's maximum number of concurrent jobs on the account level.
+    title: Maximum Concurrent Asynchronous Jobs
+    description: Maximum number of concurrent asynchronous jobs to run. This property is only relevant for sources/streams that support asynchronous job execution through the AsyncRetriever (e.g. a report-based stream that initiates a job, polls the job status, and then fetches the job results). This is often set by the API's maximum number of concurrent jobs on the account level. Refer to the API's documentation for this information.
     type: integer
   metadata:
     type: object

--- a/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -42,7 +42,7 @@ properties:
     "$ref": "#/definitions/ConcurrencyLevel"
   api_budget:
     "$ref": "#/definitions/HTTPAPIBudget"
-  max_concurrent_job_count:
+  max_concurrent_async_job_count:
     title: Maximum Concurrent Async Jobs
     description: Maximum number of concurrent async jobs to run. This property is only relevant for sources/streams that support asynchronous job execution (e.g. a Report stream that requires that initiates a job, polls the job status, and then fetches the job results). This is often set by the API's maximum number of concurrent jobs on the account level.
     type: integer

--- a/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -43,25 +43,7 @@ properties:
   api_budget:
     "$ref": "#/definitions/HTTPAPIBudget"
   max_concurrent_async_jobs:
-    title: Maximum Concurrent Async Jobs
-    description: Maximum number of concurrent async jobs to run.
-    type: object
-    required:
-      - max_concurrent_jobs
-    properties:
-      max_concurrent_jobs:
-        title: Maximum Concurrent Jobs
-        description: Maximum number of concurrent jobs to run. This value should be based on the API's maximum number of concurrent jobs per endpoint or overall on the account.
-        type: integer
-        default: 1
-      scope:
-        title: Scope
-        description: Specifies whether the maximum number of concurrent jobs is applied per stream or per source. This value should based on whether the API sets a maximum number of concurrent jobs per endpoint or overall on the account.
-        type: string
-        enum:
-          - stream
-          - source
-        default: source
+    "$ref": "#/definitions/MaxConcurrentAsyncJobs"
   metadata:
     type: object
     description: For internal Airbyte use only - DO NOT modify manually. Used by consumers of declarative manifests for storing related metadata.
@@ -2426,6 +2408,18 @@ definitions:
       $parameters:
         type: object
         additionalProperties: true
+  MaxConcurrentAsyncJobs:
+    title: Maximum Concurrent Async Jobs
+    description: Maximum number of concurrent async jobs to run. This is often set by the API's maximum number of concurrent jobs on the account level.
+    type: object
+    required:
+      - max_concurrent_job_count
+    properties:
+      max_concurrent_job_count:
+        title: Maximum Concurrent Job Count
+        description: Maximum number of concurrent jobs to run. This is often set by the API's maximum number of concurrent jobs on the account level.
+        type: integer
+        default: 1
   MinMaxDatetime:
     title: Min-Max Datetime
     description: Compares the provided date against optional minimum or maximum times. The max_datetime serves as the ceiling and will be returned when datetime exceeds it. The min_datetime serves as the floor.

--- a/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -2419,7 +2419,6 @@ definitions:
         title: Maximum Concurrent Job Count
         description: Maximum number of concurrent jobs to run. This is often set by the API's maximum number of concurrent jobs on the account level.
         type: integer
-        default: 1
   MinMaxDatetime:
     title: Min-Max Datetime
     description: Compares the provided date against optional minimum or maximum times. The max_datetime serves as the ceiling and will be returned when datetime exceeds it. The min_datetime serves as the floor.

--- a/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -42,8 +42,10 @@ properties:
     "$ref": "#/definitions/ConcurrencyLevel"
   api_budget:
     "$ref": "#/definitions/HTTPAPIBudget"
-  max_concurrent_async_jobs:
-    "$ref": "#/definitions/MaxConcurrentAsyncJobs"
+  max_concurrent_job_count:
+    title: Maximum Concurrent Async Jobs
+    description: Maximum number of concurrent async jobs to run. This is often set by the API's maximum number of concurrent jobs on the account level.
+    type: integer
   metadata:
     type: object
     description: For internal Airbyte use only - DO NOT modify manually. Used by consumers of declarative manifests for storing related metadata.
@@ -2408,17 +2410,6 @@ definitions:
       $parameters:
         type: object
         additionalProperties: true
-  MaxConcurrentAsyncJobs:
-    title: Maximum Concurrent Async Jobs
-    description: Maximum number of concurrent async jobs to run. This is often set by the API's maximum number of concurrent jobs on the account level.
-    type: object
-    required:
-      - max_concurrent_job_count
-    properties:
-      max_concurrent_job_count:
-        title: Maximum Concurrent Job Count
-        description: Maximum number of concurrent jobs to run. This is often set by the API's maximum number of concurrent jobs on the account level.
-        type: integer
   MinMaxDatetime:
     title: Min-Max Datetime
     description: Compares the provided date against optional minimum or maximum times. The max_datetime serves as the ceiling and will be returned when datetime exceeds it. The min_datetime serves as the floor.

--- a/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -42,6 +42,26 @@ properties:
     "$ref": "#/definitions/ConcurrencyLevel"
   api_budget:
     "$ref": "#/definitions/HTTPAPIBudget"
+  max_concurrent_async_jobs:
+    title: Maximum Concurrent Async Jobs
+    description: Maximum number of concurrent async jobs to run.
+    type: object
+    required:
+      - max_concurrent_jobs
+    properties:
+      max_concurrent_jobs:
+        title: Maximum Concurrent Jobs
+        description: Maximum number of concurrent jobs to run. This value should be based on the API's maximum number of concurrent jobs per endpoint or overall on the account.
+        type: integer
+        default: 1
+      scope:
+        title: Scope
+        description: Specifies whether the maximum number of concurrent jobs is applied per stream or per source. This value should based on whether the API sets a maximum number of concurrent jobs per endpoint or overall on the account.
+        type: string
+        enum:
+          - stream
+          - source
+        default: source
   metadata:
     type: object
     description: For internal Airbyte use only - DO NOT modify manually. Used by consumers of declarative manifests for storing related metadata.

--- a/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -44,7 +44,7 @@ properties:
     "$ref": "#/definitions/HTTPAPIBudget"
   max_concurrent_job_count:
     title: Maximum Concurrent Async Jobs
-    description: Maximum number of concurrent async jobs to run. This is often set by the API's maximum number of concurrent jobs on the account level.
+    description: Maximum number of concurrent async jobs to run. This property is only relevant for sources/streams that support asynchronous job execution (e.g. a Report stream that requires that initiates a job, polls the job status, and then fetches the job results). This is often set by the API's maximum number of concurrent jobs on the account level.
     type: integer
   metadata:
     type: object

--- a/airbyte_cdk/sources/declarative/manifest_declarative_source.py
+++ b/airbyte_cdk/sources/declarative/manifest_declarative_source.py
@@ -143,10 +143,6 @@ class ManifestDeclarativeSource(DeclarativeSource):
         if api_budget_model:
             self._constructor.set_api_budget(api_budget_model, config)
 
-        max_concurrent_async_jobs_model = self._source_config.get("max_concurrent_async_jobs")
-        if max_concurrent_async_jobs_model:
-            self._constructor.set_max_concurrent_async_jobs(max_concurrent_async_jobs_model, config)
-
         source_streams = [
             self._constructor.create_component(
                 DeclarativeStreamModel,

--- a/airbyte_cdk/sources/declarative/manifest_declarative_source.py
+++ b/airbyte_cdk/sources/declarative/manifest_declarative_source.py
@@ -94,7 +94,8 @@ class ManifestDeclarativeSource(DeclarativeSource):
             component_factory
             if component_factory
             else ModelToComponentFactory(
-                emit_connector_builder_messages, source_config=source_config
+                emit_connector_builder_messages,
+                max_concurrent_async_job_count=source_config.get("max_concurrent_job_count"),
             )
         )
         self._message_repository = self._constructor.get_message_repository()

--- a/airbyte_cdk/sources/declarative/manifest_declarative_source.py
+++ b/airbyte_cdk/sources/declarative/manifest_declarative_source.py
@@ -141,6 +141,10 @@ class ManifestDeclarativeSource(DeclarativeSource):
         if api_budget_model:
             self._constructor.set_api_budget(api_budget_model, config)
 
+        max_concurrent_async_jobs_model = self._source_config.get("max_concurrent_async_jobs")
+        if max_concurrent_async_jobs_model:
+            self._constructor.set_max_concurrent_async_jobs(max_concurrent_async_jobs_model, config)
+
         source_streams = [
             self._constructor.create_component(
                 DeclarativeStreamModel,

--- a/airbyte_cdk/sources/declarative/manifest_declarative_source.py
+++ b/airbyte_cdk/sources/declarative/manifest_declarative_source.py
@@ -93,7 +93,9 @@ class ManifestDeclarativeSource(DeclarativeSource):
         self._constructor = (
             component_factory
             if component_factory
-            else ModelToComponentFactory(emit_connector_builder_messages)
+            else ModelToComponentFactory(
+                emit_connector_builder_messages, source_config=source_config
+            )
         )
         self._message_repository = self._constructor.get_message_repository()
         self._slice_logger: SliceLogger = (

--- a/airbyte_cdk/sources/declarative/manifest_declarative_source.py
+++ b/airbyte_cdk/sources/declarative/manifest_declarative_source.py
@@ -95,7 +95,7 @@ class ManifestDeclarativeSource(DeclarativeSource):
             if component_factory
             else ModelToComponentFactory(
                 emit_connector_builder_messages,
-                max_concurrent_async_job_count=source_config.get("max_concurrent_job_count"),
+                max_concurrent_async_job_count=source_config.get("max_concurrent_async_job_count"),
             )
         )
         self._message_repository = self._constructor.get_message_repository()

--- a/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
+++ b/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
@@ -929,14 +929,6 @@ class CustomDecoder(BaseModel):
     parameters: Optional[Dict[str, Any]] = Field(None, alias="$parameters")
 
 
-class MaxConcurrentAsyncJobs(BaseModel):
-    max_concurrent_job_count: int = Field(
-        ...,
-        description="Maximum number of concurrent jobs to run. This is often set by the API's maximum number of concurrent jobs on the account level.",
-        title="Maximum Concurrent Job Count",
-    )
-
-
 class MinMaxDatetime(BaseModel):
     type: Literal["MinMaxDatetime"]
     datetime: str = Field(
@@ -1879,7 +1871,11 @@ class DeclarativeSource1(BaseModel):
     spec: Optional[Spec] = None
     concurrency_level: Optional[ConcurrencyLevel] = None
     api_budget: Optional[HTTPAPIBudget] = None
-    max_concurrent_async_jobs: Optional[MaxConcurrentAsyncJobs] = None
+    max_concurrent_job_count: Optional[int] = Field(
+        None,
+        description="Maximum number of concurrent async jobs to run. This is often set by the API's maximum number of concurrent jobs on the account level.",
+        title="Maximum Concurrent Async Jobs",
+    )
     metadata: Optional[Dict[str, Any]] = Field(
         None,
         description="For internal Airbyte use only - DO NOT modify manually. Used by consumers of declarative manifests for storing related metadata.",
@@ -1907,7 +1903,11 @@ class DeclarativeSource2(BaseModel):
     spec: Optional[Spec] = None
     concurrency_level: Optional[ConcurrencyLevel] = None
     api_budget: Optional[HTTPAPIBudget] = None
-    max_concurrent_async_jobs: Optional[MaxConcurrentAsyncJobs] = None
+    max_concurrent_job_count: Optional[int] = Field(
+        None,
+        description="Maximum number of concurrent async jobs to run. This is often set by the API's maximum number of concurrent jobs on the account level.",
+        title="Maximum Concurrent Async Jobs",
+    )
     metadata: Optional[Dict[str, Any]] = Field(
         None,
         description="For internal Airbyte use only - DO NOT modify manually. Used by consumers of declarative manifests for storing related metadata.",

--- a/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
+++ b/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
@@ -1873,7 +1873,7 @@ class DeclarativeSource1(BaseModel):
     api_budget: Optional[HTTPAPIBudget] = None
     max_concurrent_job_count: Optional[int] = Field(
         None,
-        description="Maximum number of concurrent async jobs to run. This is often set by the API's maximum number of concurrent jobs on the account level.",
+        description="Maximum number of concurrent async jobs to run. This property is only relevant for sources/streams that support asynchronous job execution (e.g. a Report stream that requires that initiates a job, polls the job status, and then fetches the job results). This is often set by the API's maximum number of concurrent jobs on the account level.",
         title="Maximum Concurrent Async Jobs",
     )
     metadata: Optional[Dict[str, Any]] = Field(
@@ -1905,7 +1905,7 @@ class DeclarativeSource2(BaseModel):
     api_budget: Optional[HTTPAPIBudget] = None
     max_concurrent_job_count: Optional[int] = Field(
         None,
-        description="Maximum number of concurrent async jobs to run. This is often set by the API's maximum number of concurrent jobs on the account level.",
+        description="Maximum number of concurrent async jobs to run. This property is only relevant for sources/streams that support asynchronous job execution (e.g. a Report stream that requires that initiates a job, polls the job status, and then fetches the job results). This is often set by the API's maximum number of concurrent jobs on the account level.",
         title="Maximum Concurrent Async Jobs",
     )
     metadata: Optional[Dict[str, Any]] = Field(

--- a/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
+++ b/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
@@ -9,6 +9,37 @@ from typing import Any, Dict, List, Literal, Optional, Union
 from pydantic.v1 import BaseModel, Extra, Field
 
 
+class Scope(Enum):
+    stream = "stream"
+    source = "source"
+
+
+class MaxConcurrentAsyncJobs(BaseModel):
+    max_concurrent_jobs: int = Field(
+        ...,
+        description="Maximum number of concurrent jobs to run. This value should be based on the API's maximum number of concurrent jobs per endpoint or overall on the account.",
+        title="Maximum Concurrent Jobs",
+    )
+    scope: Optional[Scope] = Field(
+        Scope.source,
+        description="Specifies whether the maximum number of concurrent jobs is applied per stream or per source. This value should based on whether the API sets a maximum number of concurrent jobs per endpoint or overall on the account.",
+        title="Scope",
+    )
+
+
+class MaxConcurrentAsyncJobs1(BaseModel):
+    max_concurrent_jobs: int = Field(
+        ...,
+        description="Maximum number of concurrent jobs to run. This value should be based on the API's maximum number of concurrent jobs per endpoint or overall on the account.",
+        title="Maximum Concurrent Jobs",
+    )
+    scope: Optional[Scope] = Field(
+        Scope.source,
+        description="Specifies whether the maximum number of concurrent jobs is applied per stream or per source. This value should based on whether the API sets a maximum number of concurrent jobs per endpoint or overall on the account.",
+        title="Scope",
+    )
+
+
 class AuthFlowType(Enum):
     oauth2_0 = "oauth2.0"
     oauth1_0 = "oauth1.0"
@@ -609,7 +640,9 @@ class OAuthAuthenticator(BaseModel):
     scopes: Optional[List[str]] = Field(
         None,
         description="List of scopes that should be granted to the access token.",
-        examples=[["crm.list.read", "crm.objects.contacts.read", "crm.schema.contacts.read"]],
+        examples=[
+            ["crm.list.read", "crm.objects.contacts.read", "crm.schema.contacts.read"]
+        ],
         title="Scopes",
     )
     token_expiry_date: Optional[str] = Field(
@@ -1078,24 +1111,28 @@ class OAuthConfigSpecification(BaseModel):
     class Config:
         extra = Extra.allow
 
-    oauth_user_input_from_connector_config_specification: Optional[Dict[str, Any]] = Field(
-        None,
-        description="OAuth specific blob. This is a Json Schema used to validate Json configurations used as input to OAuth.\nMust be a valid non-nested JSON that refers to properties from ConnectorSpecification.connectionSpecification\nusing special annotation 'path_in_connector_config'.\nThese are input values the user is entering through the UI to authenticate to the connector, that might also shared\nas inputs for syncing data via the connector.\nExamples:\nif no connector values is shared during oauth flow, oauth_user_input_from_connector_config_specification=[]\nif connector values such as 'app_id' inside the top level are used to generate the API url for the oauth flow,\n  oauth_user_input_from_connector_config_specification={\n    app_id: {\n      type: string\n      path_in_connector_config: ['app_id']\n    }\n  }\nif connector values such as 'info.app_id' nested inside another object are used to generate the API url for the oauth flow,\n  oauth_user_input_from_connector_config_specification={\n    app_id: {\n      type: string\n      path_in_connector_config: ['info', 'app_id']\n    }\n  }",
-        examples=[
-            {"app_id": {"type": "string", "path_in_connector_config": ["app_id"]}},
-            {
-                "app_id": {
-                    "type": "string",
-                    "path_in_connector_config": ["info", "app_id"],
-                }
-            },
-        ],
-        title="OAuth user input",
+    oauth_user_input_from_connector_config_specification: Optional[Dict[str, Any]] = (
+        Field(
+            None,
+            description="OAuth specific blob. This is a Json Schema used to validate Json configurations used as input to OAuth.\nMust be a valid non-nested JSON that refers to properties from ConnectorSpecification.connectionSpecification\nusing special annotation 'path_in_connector_config'.\nThese are input values the user is entering through the UI to authenticate to the connector, that might also shared\nas inputs for syncing data via the connector.\nExamples:\nif no connector values is shared during oauth flow, oauth_user_input_from_connector_config_specification=[]\nif connector values such as 'app_id' inside the top level are used to generate the API url for the oauth flow,\n  oauth_user_input_from_connector_config_specification={\n    app_id: {\n      type: string\n      path_in_connector_config: ['app_id']\n    }\n  }\nif connector values such as 'info.app_id' nested inside another object are used to generate the API url for the oauth flow,\n  oauth_user_input_from_connector_config_specification={\n    app_id: {\n      type: string\n      path_in_connector_config: ['info', 'app_id']\n    }\n  }",
+            examples=[
+                {"app_id": {"type": "string", "path_in_connector_config": ["app_id"]}},
+                {
+                    "app_id": {
+                        "type": "string",
+                        "path_in_connector_config": ["info", "app_id"],
+                    }
+                },
+            ],
+            title="OAuth user input",
+        )
     )
-    oauth_connector_input_specification: Optional[OauthConnectorInputSpecification] = Field(
-        None,
-        description='The DeclarativeOAuth specific blob.\nPertains to the fields defined by the connector relating to the OAuth flow.\n\nInterpolation capabilities:\n- The variables placeholders are declared as `{{my_var}}`.\n- The nested resolution variables like `{{ {{my_nested_var}} }}` is allowed as well.\n\n- The allowed interpolation context is:\n  + base64Encoder - encode to `base64`, {{ {{my_var_a}}:{{my_var_b}} | base64Encoder }}\n  + base64Decorer - decode from `base64` encoded string, {{ {{my_string_variable_or_string_value}} | base64Decoder }}\n  + urlEncoder - encode the input string to URL-like format, {{ https://test.host.com/endpoint | urlEncoder}}\n  + urlDecorer - decode the input url-encoded string into text format, {{ urlDecoder:https%3A%2F%2Fairbyte.io | urlDecoder}}\n  + codeChallengeS256 - get the `codeChallenge` encoded value to provide additional data-provider specific authorisation values, {{ {{state_value}} | codeChallengeS256 }}\n\nExamples:\n  - The TikTok Marketing DeclarativeOAuth spec:\n  {\n    "oauth_connector_input_specification": {\n      "type": "object",\n      "additionalProperties": false,\n      "properties": {\n          "consent_url": "https://ads.tiktok.com/marketing_api/auth?{{client_id_key}}={{client_id_value}}&{{redirect_uri_key}}={{ {{redirect_uri_value}} | urlEncoder}}&{{state_key}}={{state_value}}",\n          "access_token_url": "https://business-api.tiktok.com/open_api/v1.3/oauth2/access_token/",\n          "access_token_params": {\n              "{{ auth_code_key }}": "{{ auth_code_value }}",\n              "{{ client_id_key }}": "{{ client_id_value }}",\n              "{{ client_secret_key }}": "{{ client_secret_value }}"\n          },\n          "access_token_headers": {\n              "Content-Type": "application/json",\n              "Accept": "application/json"\n          },\n          "extract_output": ["data.access_token"],\n          "client_id_key": "app_id",\n          "client_secret_key": "secret",\n          "auth_code_key": "auth_code"\n      }\n    }\n  }',
-        title="DeclarativeOAuth Connector Specification",
+    oauth_connector_input_specification: Optional[OauthConnectorInputSpecification] = (
+        Field(
+            None,
+            description='The DeclarativeOAuth specific blob.\nPertains to the fields defined by the connector relating to the OAuth flow.\n\nInterpolation capabilities:\n- The variables placeholders are declared as `{{my_var}}`.\n- The nested resolution variables like `{{ {{my_nested_var}} }}` is allowed as well.\n\n- The allowed interpolation context is:\n  + base64Encoder - encode to `base64`, {{ {{my_var_a}}:{{my_var_b}} | base64Encoder }}\n  + base64Decorer - decode from `base64` encoded string, {{ {{my_string_variable_or_string_value}} | base64Decoder }}\n  + urlEncoder - encode the input string to URL-like format, {{ https://test.host.com/endpoint | urlEncoder}}\n  + urlDecorer - decode the input url-encoded string into text format, {{ urlDecoder:https%3A%2F%2Fairbyte.io | urlDecoder}}\n  + codeChallengeS256 - get the `codeChallenge` encoded value to provide additional data-provider specific authorisation values, {{ {{state_value}} | codeChallengeS256 }}\n\nExamples:\n  - The TikTok Marketing DeclarativeOAuth spec:\n  {\n    "oauth_connector_input_specification": {\n      "type": "object",\n      "additionalProperties": false,\n      "properties": {\n          "consent_url": "https://ads.tiktok.com/marketing_api/auth?{{client_id_key}}={{client_id_value}}&{{redirect_uri_key}}={{ {{redirect_uri_value}} | urlEncoder}}&{{state_key}}={{state_value}}",\n          "access_token_url": "https://business-api.tiktok.com/open_api/v1.3/oauth2/access_token/",\n          "access_token_params": {\n              "{{ auth_code_key }}": "{{ auth_code_value }}",\n              "{{ client_id_key }}": "{{ client_id_value }}",\n              "{{ client_secret_key }}": "{{ client_secret_value }}"\n          },\n          "access_token_headers": {\n              "Content-Type": "application/json",\n              "Accept": "application/json"\n          },\n          "extract_output": ["data.access_token"],\n          "client_id_key": "app_id",\n          "client_secret_key": "secret",\n          "auth_code_key": "auth_code"\n      }\n    }\n  }',
+            title="DeclarativeOAuth Connector Specification",
+        )
     )
     complete_oauth_output_specification: Optional[Dict[str, Any]] = Field(
         None,
@@ -1113,7 +1150,9 @@ class OAuthConfigSpecification(BaseModel):
     complete_oauth_server_input_specification: Optional[Dict[str, Any]] = Field(
         None,
         description="OAuth specific blob. This is a Json Schema used to validate Json configurations persisted as Airbyte Server configurations.\nMust be a valid non-nested JSON describing additional fields configured by the Airbyte Instance or Workspace Admins to be used by the\nserver when completing an OAuth flow (typically exchanging an auth code for refresh token).\nExamples:\n    complete_oauth_server_input_specification={\n      client_id: {\n        type: string\n      },\n      client_secret: {\n        type: string\n      }\n    }",
-        examples=[{"client_id": {"type": "string"}, "client_secret": {"type": "string"}}],
+        examples=[
+            {"client_id": {"type": "string"}, "client_secret": {"type": "string"}}
+        ],
         title="OAuth input specification",
     )
     complete_oauth_server_output_specification: Optional[Dict[str, Any]] = Field(
@@ -1766,7 +1805,9 @@ class RecordSelector(BaseModel):
         description="Responsible for filtering records to be emitted by the Source.",
         title="Record Filter",
     )
-    schema_normalization: Optional[Union[SchemaNormalization, CustomSchemaNormalization]] = Field(
+    schema_normalization: Optional[
+        Union[SchemaNormalization, CustomSchemaNormalization]
+    ] = Field(
         SchemaNormalization.None_,
         description="Responsible for normalization according to the schema.",
         title="Schema Normalization",
@@ -1871,6 +1912,11 @@ class DeclarativeSource1(BaseModel):
     spec: Optional[Spec] = None
     concurrency_level: Optional[ConcurrencyLevel] = None
     api_budget: Optional[HTTPAPIBudget] = None
+    max_concurrent_async_jobs: Optional[MaxConcurrentAsyncJobs] = Field(
+        None,
+        description="Maximum number of concurrent async jobs to run.",
+        title="Maximum Concurrent Async Jobs",
+    )
     metadata: Optional[Dict[str, Any]] = Field(
         None,
         description="For internal Airbyte use only - DO NOT modify manually. Used by consumers of declarative manifests for storing related metadata.",
@@ -1898,6 +1944,11 @@ class DeclarativeSource2(BaseModel):
     spec: Optional[Spec] = None
     concurrency_level: Optional[ConcurrencyLevel] = None
     api_budget: Optional[HTTPAPIBudget] = None
+    max_concurrent_async_jobs: Optional[MaxConcurrentAsyncJobs1] = Field(
+        None,
+        description="Maximum number of concurrent async jobs to run.",
+        title="Maximum Concurrent Async Jobs",
+    )
     metadata: Optional[Dict[str, Any]] = Field(
         None,
         description="For internal Airbyte use only - DO NOT modify manually. Used by consumers of declarative manifests for storing related metadata.",
@@ -1977,7 +2028,9 @@ class DeclarativeStream(BaseModel):
         description="Component used to fetch data incrementally based on a time field in the data.",
         title="Incremental Sync",
     )
-    name: Optional[str] = Field("", description="The stream name.", example=["Users"], title="Name")
+    name: Optional[str] = Field(
+        "", description="The stream name.", example=["Users"], title="Name"
+    )
     primary_key: Optional[PrimaryKey] = Field(
         "", description="The primary key of the stream.", title="Primary Key"
     )
@@ -2251,7 +2304,11 @@ class SimpleRetriever(BaseModel):
             CustomPartitionRouter,
             ListPartitionRouter,
             SubstreamPartitionRouter,
-            List[Union[CustomPartitionRouter, ListPartitionRouter, SubstreamPartitionRouter]],
+            List[
+                Union[
+                    CustomPartitionRouter, ListPartitionRouter, SubstreamPartitionRouter
+                ]
+            ],
         ]
     ] = Field(
         [],
@@ -2295,7 +2352,9 @@ class AsyncRetriever(BaseModel):
     )
     download_extractor: Optional[
         Union[CustomRecordExtractor, DpathExtractor, ResponseToFileExtractor]
-    ] = Field(None, description="Responsible for fetching the records from provided urls.")
+    ] = Field(
+        None, description="Responsible for fetching the records from provided urls."
+    )
     creation_requester: Union[CustomRequester, HttpRequester] = Field(
         ...,
         description="Requester component that describes how to prepare HTTP requests to send to the source API to create the async server-side job.",
@@ -2329,7 +2388,11 @@ class AsyncRetriever(BaseModel):
             CustomPartitionRouter,
             ListPartitionRouter,
             SubstreamPartitionRouter,
-            List[Union[CustomPartitionRouter, ListPartitionRouter, SubstreamPartitionRouter]],
+            List[
+                Union[
+                    CustomPartitionRouter, ListPartitionRouter, SubstreamPartitionRouter
+                ]
+            ],
         ]
     ] = Field(
         [],
@@ -2397,10 +2460,12 @@ class DynamicDeclarativeStream(BaseModel):
     stream_template: DeclarativeStream = Field(
         ..., description="Reference to the stream template.", title="Stream Template"
     )
-    components_resolver: Union[HttpComponentsResolver, ConfigComponentsResolver] = Field(
-        ...,
-        description="Component resolve and populates stream templates with components values.",
-        title="Components Resolver",
+    components_resolver: Union[HttpComponentsResolver, ConfigComponentsResolver] = (
+        Field(
+            ...,
+            description="Component resolve and populates stream templates with components values.",
+            title="Components Resolver",
+        )
     )
 
 

--- a/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
+++ b/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
@@ -9,37 +9,6 @@ from typing import Any, Dict, List, Literal, Optional, Union
 from pydantic.v1 import BaseModel, Extra, Field
 
 
-class Scope(Enum):
-    stream = "stream"
-    source = "source"
-
-
-class MaxConcurrentAsyncJobs(BaseModel):
-    max_concurrent_jobs: int = Field(
-        ...,
-        description="Maximum number of concurrent jobs to run. This value should be based on the API's maximum number of concurrent jobs per endpoint or overall on the account.",
-        title="Maximum Concurrent Jobs",
-    )
-    scope: Optional[Scope] = Field(
-        Scope.source,
-        description="Specifies whether the maximum number of concurrent jobs is applied per stream or per source. This value should based on whether the API sets a maximum number of concurrent jobs per endpoint or overall on the account.",
-        title="Scope",
-    )
-
-
-class MaxConcurrentAsyncJobs1(BaseModel):
-    max_concurrent_jobs: int = Field(
-        ...,
-        description="Maximum number of concurrent jobs to run. This value should be based on the API's maximum number of concurrent jobs per endpoint or overall on the account.",
-        title="Maximum Concurrent Jobs",
-    )
-    scope: Optional[Scope] = Field(
-        Scope.source,
-        description="Specifies whether the maximum number of concurrent jobs is applied per stream or per source. This value should based on whether the API sets a maximum number of concurrent jobs per endpoint or overall on the account.",
-        title="Scope",
-    )
-
-
 class AuthFlowType(Enum):
     oauth2_0 = "oauth2.0"
     oauth1_0 = "oauth1.0"
@@ -640,9 +609,7 @@ class OAuthAuthenticator(BaseModel):
     scopes: Optional[List[str]] = Field(
         None,
         description="List of scopes that should be granted to the access token.",
-        examples=[
-            ["crm.list.read", "crm.objects.contacts.read", "crm.schema.contacts.read"]
-        ],
+        examples=[["crm.list.read", "crm.objects.contacts.read", "crm.schema.contacts.read"]],
         title="Scopes",
     )
     token_expiry_date: Optional[str] = Field(
@@ -962,6 +929,14 @@ class CustomDecoder(BaseModel):
     parameters: Optional[Dict[str, Any]] = Field(None, alias="$parameters")
 
 
+class MaxConcurrentAsyncJobs(BaseModel):
+    max_concurrent_job_count: int = Field(
+        ...,
+        description="Maximum number of concurrent jobs to run. This is often set by the API's maximum number of concurrent jobs on the account level.",
+        title="Maximum Concurrent Job Count",
+    )
+
+
 class MinMaxDatetime(BaseModel):
     type: Literal["MinMaxDatetime"]
     datetime: str = Field(
@@ -1111,28 +1086,24 @@ class OAuthConfigSpecification(BaseModel):
     class Config:
         extra = Extra.allow
 
-    oauth_user_input_from_connector_config_specification: Optional[Dict[str, Any]] = (
-        Field(
-            None,
-            description="OAuth specific blob. This is a Json Schema used to validate Json configurations used as input to OAuth.\nMust be a valid non-nested JSON that refers to properties from ConnectorSpecification.connectionSpecification\nusing special annotation 'path_in_connector_config'.\nThese are input values the user is entering through the UI to authenticate to the connector, that might also shared\nas inputs for syncing data via the connector.\nExamples:\nif no connector values is shared during oauth flow, oauth_user_input_from_connector_config_specification=[]\nif connector values such as 'app_id' inside the top level are used to generate the API url for the oauth flow,\n  oauth_user_input_from_connector_config_specification={\n    app_id: {\n      type: string\n      path_in_connector_config: ['app_id']\n    }\n  }\nif connector values such as 'info.app_id' nested inside another object are used to generate the API url for the oauth flow,\n  oauth_user_input_from_connector_config_specification={\n    app_id: {\n      type: string\n      path_in_connector_config: ['info', 'app_id']\n    }\n  }",
-            examples=[
-                {"app_id": {"type": "string", "path_in_connector_config": ["app_id"]}},
-                {
-                    "app_id": {
-                        "type": "string",
-                        "path_in_connector_config": ["info", "app_id"],
-                    }
-                },
-            ],
-            title="OAuth user input",
-        )
+    oauth_user_input_from_connector_config_specification: Optional[Dict[str, Any]] = Field(
+        None,
+        description="OAuth specific blob. This is a Json Schema used to validate Json configurations used as input to OAuth.\nMust be a valid non-nested JSON that refers to properties from ConnectorSpecification.connectionSpecification\nusing special annotation 'path_in_connector_config'.\nThese are input values the user is entering through the UI to authenticate to the connector, that might also shared\nas inputs for syncing data via the connector.\nExamples:\nif no connector values is shared during oauth flow, oauth_user_input_from_connector_config_specification=[]\nif connector values such as 'app_id' inside the top level are used to generate the API url for the oauth flow,\n  oauth_user_input_from_connector_config_specification={\n    app_id: {\n      type: string\n      path_in_connector_config: ['app_id']\n    }\n  }\nif connector values such as 'info.app_id' nested inside another object are used to generate the API url for the oauth flow,\n  oauth_user_input_from_connector_config_specification={\n    app_id: {\n      type: string\n      path_in_connector_config: ['info', 'app_id']\n    }\n  }",
+        examples=[
+            {"app_id": {"type": "string", "path_in_connector_config": ["app_id"]}},
+            {
+                "app_id": {
+                    "type": "string",
+                    "path_in_connector_config": ["info", "app_id"],
+                }
+            },
+        ],
+        title="OAuth user input",
     )
-    oauth_connector_input_specification: Optional[OauthConnectorInputSpecification] = (
-        Field(
-            None,
-            description='The DeclarativeOAuth specific blob.\nPertains to the fields defined by the connector relating to the OAuth flow.\n\nInterpolation capabilities:\n- The variables placeholders are declared as `{{my_var}}`.\n- The nested resolution variables like `{{ {{my_nested_var}} }}` is allowed as well.\n\n- The allowed interpolation context is:\n  + base64Encoder - encode to `base64`, {{ {{my_var_a}}:{{my_var_b}} | base64Encoder }}\n  + base64Decorer - decode from `base64` encoded string, {{ {{my_string_variable_or_string_value}} | base64Decoder }}\n  + urlEncoder - encode the input string to URL-like format, {{ https://test.host.com/endpoint | urlEncoder}}\n  + urlDecorer - decode the input url-encoded string into text format, {{ urlDecoder:https%3A%2F%2Fairbyte.io | urlDecoder}}\n  + codeChallengeS256 - get the `codeChallenge` encoded value to provide additional data-provider specific authorisation values, {{ {{state_value}} | codeChallengeS256 }}\n\nExamples:\n  - The TikTok Marketing DeclarativeOAuth spec:\n  {\n    "oauth_connector_input_specification": {\n      "type": "object",\n      "additionalProperties": false,\n      "properties": {\n          "consent_url": "https://ads.tiktok.com/marketing_api/auth?{{client_id_key}}={{client_id_value}}&{{redirect_uri_key}}={{ {{redirect_uri_value}} | urlEncoder}}&{{state_key}}={{state_value}}",\n          "access_token_url": "https://business-api.tiktok.com/open_api/v1.3/oauth2/access_token/",\n          "access_token_params": {\n              "{{ auth_code_key }}": "{{ auth_code_value }}",\n              "{{ client_id_key }}": "{{ client_id_value }}",\n              "{{ client_secret_key }}": "{{ client_secret_value }}"\n          },\n          "access_token_headers": {\n              "Content-Type": "application/json",\n              "Accept": "application/json"\n          },\n          "extract_output": ["data.access_token"],\n          "client_id_key": "app_id",\n          "client_secret_key": "secret",\n          "auth_code_key": "auth_code"\n      }\n    }\n  }',
-            title="DeclarativeOAuth Connector Specification",
-        )
+    oauth_connector_input_specification: Optional[OauthConnectorInputSpecification] = Field(
+        None,
+        description='The DeclarativeOAuth specific blob.\nPertains to the fields defined by the connector relating to the OAuth flow.\n\nInterpolation capabilities:\n- The variables placeholders are declared as `{{my_var}}`.\n- The nested resolution variables like `{{ {{my_nested_var}} }}` is allowed as well.\n\n- The allowed interpolation context is:\n  + base64Encoder - encode to `base64`, {{ {{my_var_a}}:{{my_var_b}} | base64Encoder }}\n  + base64Decorer - decode from `base64` encoded string, {{ {{my_string_variable_or_string_value}} | base64Decoder }}\n  + urlEncoder - encode the input string to URL-like format, {{ https://test.host.com/endpoint | urlEncoder}}\n  + urlDecorer - decode the input url-encoded string into text format, {{ urlDecoder:https%3A%2F%2Fairbyte.io | urlDecoder}}\n  + codeChallengeS256 - get the `codeChallenge` encoded value to provide additional data-provider specific authorisation values, {{ {{state_value}} | codeChallengeS256 }}\n\nExamples:\n  - The TikTok Marketing DeclarativeOAuth spec:\n  {\n    "oauth_connector_input_specification": {\n      "type": "object",\n      "additionalProperties": false,\n      "properties": {\n          "consent_url": "https://ads.tiktok.com/marketing_api/auth?{{client_id_key}}={{client_id_value}}&{{redirect_uri_key}}={{ {{redirect_uri_value}} | urlEncoder}}&{{state_key}}={{state_value}}",\n          "access_token_url": "https://business-api.tiktok.com/open_api/v1.3/oauth2/access_token/",\n          "access_token_params": {\n              "{{ auth_code_key }}": "{{ auth_code_value }}",\n              "{{ client_id_key }}": "{{ client_id_value }}",\n              "{{ client_secret_key }}": "{{ client_secret_value }}"\n          },\n          "access_token_headers": {\n              "Content-Type": "application/json",\n              "Accept": "application/json"\n          },\n          "extract_output": ["data.access_token"],\n          "client_id_key": "app_id",\n          "client_secret_key": "secret",\n          "auth_code_key": "auth_code"\n      }\n    }\n  }',
+        title="DeclarativeOAuth Connector Specification",
     )
     complete_oauth_output_specification: Optional[Dict[str, Any]] = Field(
         None,
@@ -1150,9 +1121,7 @@ class OAuthConfigSpecification(BaseModel):
     complete_oauth_server_input_specification: Optional[Dict[str, Any]] = Field(
         None,
         description="OAuth specific blob. This is a Json Schema used to validate Json configurations persisted as Airbyte Server configurations.\nMust be a valid non-nested JSON describing additional fields configured by the Airbyte Instance or Workspace Admins to be used by the\nserver when completing an OAuth flow (typically exchanging an auth code for refresh token).\nExamples:\n    complete_oauth_server_input_specification={\n      client_id: {\n        type: string\n      },\n      client_secret: {\n        type: string\n      }\n    }",
-        examples=[
-            {"client_id": {"type": "string"}, "client_secret": {"type": "string"}}
-        ],
+        examples=[{"client_id": {"type": "string"}, "client_secret": {"type": "string"}}],
         title="OAuth input specification",
     )
     complete_oauth_server_output_specification: Optional[Dict[str, Any]] = Field(
@@ -1805,9 +1774,7 @@ class RecordSelector(BaseModel):
         description="Responsible for filtering records to be emitted by the Source.",
         title="Record Filter",
     )
-    schema_normalization: Optional[
-        Union[SchemaNormalization, CustomSchemaNormalization]
-    ] = Field(
+    schema_normalization: Optional[Union[SchemaNormalization, CustomSchemaNormalization]] = Field(
         SchemaNormalization.None_,
         description="Responsible for normalization according to the schema.",
         title="Schema Normalization",
@@ -1912,11 +1879,7 @@ class DeclarativeSource1(BaseModel):
     spec: Optional[Spec] = None
     concurrency_level: Optional[ConcurrencyLevel] = None
     api_budget: Optional[HTTPAPIBudget] = None
-    max_concurrent_async_jobs: Optional[MaxConcurrentAsyncJobs] = Field(
-        None,
-        description="Maximum number of concurrent async jobs to run.",
-        title="Maximum Concurrent Async Jobs",
-    )
+    max_concurrent_async_jobs: Optional[MaxConcurrentAsyncJobs] = None
     metadata: Optional[Dict[str, Any]] = Field(
         None,
         description="For internal Airbyte use only - DO NOT modify manually. Used by consumers of declarative manifests for storing related metadata.",
@@ -1944,11 +1907,7 @@ class DeclarativeSource2(BaseModel):
     spec: Optional[Spec] = None
     concurrency_level: Optional[ConcurrencyLevel] = None
     api_budget: Optional[HTTPAPIBudget] = None
-    max_concurrent_async_jobs: Optional[MaxConcurrentAsyncJobs1] = Field(
-        None,
-        description="Maximum number of concurrent async jobs to run.",
-        title="Maximum Concurrent Async Jobs",
-    )
+    max_concurrent_async_jobs: Optional[MaxConcurrentAsyncJobs] = None
     metadata: Optional[Dict[str, Any]] = Field(
         None,
         description="For internal Airbyte use only - DO NOT modify manually. Used by consumers of declarative manifests for storing related metadata.",
@@ -2028,9 +1987,7 @@ class DeclarativeStream(BaseModel):
         description="Component used to fetch data incrementally based on a time field in the data.",
         title="Incremental Sync",
     )
-    name: Optional[str] = Field(
-        "", description="The stream name.", example=["Users"], title="Name"
-    )
+    name: Optional[str] = Field("", description="The stream name.", example=["Users"], title="Name")
     primary_key: Optional[PrimaryKey] = Field(
         "", description="The primary key of the stream.", title="Primary Key"
     )
@@ -2304,11 +2261,7 @@ class SimpleRetriever(BaseModel):
             CustomPartitionRouter,
             ListPartitionRouter,
             SubstreamPartitionRouter,
-            List[
-                Union[
-                    CustomPartitionRouter, ListPartitionRouter, SubstreamPartitionRouter
-                ]
-            ],
+            List[Union[CustomPartitionRouter, ListPartitionRouter, SubstreamPartitionRouter]],
         ]
     ] = Field(
         [],
@@ -2352,9 +2305,7 @@ class AsyncRetriever(BaseModel):
     )
     download_extractor: Optional[
         Union[CustomRecordExtractor, DpathExtractor, ResponseToFileExtractor]
-    ] = Field(
-        None, description="Responsible for fetching the records from provided urls."
-    )
+    ] = Field(None, description="Responsible for fetching the records from provided urls.")
     creation_requester: Union[CustomRequester, HttpRequester] = Field(
         ...,
         description="Requester component that describes how to prepare HTTP requests to send to the source API to create the async server-side job.",
@@ -2388,11 +2339,7 @@ class AsyncRetriever(BaseModel):
             CustomPartitionRouter,
             ListPartitionRouter,
             SubstreamPartitionRouter,
-            List[
-                Union[
-                    CustomPartitionRouter, ListPartitionRouter, SubstreamPartitionRouter
-                ]
-            ],
+            List[Union[CustomPartitionRouter, ListPartitionRouter, SubstreamPartitionRouter]],
         ]
     ] = Field(
         [],
@@ -2460,12 +2407,10 @@ class DynamicDeclarativeStream(BaseModel):
     stream_template: DeclarativeStream = Field(
         ..., description="Reference to the stream template.", title="Stream Template"
     )
-    components_resolver: Union[HttpComponentsResolver, ConfigComponentsResolver] = (
-        Field(
-            ...,
-            description="Component resolve and populates stream templates with components values.",
-            title="Components Resolver",
-        )
+    components_resolver: Union[HttpComponentsResolver, ConfigComponentsResolver] = Field(
+        ...,
+        description="Component resolve and populates stream templates with components values.",
+        title="Components Resolver",
     )
 
 

--- a/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
+++ b/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
@@ -1873,8 +1873,8 @@ class DeclarativeSource1(BaseModel):
     api_budget: Optional[HTTPAPIBudget] = None
     max_concurrent_async_job_count: Optional[int] = Field(
         None,
-        description="Maximum number of concurrent async jobs to run. This property is only relevant for sources/streams that support asynchronous job execution (e.g. a Report stream that requires that initiates a job, polls the job status, and then fetches the job results). This is often set by the API's maximum number of concurrent jobs on the account level.",
-        title="Maximum Concurrent Async Jobs",
+        description="Maximum number of concurrent asynchronous jobs to run. This property is only relevant for sources/streams that support asynchronous job execution through the AsyncRetriever (e.g. a report-based stream that initiates a job, polls the job status, and then fetches the job results). This is often set by the API's maximum number of concurrent jobs on the account level. Refer to the API's documentation for this information.",
+        title="Maximum Concurrent Asynchronous Jobs",
     )
     metadata: Optional[Dict[str, Any]] = Field(
         None,
@@ -1905,8 +1905,8 @@ class DeclarativeSource2(BaseModel):
     api_budget: Optional[HTTPAPIBudget] = None
     max_concurrent_async_job_count: Optional[int] = Field(
         None,
-        description="Maximum number of concurrent async jobs to run. This property is only relevant for sources/streams that support asynchronous job execution (e.g. a Report stream that requires that initiates a job, polls the job status, and then fetches the job results). This is often set by the API's maximum number of concurrent jobs on the account level.",
-        title="Maximum Concurrent Async Jobs",
+        description="Maximum number of concurrent asynchronous jobs to run. This property is only relevant for sources/streams that support asynchronous job execution through the AsyncRetriever (e.g. a report-based stream that initiates a job, polls the job status, and then fetches the job results). This is often set by the API's maximum number of concurrent jobs on the account level. Refer to the API's documentation for this information.",
+        title="Maximum Concurrent Asynchronous Jobs",
     )
     metadata: Optional[Dict[str, Any]] = Field(
         None,

--- a/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
+++ b/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
@@ -1871,7 +1871,7 @@ class DeclarativeSource1(BaseModel):
     spec: Optional[Spec] = None
     concurrency_level: Optional[ConcurrencyLevel] = None
     api_budget: Optional[HTTPAPIBudget] = None
-    max_concurrent_job_count: Optional[int] = Field(
+    max_concurrent_async_job_count: Optional[int] = Field(
         None,
         description="Maximum number of concurrent async jobs to run. This property is only relevant for sources/streams that support asynchronous job execution (e.g. a Report stream that requires that initiates a job, polls the job status, and then fetches the job results). This is often set by the API's maximum number of concurrent jobs on the account level.",
         title="Maximum Concurrent Async Jobs",
@@ -1903,7 +1903,7 @@ class DeclarativeSource2(BaseModel):
     spec: Optional[Spec] = None
     concurrency_level: Optional[ConcurrencyLevel] = None
     api_budget: Optional[HTTPAPIBudget] = None
-    max_concurrent_job_count: Optional[int] = Field(
+    max_concurrent_async_job_count: Optional[int] = Field(
         None,
         description="Maximum number of concurrent async jobs to run. This property is only relevant for sources/streams that support asynchronous job execution (e.g. a Report stream that requires that initiates a job, polls the job status, and then fetches the job results). This is often set by the API's maximum number of concurrent jobs on the account level.",
         title="Maximum Concurrent Async Jobs",

--- a/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -541,7 +541,7 @@ class ModelToComponentFactory:
         )
         self._connector_state_manager = connector_state_manager or ConnectorStateManager()
         self._api_budget: Optional[Union[APIBudget, HttpAPIBudget]] = None
-        self._job_tracker: Optional[JobTracker] = self._set_max_concurrent_async_job_count(
+        self._job_tracker: Optional[JobTracker] = self._create_async_job_tracker(
             source_config=source_config
         )
 
@@ -3225,7 +3225,7 @@ class ModelToComponentFactory:
             model_type=HTTPAPIBudgetModel, component_definition=component_definition, config=config
         )
 
-    def _set_max_concurrent_async_job_count(
+    def _create_async_job_tracker(
         self, source_config: ConnectionDefinition
     ) -> Optional[JobTracker]:
         """

--- a/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -541,8 +541,10 @@ class ModelToComponentFactory:
         )
         self._connector_state_manager = connector_state_manager or ConnectorStateManager()
         self._api_budget: Optional[Union[APIBudget, HttpAPIBudget]] = None
-        self._job_tracker: Optional[JobTracker] = self._create_async_job_tracker(
-            source_config=source_config
+        self._job_tracker: Optional[JobTracker] = (
+            self._create_async_job_tracker(source_config=source_config)
+            if source_config
+            else None
         )
 
     def _init_mappings(self) -> None:
@@ -2928,8 +2930,7 @@ class ModelToComponentFactory:
             download_target_extractor=download_target_extractor,
         )
 
-        if not self._job_tracker:
-            self._job_tracker = JobTracker(1)
+        self._job_tracker = JobTracker(1) if not self._job_tracker else self._job_tracker
 
         async_job_partition_router = AsyncJobPartitionRouter(
             job_orchestrator_factory=lambda stream_slices: AsyncJobOrchestrator(

--- a/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -541,7 +541,7 @@ class ModelToComponentFactory:
         )
         self._connector_state_manager = connector_state_manager or ConnectorStateManager()
         self._api_budget: Optional[Union[APIBudget, HttpAPIBudget]] = None
-        self._job_tracker = JobTracker(max_concurrent_async_job_count or 1)
+        self._job_tracker: JobTracker = JobTracker(max_concurrent_async_job_count or 1)
 
     def _init_mappings(self) -> None:
         self.PYDANTIC_MODEL_TO_CONSTRUCTOR: Mapping[Type[BaseModel], Callable[..., Any]] = {

--- a/unit_tests/sources/declarative/async_job/test_job_tracker.py
+++ b/unit_tests/sources/declarative/async_job/test_job_tracker.py
@@ -39,3 +39,9 @@ class JobTrackerTest(TestCase):
 
     def _reach_limit(self) -> List[str]:
         return [self._tracker.try_to_get_intent() for i in range(_LIMIT)]
+
+
+@pytest.mark.parametrize("limit", [-1, 0])
+def test_given_limit_is_less_than_1_when_init_then_set_to_1(limit: int):
+    tracker = JobTracker(limit)
+    assert tracker._limit == 1


### PR DESCRIPTION
## What
Enables source-level job tracking and job count limit for async jobs managed by each stream's `AsyncJobOrchestrator`.

- Adds new optional `max_concurrent_async_job_count` top-level property in manifest and passes to `ModelToComponentFactory` where a `JobTracker` component is instantiated in its conctructor w/ the defined job count value.
- Closes https://github.com/airbytehq/airbyte-internal-issues/issues/11343

## Recommended Review Order
1. `declarative_component_schema.yaml`
2. `manifest_declarative_source.py`
3. `model_to_component_factory.py`
4. `job_tracker.py`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced a new configuration option, "Maximum Concurrent Async Jobs", allowing users to specify the maximum number of asynchronous jobs.
  - Enhanced the handling of job tracking to ensure consistent usage of the same tracker instance across components.

- **Bug Fixes**
  - Improved job limit handling by enforcing a minimum value of 1, preventing scenarios with invalid job limits.

- **Tests**
  - Added new test coverage for the `JobTracker` class to validate behavior when initialized with limits less than 1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->