### PR TITLE
fix(test): Check method when comparing matchers

### DIFF
--- a/unit_tests/test/mock_http/test_mocker.py
+++ b/unit_tests/test/mock_http/test_mocker.py
@@ -295,10 +295,17 @@ class HttpMockerTest(TestCase):
         with pytest.raises(ValueError):
             decorated_function()
 
-    def test_given_request_already_mocked_when_decorate_then_raise(self):
+    def test_given_request_already_mocked_when_mock_then_raise(self):
         with HttpMocker() as http_mocker:
             a_request = HttpRequest(_A_URL, _SOME_QUERY_PARAMS, _SOME_HEADERS)
             http_mocker.get(a_request, _A_RESPONSE)
 
             with pytest.raises(ValueError):
                 http_mocker.get(a_request, _A_RESPONSE)
+
+    def test_given_same_request_with_different_method_when_mock_then_do_not_raise(self):
+        with HttpMocker() as http_mocker:
+            a_request = HttpRequest(_A_URL, _SOME_QUERY_PARAMS, _SOME_HEADERS)
+            http_mocker.get(a_request, _A_RESPONSE)
+
+            http_mocker.delete(a_request, _A_RESPONSE)


### PR DESCRIPTION
## What

[This test](https://github.com/airbytehq/airbyte/blob/ea7fdb07b233ebfaf83c0454597a923e1ed9de0a/airbyte-integrations/connectors/source-salesforce/unit_tests/integration/test_bulk_stream.py#L121) (and others but I'm using this one as an example) were failing after updating the CDK version. The reason is that the polling and delete requests are identical except from the method. 

## How

So maybe HttpRequest should have the method but it does not seem like an easy change for now as this would be a breaking change (i.e. requiring the method in the HttpRequest) and it also goes against how the HttpMocker was structure by having one method per method. Those are probably errors from the past and things we would do differently in the future but eh...!

So for now, I've just:
* added the method in the comparison in HttpMocker
* matched on the reference and not the __eq__ in `assert_number_of_calls`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced internal HTTP request handling by organizing requests by method, leading to more precise matching and clearer error reporting.
  
- **Tests**
  - Improved and expanded test scenarios to ensure that requests with varying HTTP methods are validated correctly, boosting overall system reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->