### PR TITLE
fix: (CDK) (AsyncRetriever) - fix the regression. The `TIMEOUT` Job Status should Retry on server status.

### DIFF
--- a/airbyte_cdk/sources/declarative/async_job/job.py
+++ b/airbyte_cdk/sources/declarative/async_job/job.py
@@ -34,7 +34,7 @@ class AsyncJob:
 
     def status(self) -> AsyncJobStatus:
         if self._timer.has_timed_out():
-            return AsyncJobStatus.TIMED_OUT
+            return AsyncJobStatus.FORCED_TIME_OUT
         return self._status
 
     def job_parameters(self) -> StreamSlice:

--- a/airbyte_cdk/sources/declarative/async_job/job_orchestrator.py
+++ b/airbyte_cdk/sources/declarative/async_job/job_orchestrator.py
@@ -382,15 +382,15 @@ class AsyncJobOrchestrator:
 
     def _stop_timed_out_jobs(self, partition: AsyncPartition) -> None:
         for job in partition.jobs:
-            if job.status() == AsyncJobStatus.TIMED_OUT:
-                # we don't free allocation here because it is expected to retry the job
-                self._abort_job(job, free_job_allocation=False)
-            elif job.status() == AsyncJobStatus.FORCED_TIME_OUT:
+            if job.status() == AsyncJobStatus.FORCED_TIME_OUT:
                 self._abort_job(job, free_job_allocation=True)
                 raise AirbyteTracedException(
                     internal_message=f"Job {job.api_job_id()} has timed out. Try increasing the `polling job timeout`.",
                     failure_type=FailureType.config_error,
                 )
+            # we don't free allocation here because it is expected to retry the job
+            if job.status() == AsyncJobStatus.TIMED_OUT:
+                self._abort_job(job, free_job_allocation=False)
 
     def _abort_job(self, job: AsyncJob, free_job_allocation: bool = True) -> None:
         try:

--- a/airbyte_cdk/sources/declarative/async_job/status.py
+++ b/airbyte_cdk/sources/declarative/async_job/status.py
@@ -11,6 +11,8 @@ class AsyncJobStatus(Enum):
     COMPLETED = ("COMPLETED", _TERMINAL)
     FAILED = ("FAILED", _TERMINAL)
     TIMED_OUT = ("TIMED_OUT", _TERMINAL)
+    # service status to force the job to be stopped by the system
+    FORCED_TIME_OUT = ("FORCED_TIME_OUT", _TERMINAL)
 
     def __init__(self, value: str, is_terminal: bool) -> None:
         self._value = value
@@ -19,6 +21,6 @@ class AsyncJobStatus(Enum):
     def is_terminal(self) -> bool:
         """
         A status is terminal when a job status can't be updated anymore. For example if a job is completed, it will stay completed but a
-        running job might because completed, failed or timed out.
+        running job might become completed, failed or timed out.
         """
         return self._is_terminal

--- a/unit_tests/sources/declarative/async_job/test_job.py
+++ b/unit_tests/sources/declarative/async_job/test_job.py
@@ -19,10 +19,10 @@ class AsyncJobTest(TestCase):
         job = AsyncJob(_AN_API_JOB_ID, _ANY_STREAM_SLICE, _A_VERY_BIG_TIMEOUT)
         assert job.status() == AsyncJobStatus.RUNNING
 
-    def test_given_timer_is_out_when_status_then_return_timed_out(self) -> None:
+    def test_given_timer_is_out_when_status_then_return_forced_time_out(self) -> None:
         job = AsyncJob(_AN_API_JOB_ID, _ANY_STREAM_SLICE, _IMMEDIATELY_TIMED_OUT)
         time.sleep(0.001)
-        assert job.status() == AsyncJobStatus.TIMED_OUT
+        assert job.status() == AsyncJobStatus.FORCED_TIME_OUT
 
     def test_given_status_is_terminal_when_update_status_then_stop_timer(self) -> None:
         """

--- a/unit_tests/sources/declarative/async_job/test_job_orchestrator.py
+++ b/unit_tests/sources/declarative/async_job/test_job_orchestrator.py
@@ -144,6 +144,26 @@ class AsyncJobOrchestratorTest(TestCase):
         )
         orchestrator = self._orchestrator([_A_STREAM_SLICE], job_tracker)
 
+        with pytest.raises(AirbyteTracedException):
+            list(orchestrator.create_and_get_completed_partitions())
+
+        assert job_tracker.try_to_get_intent()
+        assert (
+            self._job_repository.start.call_args_list
+            == [call(_A_STREAM_SLICE)] * _MAX_NUMBER_OF_ATTEMPTS
+        )
+
+    @mock.patch(sleep_mock_target)
+    def test_given_forced_timeout_when_create_and_get_completed_partitions_then_free_budget_and_raise_exception(
+        self, mock_sleep: MagicMock
+    ) -> None:
+        job_tracker = JobTracker(1)
+        self._job_repository.start.return_value = self._job_for_a_slice
+        self._job_repository.update_jobs_status.side_effect = _status_update_per_jobs(
+            {self._job_for_a_slice: [AsyncJobStatus.FORCED_TIME_OUT]}
+        )
+        orchestrator = self._orchestrator([_A_STREAM_SLICE], job_tracker)
+
         with pytest.raises(AirbyteTracedException) as error:
             list(orchestrator.create_and_get_completed_partitions())
 


### PR DESCRIPTION
## What 
Given this dialog: https://airbytehq-team.slack.com/archives/C07JMAAE620/p1742346710533189?thread_ts=1742236041.905529&cid=C07JMAAE620

Related to:
- https://github.com/airbytehq/airbyte-python-cdk/pull/429

There is a need to introduce the `FORCED_TIME_OUT` Job status, so we can distinguish between the Server Timeout status of the Job and the status that should be treated as a `dead end` because of the `pooling_job_timeout` limitation. This helps us to prevent inf loops when the `status_mapping` provided incorrectly, such as:
```yaml
status_mapping:
    failed:
      - failed
    running:
      - pending
      - ready # this should be under the `completed` type.
    timeout:
      - timeout
    completed:
      - dont_care_about_this_status # this is dummy status, doesn't exist.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced job management by introducing a distinct "Forced Timeout" state, providing clearer differentiation for timeout conditions.
  
- **Tests**
	- Added test scenarios to validate both standard and forced timeout behaviors, ensuring proper error handling and job management adjustments.
	- Updated existing test to reflect the new "Forced Timeout" status for improved accuracy in testing job status behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->