### PR TITLE
chore: rename AIRBYTE_ALLOW_CUSTOM_CODE to AIRBYTE_ENABLE_UNSAFE_CODE

### DIFF
--- a/airbyte_cdk/sources/declarative/parsers/custom_code_compiler.py
+++ b/airbyte_cdk/sources/declarative/parsers/custom_code_compiler.py
@@ -19,7 +19,7 @@ SDM_COMPONENTS_MODULE_NAME = "source_declarative_manifest.components"
 INJECTED_MANIFEST = "__injected_declarative_manifest"
 INJECTED_COMPONENTS_PY = "__injected_components_py"
 INJECTED_COMPONENTS_PY_CHECKSUMS = "__injected_components_py_checksums"
-ENV_VAR_ALLOW_CUSTOM_CODE = "AIRBYTE_ALLOW_CUSTOM_CODE"
+ENV_VAR_ALLOW_CUSTOM_CODE = "AIRBYTE_ENABLE_UNSAFE_CODE"
 
 
 class AirbyteCodeTamperedError(Exception):
@@ -35,7 +35,7 @@ class AirbyteCustomCodeNotPermittedError(Exception):
     def __init__(self) -> None:
         super().__init__(
             "Custom connector code is not permitted in this environment. "
-            "If you need to run custom code, please ask your administrator to set the `AIRBYTE_ALLOW_CUSTOM_CODE` "
+            "If you need to run custom code, please ask your administrator to set the `AIRBYTE_ENABLE_UNSAFE_CODE` "
             "environment variable to 'true' in your Airbyte environment. "
             "If you see this message in Airbyte Cloud, your workspace does not allow executing "
             "custom connector code."
@@ -55,7 +55,7 @@ def _hash_text(input_text: str, hash_type: str = "md5") -> str:
 def custom_code_execution_permitted() -> bool:
     """Return `True` if custom code execution is permitted, otherwise `False`.
 
-    Custom code execution is permitted if the `AIRBYTE_ALLOW_CUSTOM_CODE` environment variable is set to 'true'.
+    Custom code execution is permitted if the `AIRBYTE_ENABLE_UNSAFE_CODE` environment variable is set to 'true'.
     """
     return os.environ.get(ENV_VAR_ALLOW_CUSTOM_CODE, "").lower() == "true"
 


### PR DESCRIPTION
## What
- The PR addresses [a comment](https://github.com/airbytehq/airbyte-platform-internal/pull/15491) from AJ Steers regarding environment variable consistency.
- It renames the environment variable used to enable unsafe code (AIRBYTE_ALLOW_CUSTOM_CODE) to AIRBYTE_ENABLE_UNSAFE_CODE.

## How
- Updated the environment variable name for clarity and consistency.
- Ensured that the variable matches the one in the source declarative manifest.

## Additional Context
- This change was prompted by a discussion in a different PR.
- Aims to improve alignment between platform and manifest settings.

## Notes for Reviewer
- Review the changes to ensure the new variable name is correctly implemented.
- Confirm that the new name aligns with the declarative manifest requirements.

## Recommended Reading Order
- Review the comments from AJ Steers on the original PR.
- Examine the changes made in this PR for context.

## Can This PR Be Reverted and Rolled Back
- Yes, if any issues arise, this PR can be reverted by restoring the previous variable name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated error messages and user instructions to reference the new configuration setting for custom code execution.
- **Chores**
	- Renamed the environment variable to improve clarity without impacting functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->