### PR TITLE
fix: (CDK) (AsyncRetriever) - fix `availability strategy` issues, during `check connection`

### DIFF
--- a/airbyte_cdk/sources/declarative/retrievers/async_retriever.py
+++ b/airbyte_cdk/sources/declarative/retrievers/async_retriever.py
@@ -49,16 +49,22 @@ class AsyncRetriever(Retriever):
          - If the `creation_requester` can place / create the job - it means all other requesters should successfully manage
            to complete the results.
         """
-        return self.stream_slicer._job_orchestrator._job_repository.creation_requester.exit_on_rate_limit  # type: ignore[return-value]
+        job_orchestrator = self.stream_slicer._job_orchestrator
+        if job_orchestrator is None:
+            # Default value when orchestrator is not available
+            return False
+        return job_orchestrator._job_repository.creation_requester.exit_on_rate_limit  # type: ignore
 
     @exit_on_rate_limit.setter
     def exit_on_rate_limit(self, value: bool) -> None:
         """
         Sets the `exit_on_rate_limit` property of the job repository > creation_requester,
         meaning that the Job cannot be placed / created if the rate limit is reached.
-        Thus no futher work on managing jobs is expected to be done.
+        Thus no further work on managing jobs is expected to be done.
         """
-        self.stream_slicer._job_orchestrator._job_repository.creation_requester.exit_on_rate_limit = value  # type: ignore[assignment]
+        job_orchestrator = self.stream_slicer._job_orchestrator
+        if job_orchestrator is not None:
+            job_orchestrator._job_repository.creation_requester.exit_on_rate_limit = value  # type: ignore[attr-defined, assignment]
 
     @property
     def state(self) -> StreamState:

--- a/airbyte_cdk/sources/declarative/retrievers/async_retriever.py
+++ b/airbyte_cdk/sources/declarative/retrievers/async_retriever.py
@@ -37,6 +37,30 @@ class AsyncRetriever(Retriever):
         self._parameters = parameters
 
     @property
+    def exit_on_rate_limit(self) -> bool:
+        """
+        Whether to exit on rate limit. This is a property of the job repository
+        and not the stream slicer. The stream slicer is responsible for creating
+        the jobs, but the job repository is responsible for managing the rate
+        limits and other job-related properties.
+
+        Note:
+         - If the `creation_requester` cannot place / create the job - it might be the case of the RateLimits
+         - If the `creation_requester` can place / create the job - it means all other requesters should successfully manage
+           to complete the results.
+        """
+        return self.stream_slicer._job_orchestrator._job_repository.creation_requester.exit_on_rate_limit  # type: ignore[return-value]
+
+    @exit_on_rate_limit.setter
+    def exit_on_rate_limit(self, value: bool) -> None:
+        """
+        Sets the `exit_on_rate_limit` property of the job repository > creation_requester,
+        meaning that the Job cannot be placed / created if the rate limit is reached.
+        Thus no futher work on managing jobs is expected to be done.
+        """
+        self.stream_slicer._job_orchestrator._job_repository.creation_requester.exit_on_rate_limit = value  # type: ignore[assignment]
+
+    @property
     def state(self) -> StreamState:
         """
         As a first iteration for sendgrid, there is no state to be managed


### PR DESCRIPTION
## What
Original Slack conversation: https://airbytehq-team.slack.com/archives/C07JMAAE620/p1741825218622419

Problem Statement:
- Attempting to utilize the name of an asynchronous stream in CheckStream resulted in an error during the check request process when attempting to establish a Source for that manifest.
- The issue is associated with the `availability strategy` that searches for the `retriever.requester.exit_on_rate_limits`, which is not available for the `AsyncRetriever`.

## How
- created dedicated property methods to expose the `creation_requester.exit_on_rate_limits` and re-use it

## User Impact
With this update, customers who utilize the `AsyncRetriever` will now have the capability to specify the asynchronous stream as the one for checking the connection. This was not the case previously.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an asynchronous retrieval mode with enhanced rate limit handling, providing improved flexibility in managing job creation when limits are reached.
  
- **Documentation**
  - Updated guidance and explanations around rate limit management in asynchronous operations for clearer understanding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->