### PR TITLE
fix: substreampartitionrouter state migration from child when it is empty

### DIFF
--- a/airbyte_cdk/sources/declarative/partition_routers/substream_partition_router.py
+++ b/airbyte_cdk/sources/declarative/partition_routers/substream_partition_router.py
@@ -374,7 +374,7 @@ class SubstreamPartitionRouter(PartitionRouter):
         # Ignore per-partition states or invalid formats.
         if isinstance(substream_state, (list, dict)) or len(substream_state_values) != 1:
             # If a global state is present under the key "state", use its first value.
-            if "state" in stream_state and isinstance(stream_state["state"], dict):
+            if "state" in stream_state and isinstance(stream_state["state"], dict) and stream_state["state"] != {}:
                 substream_state = list(stream_state["state"].values())[0]
             else:
                 return {}

--- a/airbyte_cdk/sources/declarative/partition_routers/substream_partition_router.py
+++ b/airbyte_cdk/sources/declarative/partition_routers/substream_partition_router.py
@@ -374,7 +374,11 @@ class SubstreamPartitionRouter(PartitionRouter):
         # Ignore per-partition states or invalid formats.
         if isinstance(substream_state, (list, dict)) or len(substream_state_values) != 1:
             # If a global state is present under the key "state", use its first value.
-            if "state" in stream_state and isinstance(stream_state["state"], dict) and stream_state["state"] != {}:
+            if (
+                "state" in stream_state
+                and isinstance(stream_state["state"], dict)
+                and stream_state["state"] != {}
+            ):
                 substream_state = list(stream_state["state"].values())[0]
             else:
                 return {}

--- a/unit_tests/sources/declarative/partition_routers/test_substream_partition_router.py
+++ b/unit_tests/sources/declarative/partition_routers/test_substream_partition_router.py
@@ -475,16 +475,14 @@ def test_substream_partition_router_invalid_parent_record_type():
         ),
         # Case 7: Migrate child state to parent state but child state is empty
         (
-                {
-                    "state": {},
-                    "states": [],
-                    "parent_state": {
-                        "posts": {}
-                    },
-                    "lookback_window": 1,
-                    "use_global_cursor": False
-                },
-                {},
+            {
+                "state": {},
+                "states": [],
+                "parent_state": {"posts": {}},
+                "lookback_window": 1,
+                "use_global_cursor": False,
+            },
+            {},
         ),
     ],
     ids=[

--- a/unit_tests/sources/declarative/partition_routers/test_substream_partition_router.py
+++ b/unit_tests/sources/declarative/partition_routers/test_substream_partition_router.py
@@ -473,6 +473,19 @@ def test_substream_partition_router_invalid_parent_record_type():
             },
             {"parent_stream_cursor": "2023-05-27T00:00:00Z"},
         ),
+        # Case 7: Migrate child state to parent state but child state is empty
+        (
+                {
+                    "state": {},
+                    "states": [],
+                    "parent_state": {
+                        "posts": {}
+                    },
+                    "lookback_window": 1,
+                    "use_global_cursor": False
+                },
+                {},
+        ),
     ],
     ids=[
         "empty_initial_state",
@@ -481,6 +494,7 @@ def test_substream_partition_router_invalid_parent_record_type():
         "initial_state_no_parent_per_partition_state",
         "initial_state_with_parent_state",
         "initial_state_no_parent_global_state_declarative",
+        "initial_state_no_parent_and_no_child",
     ],
 )
 def test_set_initial_state(initial_state, expected_parent_state):


### PR DESCRIPTION
## Context

We had [this alert](https://airbytehq.sentry.io/issues/6459218674/?project=6527718&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D%20connector_definition_id%3A79c1aa37-dae3-42ae-b333-d1c105477715&referrer=issue-stream&stream_index=0) after doing the low-code migration of source-zendesk-support. The series of event seems to be that:
* We sync has `post_comment_votes` but it is empty. Therefore, state is `{}` (as shown by [this](https://airbyte.metabaseapp.com/question/7188-state-rollback-generator?connection_ids=c3c70458-a8a6-48ff-91ab-67f41c55e94a&first_bad_timestamp=2025-03-25%2003%3A25%3A56-07%3A00&last_bad_timestamp=2025-03-25%2013%3A25%3A56-07%3A00))
* We run once, the migration will create the following state:
```
{
      "states": [],
      "parent_state": {
        "post_comments": {
          "state": {},
          "states": [],
          "parent_state": {
            "posts": {}
          },
          "lookback_window": 1,
          "use_global_cursor": false
        }
      },
      "lookback_window": 1,
      "use_global_cursor": false
    }
}
```
* When running the next sync, we think we need to run `_migrate_child_state_to_parent_state` because the parent state is empty but we call `list(stream_state["state"].values())[0]` on `{}` which leads to a index error

## Proposed solution
If the child state is empty, we should fallback on `{}` for the parent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved state update handling to ensure that only valid, non-empty state data is processed.
- **Tests**
  - Expanded test coverage with a new case to verify proper state initialization when both child and parent states are empty.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->