### PR TITLE
fix(low-code cdk): fix partition router validation for async retriever

### DIFF
--- a/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -1900,6 +1900,8 @@ class ModelToComponentFactory:
     ) -> Optional[StreamSlicer]:
         retriever_model = model.retriever
 
+        stream_slicer = self._build_stream_slicer_from_partition_router(retriever_model, config)
+
         if retriever_model.type == "AsyncRetriever":
             is_not_datetime_cursor = (
                 model.incremental_sync.type != "DatetimeBasedCursor"
@@ -1919,12 +1921,10 @@ class ModelToComponentFactory:
                     "AsyncRetriever with cursor other than DatetimeBasedCursor is not supported yet."
                 )
 
-            if is_partition_router:
+            if is_partition_router and not stream_slicer:
                 # Note that this development is also done in parallel to the per partition development which once merged
                 # we could support here by calling create_concurrent_cursor_from_perpartition_cursor
                 raise ValueError("Per partition state is not supported yet for AsyncRetriever.")
-
-        stream_slicer = self._build_stream_slicer_from_partition_router(retriever_model, config)
 
         if model.incremental_sync:
             return self._build_incremental_cursor(model, stream_slicer, config)


### PR DESCRIPTION
This PR fixes an issue with `partition_router` validation for AsyncRetriever and allows creating a slicer when `stream_slicer_from_partition_router` is built.

link to thread - https://airbytehq-team.slack.com/archives/C02U9R3AF37/p1741883530973919