### PR TITLE
fix: When grouping streams, ensure stream is declarative before checking in the manifest

### DIFF
--- a/airbyte_cdk/sources/declarative/concurrent_declarative_source.py
+++ b/airbyte_cdk/sources/declarative/concurrent_declarative_source.py
@@ -206,7 +206,7 @@ class ConcurrentDeclarativeSource(ManifestDeclarativeSource, Generic[TState]):
             # these legacy Python streams the way we do low-code streams to determine if they are concurrent compatible,
             # so we need to treat them as synchronous
 
-            if name_to_stream_mapping[declarative_stream.name]["type"] == "StateDelegatingStream":
+            if isinstance(declarative_stream, DeclarativeStream) and name_to_stream_mapping[declarative_stream.name]["type"] == "StateDelegatingStream":
                 stream_state = self._connector_state_manager.get_stream_state(
                     stream_name=declarative_stream.name, namespace=declarative_stream.namespace
                 )

--- a/airbyte_cdk/sources/declarative/concurrent_declarative_source.py
+++ b/airbyte_cdk/sources/declarative/concurrent_declarative_source.py
@@ -206,7 +206,11 @@ class ConcurrentDeclarativeSource(ManifestDeclarativeSource, Generic[TState]):
             # these legacy Python streams the way we do low-code streams to determine if they are concurrent compatible,
             # so we need to treat them as synchronous
 
-            if isinstance(declarative_stream, DeclarativeStream) and name_to_stream_mapping[declarative_stream.name]["type"] == "StateDelegatingStream":
+            if (
+                isinstance(declarative_stream, DeclarativeStream)
+                and name_to_stream_mapping[declarative_stream.name]["type"]
+                == "StateDelegatingStream"
+            ):
                 stream_state = self._connector_state_manager.get_stream_state(
                     stream_name=declarative_stream.name, namespace=declarative_stream.namespace
                 )


### PR DESCRIPTION
## What 

If a stream returned by `streams` is not declarative, we would get a key error as such:

```
  File "/Users/maxime/devel/code/airbyte-python-cdk/airbyte_cdk/sources/declarative/concurrent_declarative_source.py", line 209, in _group_streams
    if name_to_stream_mapping[declarative_stream.name]["type"] == "StateDelegatingStream":
KeyError: 'articles'
```

## How
Checking if the stream is declarative before checking in the manifest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved validation of data streams to prevent potential processing errors and enhance overall reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->