### PR TITLE
feat(low code cdk): updated format_datetime macros to format timestamps

### DIFF
--- a/airbyte_cdk/sources/declarative/interpolation/macros.py
+++ b/airbyte_cdk/sources/declarative/interpolation/macros.py
@@ -172,7 +172,7 @@ def format_datetime(
         return dt.strftime(format)
 
     if isinstance(dt, int):
-        dt_datetime = datetime.datetime.fromtimestamp(dt, tz=datetime.timezone.utc)
+        dt_datetime = DatetimeParser().parse(dt, input_format if input_format else "%s")
     else:
         dt_datetime = (
             datetime.datetime.strptime(dt, input_format) if input_format else str_to_datetime(dt)

--- a/airbyte_cdk/sources/declarative/interpolation/macros.py
+++ b/airbyte_cdk/sources/declarative/interpolation/macros.py
@@ -156,7 +156,7 @@ def duration(datestring: str) -> Union[datetime.timedelta, isodate.Duration]:
 
 
 def format_datetime(
-    dt: Union[str, datetime.datetime], format: str, input_format: Optional[str] = None
+    dt: Union[str, datetime.datetime, int], format: str, input_format: Optional[str] = None
 ) -> str:
     """
     Converts datetime to another format
@@ -170,9 +170,13 @@ def format_datetime(
     """
     if isinstance(dt, datetime.datetime):
         return dt.strftime(format)
-    dt_datetime = (
-        datetime.datetime.strptime(dt, input_format) if input_format else str_to_datetime(dt)
-    )
+
+    if isinstance(dt, int):
+        dt_datetime = datetime.datetime.fromtimestamp(dt, tz=datetime.timezone.utc)
+    else:
+        dt_datetime = (
+            datetime.datetime.strptime(dt, input_format) if input_format else str_to_datetime(dt)
+        )
     return DatetimeParser().format(dt=dt_datetime, format=format)
 
 

--- a/unit_tests/sources/declarative/interpolation/test_macros.py
+++ b/unit_tests/sources/declarative/interpolation/test_macros.py
@@ -83,6 +83,12 @@ def test_macros_export(test_name, fn_name, found_in_macros):
             "%Y-%m-%dT%H:%M:%SZ",
             "1640998861000000",
         ),
+        (
+            1683729087,
+            "%Y-%m-%dT%H:%M:%SZ",
+            None,
+            "2023-05-10T14:31:27Z",
+        ),
     ],
     ids=[
         "test_datetime_string_to_date",
@@ -96,6 +102,7 @@ def test_macros_export(test_name, fn_name, found_in_macros):
         "test_datetime_string_to_rfc2822_date",
         "test_datetime_string_to_timestamp_in_seconds",
         "test_datetime_string_to_timestamp_in_microseconds",
+        "test_timestamp_to_format_string",
     ],
 )
 def test_format_datetime(input_value, format, input_format, expected_output):

--- a/unit_tests/sources/declarative/interpolation/test_macros.py
+++ b/unit_tests/sources/declarative/interpolation/test_macros.py
@@ -89,6 +89,18 @@ def test_macros_export(test_name, fn_name, found_in_macros):
             None,
             "2023-05-10T14:31:27Z",
         ),
+        (
+            1640998861000000,
+            "%Y-%m-%dT%H:%M:%SZ",
+            "%epoch_microseconds",
+            "2022-01-01T01:01:01Z",
+        ),
+        (
+            1640998861000,
+            "%Y-%m-%dT%H:%M:%SZ",
+            "%ms",
+            "2022-01-01T01:01:01Z",
+        ),
     ],
     ids=[
         "test_datetime_string_to_date",
@@ -103,6 +115,8 @@ def test_macros_export(test_name, fn_name, found_in_macros):
         "test_datetime_string_to_timestamp_in_seconds",
         "test_datetime_string_to_timestamp_in_microseconds",
         "test_timestamp_to_format_string",
+        "test_timestamp_epoch_microseconds_to_format_string",
+        "test_timestamp_ms_to_format_string",
     ],
 )
 def test_format_datetime(input_value, format, input_format, expected_output):


### PR DESCRIPTION
### What
Needed for export stream migration to low code in source mixpanel https://github.com/airbytehq/airbyte/pull/55189
in python implementation of export stream cursor field `time` was transformed from timestamp to string in format "%Y-%m-%dT%H:%M:%SZ".
### How
As `format_datetime` macros works only with str and datetime objects , logic to parse timestamp to datetime if input value is instance of int was added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Expanded date formatting capabilities to now handle integer timestamps along with string and datetime inputs.
- **Tests**
	- Enhanced test coverage with additional cases for converting Unix timestamps and epoch formats to formatted date strings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->