### PR TITLE
fix: ensure most_recent_cursor_value is deserialized

### DIFF
--- a/airbyte_cdk/sources/streams/concurrent/state_converters/abstract_stream_state_converter.py
+++ b/airbyte_cdk/sources/streams/concurrent/state_converters/abstract_stream_state_converter.py
@@ -72,7 +72,9 @@ class AbstractStreamStateConverter(ABC):
             stream_slice[self.START_KEY] = self._from_state_message(stream_slice[self.START_KEY])
             stream_slice[self.END_KEY] = self._from_state_message(stream_slice[self.END_KEY])
             if self.MOST_RECENT_RECORD_KEY in stream_slice:
-                stream_slice[self.MOST_RECENT_RECORD_KEY] = self._from_state_message(stream_slice[self.MOST_RECENT_RECORD_KEY])
+                stream_slice[self.MOST_RECENT_RECORD_KEY] = self._from_state_message(
+                    stream_slice[self.MOST_RECENT_RECORD_KEY]
+                )
         return state
 
     def serialize(

--- a/airbyte_cdk/sources/streams/concurrent/state_converters/abstract_stream_state_converter.py
+++ b/airbyte_cdk/sources/streams/concurrent/state_converters/abstract_stream_state_converter.py
@@ -71,6 +71,8 @@ class AbstractStreamStateConverter(ABC):
         for stream_slice in state.get("slices", []):
             stream_slice[self.START_KEY] = self._from_state_message(stream_slice[self.START_KEY])
             stream_slice[self.END_KEY] = self._from_state_message(stream_slice[self.END_KEY])
+            if self.MOST_RECENT_RECORD_KEY in stream_slice:
+                stream_slice[self.MOST_RECENT_RECORD_KEY] = self._from_state_message(stream_slice[self.MOST_RECENT_RECORD_KEY])
         return state
 
     def serialize(

--- a/unit_tests/sources/streams/concurrent/test_cursor.py
+++ b/unit_tests/sources/streams/concurrent/test_cursor.py
@@ -977,16 +977,18 @@ class ConcurrentCursorStateTest(TestCase):
             _NO_LOOKBACK_WINDOW,
         )
 
-        cursor.close_partition(_partition(
-            StreamSlice(
-                partition={},
-                cursor_slice={
-                    _LOWER_SLICE_BOUNDARY_FIELD: 20,
-                    _UPPER_SLICE_BOUNDARY_FIELD: 50,
-                },
-            ),
-            _stream_name=_A_STREAM_NAME,
-        ))
+        cursor.close_partition(
+            _partition(
+                StreamSlice(
+                    partition={},
+                    cursor_slice={
+                        _LOWER_SLICE_BOUNDARY_FIELD: 20,
+                        _UPPER_SLICE_BOUNDARY_FIELD: 50,
+                    },
+                ),
+                _stream_name=_A_STREAM_NAME,
+            )
+        )
 
         expected_state = {
             "state_type": ConcurrencyCompatibleStateType.date_range.value,
@@ -998,8 +1000,9 @@ class ConcurrentCursorStateTest(TestCase):
                 },
             ],
         }
-        self._state_manager.update_state_for_stream.assert_called_once_with(_A_STREAM_NAME, _A_STREAM_NAMESPACE, expected_state)
-
+        self._state_manager.update_state_for_stream.assert_called_once_with(
+            _A_STREAM_NAME, _A_STREAM_NAMESPACE, expected_state
+        )
 
 
 class ClampingIntegrationTest(TestCase):

--- a/unit_tests/sources/streams/concurrent/test_cursor.py
+++ b/unit_tests/sources/streams/concurrent/test_cursor.py
@@ -1,7 +1,7 @@
 #
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
-
+from copy import deepcopy
 from datetime import datetime, timedelta, timezone
 from functools import partial
 from typing import Any, Mapping, Optional
@@ -84,7 +84,7 @@ class ConcurrentCursorStateTest(TestCase):
         return ConcurrentCursor(
             _A_STREAM_NAME,
             _A_STREAM_NAMESPACE,
-            {},
+            deepcopy(_NO_STATE),
             self._message_repository,
             self._state_manager,
             EpochValueConcurrentStreamStateConverter(is_sequential_state),
@@ -99,7 +99,7 @@ class ConcurrentCursorStateTest(TestCase):
         return ConcurrentCursor(
             _A_STREAM_NAME,
             _A_STREAM_NAMESPACE,
-            {},
+            deepcopy(_NO_STATE),
             self._message_repository,
             self._state_manager,
             EpochValueConcurrentStreamStateConverter(is_sequential_state=True),
@@ -265,7 +265,7 @@ class ConcurrentCursorStateTest(TestCase):
         cursor = ConcurrentCursor(
             _A_STREAM_NAME,
             _A_STREAM_NAMESPACE,
-            _NO_STATE,
+            deepcopy(_NO_STATE),
             self._message_repository,
             self._state_manager,
             EpochValueConcurrentStreamStateConverter(is_sequential_state=False),
@@ -949,6 +949,57 @@ class ConcurrentCursorStateTest(TestCase):
                 _A_CURSOR_FIELD_KEY: 10
             },  # State message is updated to the legacy format before being emitted
         )
+
+    @freezegun.freeze_time(time_to_freeze=datetime.fromtimestamp(50, timezone.utc))
+    def test_given_most_recent_cursor_value_in_input_state_when_emit_state_then_serialize_state_properly(
+        self,
+    ) -> None:
+        cursor = ConcurrentCursor(
+            _A_STREAM_NAME,
+            _A_STREAM_NAMESPACE,
+            {
+                "state_type": ConcurrencyCompatibleStateType.date_range.value,
+                "slices": [
+                    {
+                        EpochValueConcurrentStreamStateConverter.START_KEY: 0,
+                        EpochValueConcurrentStreamStateConverter.END_KEY: 20,
+                        EpochValueConcurrentStreamStateConverter.MOST_RECENT_RECORD_KEY: 15,
+                    },
+                ],
+            },
+            self._message_repository,
+            self._state_manager,
+            EpochValueConcurrentStreamStateConverter(is_sequential_state=False),
+            CursorField(_A_CURSOR_FIELD_KEY),
+            _SLICE_BOUNDARY_FIELDS,
+            datetime.fromtimestamp(0, timezone.utc),
+            EpochValueConcurrentStreamStateConverter.get_end_provider(),
+            _NO_LOOKBACK_WINDOW,
+        )
+
+        cursor.close_partition(_partition(
+            StreamSlice(
+                partition={},
+                cursor_slice={
+                    _LOWER_SLICE_BOUNDARY_FIELD: 20,
+                    _UPPER_SLICE_BOUNDARY_FIELD: 50,
+                },
+            ),
+            _stream_name=_A_STREAM_NAME,
+        ))
+
+        expected_state = {
+            "state_type": ConcurrencyCompatibleStateType.date_range.value,
+            "slices": [
+                {
+                    EpochValueConcurrentStreamStateConverter.START_KEY: 0,
+                    EpochValueConcurrentStreamStateConverter.END_KEY: 50,
+                    EpochValueConcurrentStreamStateConverter.MOST_RECENT_RECORD_KEY: 15,
+                },
+            ],
+        }
+        self._state_manager.update_state_for_stream.assert_called_once_with(_A_STREAM_NAME, _A_STREAM_NAMESPACE, expected_state)
+
 
 
 class ClampingIntegrationTest(TestCase):


### PR DESCRIPTION
Following issue on source-salesforce: https://airbytehq-team.slack.com/archives/C08JX410FJM

The issue was that we re-use the input dictionary for the state but `most_recent_cursor_value` was not converted to a datetime which mean that when we were trying to serialize it, it would fail because of a typing issue (this field was still a string and not a datetime and hence would cause ` 'str' object has no attribute 'year'` error).

In order to fix that, we just have to properly deserialize `most_recent_cursor_value`.  This wasn't an issue for low-code connectors because they have sequential state. source-salesforce has a partitioned state which is different.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced state handling to accurately process and convert recent record data during state updates.
- **Tests**
  - Expanded test coverage to ensure consistent initialization and serialization of state, improving overall reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->