### PR TITLE
fix: update decoder title & descriptions for improved tooltip

### DIFF
--- a/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -2193,7 +2193,7 @@ definitions:
         additionalProperties: true
   JsonDecoder:
     title: Json Decoder
-    description: Select 'JSON' as the decoder to parse the response as JSON.
+    description: Select 'JSON' if the response is formatted as a JSON object.
     type: object
     required:
       - type

--- a/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -2193,6 +2193,7 @@ definitions:
         additionalProperties: true
   JsonDecoder:
     title: Json Decoder
+    description: Select 'JSON' as the decoder to parse the response as JSON.
     type: object
     required:
       - type
@@ -2202,7 +2203,7 @@ definitions:
         enum: [JsonDecoder]
   JsonlDecoder:
     title: JSONL Decoder
-    description: Use this if the response consists of JSON objects separated by new lines (`\n`) in JSONL format.
+    description: Select 'JSONL' if the response consists of JSON objects separated by new lines ('\n') in JSONL format.
     type: object
     required:
       - type
@@ -2328,7 +2329,7 @@ definitions:
         additionalProperties: true
   IterableDecoder:
     title: Iterable Decoder
-    description: Use this if the response consists of strings separated by new lines (`\n`). The Decoder will wrap each row into a JSON object with the `record` key.
+    description: Select 'Iterable' if the response consists of strings separated by new lines (`\n`). The string will then be wrapped into a JSON object with the `record` key.
     type: object
     required:
       - type
@@ -2338,7 +2339,7 @@ definitions:
         enum: [IterableDecoder]
   XmlDecoder:
     title: XML Decoder
-    description: Use this if the response is XML.
+    description: Select 'XML' if the response consists of XML-formatted data.
     type: object
     required:
       - type
@@ -2370,7 +2371,7 @@ definitions:
         additionalProperties: true
   ZipfileDecoder:
     title: Zipfile Decoder
-    description: Decoder for response data that is returned as zipfile(s).
+    description: Select 'ZIP'file" for response data that is returned as a zipfile. Requires specifying an inner data type/decoder to parse the unzipped data.
     type: object
     additionalProperties: true
     required:
@@ -3276,6 +3277,8 @@ definitions:
         type: object
         additionalProperties: true
   GzipDecoder:
+    title: Gzip Decoder
+    description: Select 'gzip' for response data that is compressed with gzip. Requires specifying an inner data type/decoder to parse the decompressed data.
     type: object
     required:
       - type
@@ -3291,6 +3294,8 @@ definitions:
           - "$ref": "#/definitions/JsonDecoder"
           - "$ref": "#/definitions/JsonlDecoder"
   CsvDecoder:
+    title: CSV Decoder
+    description: "Select 'CSV' for response data that is formatted as CSV (comma-separated values). Can specify an encoding (default: 'utf-8') and a delimiter (default: ',')."
     type: object
     required:
       - type

--- a/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -2192,7 +2192,7 @@ definitions:
         type: object
         additionalProperties: true
   JsonDecoder:
-    title: Json Decoder
+    title: JSON
     description: Select 'JSON' if the response is formatted as a JSON object.
     type: object
     required:
@@ -2202,7 +2202,7 @@ definitions:
         type: string
         enum: [JsonDecoder]
   JsonlDecoder:
-    title: JSONL Decoder
+    title: JSON Lines
     description: Select 'JSONL' if the response consists of JSON objects separated by new lines ('\n') in JSONL format.
     type: object
     required:
@@ -2328,7 +2328,7 @@ definitions:
         type: object
         additionalProperties: true
   IterableDecoder:
-    title: Iterable Decoder
+    title: Iterable
     description: Select 'Iterable' if the response consists of strings separated by new lines (`\n`). The string will then be wrapped into a JSON object with the `record` key.
     type: object
     required:
@@ -2338,7 +2338,7 @@ definitions:
         type: string
         enum: [IterableDecoder]
   XmlDecoder:
-    title: XML Decoder
+    title: XML
     description: Select 'XML' if the response consists of XML-formatted data.
     type: object
     required:
@@ -2370,7 +2370,7 @@ definitions:
         type: object
         additionalProperties: true
   ZipfileDecoder:
-    title: Zipfile Decoder
+    title: ZIP File
     description: Select 'ZIP'file" for response data that is returned as a zipfile. Requires specifying an inner data type/decoder to parse the unzipped data.
     type: object
     additionalProperties: true
@@ -2895,7 +2895,7 @@ definitions:
         title: Lazy Read Pointer
         description: If set, this will enable lazy reading, using the initial read of parent records to extract child records.
         type: array
-        default: [ ]
+        default: []
         items:
           - type: string
         interpolation_context:
@@ -3200,7 +3200,7 @@ definitions:
     properties:
       type:
         type: string
-        enum: [ StateDelegatingStream ]
+        enum: [StateDelegatingStream]
       name:
         title: Name
         description: The stream name.
@@ -3277,7 +3277,7 @@ definitions:
         type: object
         additionalProperties: true
   GzipDecoder:
-    title: Gzip Decoder
+    title: gzip
     description: Select 'gzip' for response data that is compressed with gzip. Requires specifying an inner data type/decoder to parse the decompressed data.
     type: object
     required:
@@ -3294,7 +3294,7 @@ definitions:
           - "$ref": "#/definitions/JsonDecoder"
           - "$ref": "#/definitions/JsonlDecoder"
   CsvDecoder:
-    title: CSV Decoder
+    title: CSV
     description: "Select 'CSV' for response data that is formatted as CSV (comma-separated values). Can specify an encoding (default: 'utf-8') and a delimiter (default: ',')."
     type: object
     required:

--- a/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -2203,7 +2203,7 @@ definitions:
         enum: [JsonDecoder]
   JsonlDecoder:
     title: JSON Lines
-    description: Select 'JSONL' if the response consists of JSON objects separated by new lines ('\n') in JSONL format.
+    description: Select 'JSON Lines' if the response consists of JSON objects separated by new lines ('\n') in JSONL format.
     type: object
     required:
       - type
@@ -2371,7 +2371,7 @@ definitions:
         additionalProperties: true
   ZipfileDecoder:
     title: ZIP File
-    description: Select 'ZIP'file" for response data that is returned as a zipfile. Requires specifying an inner data type/decoder to parse the unzipped data.
+    description: Select 'ZIP file' for response data that is returned as a zipfile. Requires specifying an inner data type/decoder to parse the unzipped data.
     type: object
     additionalProperties: true
     required:


### PR DESCRIPTION
## What
This PR adds titles/descriptions to decoders where missing and updates existing descriptions as necessary to more closely align with the Builder UI.

Current tooltip provides insufficient and incorrect data as not all decoders title/description fields are properly populated:

![Screenshot 2025-03-19 at 11 07 53 AM](https://github.com/user-attachments/assets/a037762d-6825-413e-9390-4cbfc2227e28)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Enhanced guidance for selecting decoders based on response formats such as JSON, JSON Lines, Iterable, XML, ZIP File, Gzip, and CSV.

- **New Features**
  - Introduced new instructions for handling Gzip-compressed data and CSV-formatted data, including configuration options for inner data processing and formatting settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->