### PR TITLE
feat(low code cdk): add path to filter interpolation in AddFields condition

### DIFF
--- a/airbyte_cdk/sources/declarative/transformations/add_fields.py
+++ b/airbyte_cdk/sources/declarative/transformations/add_fields.py
@@ -139,7 +139,9 @@ class AddFields(RecordTransformation):
             valid_types = (parsed_field.value_type,) if parsed_field.value_type else None
             value = parsed_field.value.eval(config, valid_types=valid_types, **kwargs)
             is_empty_condition = not self.condition
-            if is_empty_condition or self._filter_interpolator.eval(config, value=value, path=parsed_field.path, **kwargs):
+            if is_empty_condition or self._filter_interpolator.eval(
+                config, value=value, path=parsed_field.path, **kwargs
+            ):
                 dpath.new(record, parsed_field.path, value)
 
     def __eq__(self, other: Any) -> bool:

--- a/airbyte_cdk/sources/declarative/transformations/add_fields.py
+++ b/airbyte_cdk/sources/declarative/transformations/add_fields.py
@@ -139,7 +139,7 @@ class AddFields(RecordTransformation):
             valid_types = (parsed_field.value_type,) if parsed_field.value_type else None
             value = parsed_field.value.eval(config, valid_types=valid_types, **kwargs)
             is_empty_condition = not self.condition
-            if is_empty_condition or self._filter_interpolator.eval(config, value=value, **kwargs):
+            if is_empty_condition or self._filter_interpolator.eval(config, value=value, path=parsed_field.path, **kwargs):
                 dpath.new(record, parsed_field.path, value)
 
     def __eq__(self, other: Any) -> bool:

--- a/unit_tests/sources/declarative/transformations/test_add_fields.py
+++ b/unit_tests/sources/declarative/transformations/test_add_fields.py
@@ -176,6 +176,24 @@ from airbyte_cdk.sources.types import FieldPointer
             {"k": "v", "path": "static_value"},
             id="add all fields if condition is boolean True",
         ),
+        pytest.param(
+            {"k": "v"},
+            [(["path"], "static_value")],
+            None,
+            "{{ path[0] not in record.keys() }}",
+            {},
+            {"k": "v", "path": "static_value"},
+            id="add fields when condition uses path value",
+        ),
+        pytest.param(
+            {"k": "v", "existing_path": "record_value"},
+            [(["existing_path"], "static_value")],
+            None,
+            "{{ path[0] not in record.keys() }}",
+            {},
+            {"k": "v", "existing_path": "record_value"},
+            id="do not add fields when condition uses path value",
+        ),
     ],
 )
 def test_add_fields(


### PR DESCRIPTION
### What
Needed for mixpanel dynamic schemas https://github.com/airbytehq/airbyte/pull/55189
When stream has static fields in schema, they should be added only when dynamic schema doesn't have these fields in it.
### How
To check if field already exists in schema a condition in AddFields transformation can be used, but now it doesn't have path value in interpolation arguments.
Added  `path=parsed_field.path` to `_filter_interpolator.eval`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Enhanced field processing by refining the transformation logic to incorporate additional context during condition checks. This update improves how fields are added based on record content, ensuring more consistent and reliable outcomes during data processing. These enhancements contribute to a smoother and more predictable overall experience when working with records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->