### PR TITLE
fix(low-code cdk): fix set_initial_state for incremental_dependency and empty parent state

### DIFF
--- a/airbyte_cdk/sources/declarative/partition_routers/substream_partition_router.py
+++ b/airbyte_cdk/sources/declarative/partition_routers/substream_partition_router.py
@@ -280,20 +280,12 @@ class SubstreamPartitionRouter(PartitionRouter):
 
         parent_state = stream_state.get("parent_state", {})
 
-        # If `parent_state` doesn't exist and at least one parent stream has an incremental dependency,
-        # copy the child state to parent streams with incremental dependencies.
-        incremental_dependency = any(
-            [parent_config.incremental_dependency for parent_config in self.parent_stream_configs]
-        )
-        if not parent_state and not incremental_dependency:
-            return
-
-        if not parent_state and incremental_dependency:
-            # Migrate child state to parent state format
-            parent_state = self._migrate_child_state_to_parent_state(stream_state)
-
         # Set state for each parent stream with an incremental dependency
         for parent_config in self.parent_stream_configs:
+            if not parent_state.get(parent_config.stream.name, {}) and parent_config.incremental_dependency:
+                # Migrate child state to parent state format
+                parent_state = self._migrate_child_state_to_parent_state(stream_state)
+
             if parent_config.incremental_dependency:
                 parent_config.stream.state = parent_state.get(parent_config.stream.name, {})
 

--- a/airbyte_cdk/sources/declarative/partition_routers/substream_partition_router.py
+++ b/airbyte_cdk/sources/declarative/partition_routers/substream_partition_router.py
@@ -282,7 +282,10 @@ class SubstreamPartitionRouter(PartitionRouter):
 
         # Set state for each parent stream with an incremental dependency
         for parent_config in self.parent_stream_configs:
-            if not parent_state.get(parent_config.stream.name, {}) and parent_config.incremental_dependency:
+            if (
+                not parent_state.get(parent_config.stream.name, {})
+                and parent_config.incremental_dependency
+            ):
                 # Migrate child state to parent state format
                 parent_state = self._migrate_child_state_to_parent_state(stream_state)
 


### PR DESCRIPTION
Fixed: https://github.com/airbytehq/airbyte-internal-issues/issues/11934

This PR updates `set_initial_state` to handle cases where child-to-parent state migration is skipped when the parent state looks like:

```json
"parent_state": {
    "parent_stream_name": {
        "parent_stream_cursor": ""
    }
}
``` 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined the process for managing initialization and migration of state data, resulting in a more robust and efficient workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->