### PR TITLE
fix: locally running tests errors

### DIFF
--- a/airbyte_cdk/sources/declarative/interpolation/macros.py
+++ b/airbyte_cdk/sources/declarative/interpolation/macros.py
@@ -177,7 +177,8 @@ def format_datetime(
         dt_datetime = (
             datetime.datetime.strptime(dt, input_format) if input_format else str_to_datetime(dt)
         )
-    dt_datetime = dt_datetime.replace(tzinfo=pytz.utc)
+    if dt_datetime.tzinfo is None:
+        dt_datetime = dt_datetime.replace(tzinfo=pytz.utc)
     return DatetimeParser().format(dt=dt_datetime, format=format)
 
 

--- a/airbyte_cdk/sources/declarative/interpolation/macros.py
+++ b/airbyte_cdk/sources/declarative/interpolation/macros.py
@@ -177,6 +177,7 @@ def format_datetime(
         dt_datetime = (
             datetime.datetime.strptime(dt, input_format) if input_format else str_to_datetime(dt)
         )
+    dt_datetime = dt_datetime.replace(tzinfo=pytz.utc)
     return DatetimeParser().format(dt=dt_datetime, format=format)
 
 

--- a/airbyte_cdk/sources/declarative/schema/default_schema_loader.py
+++ b/airbyte_cdk/sources/declarative/schema/default_schema_loader.py
@@ -37,7 +37,7 @@ class DefaultSchemaLoader(SchemaLoader):
 
         try:
             return self.default_loader.get_json_schema()
-        except OSError:
+        except (OSError, ValueError):
             # A slight hack since we don't directly have the stream name. However, when building the default filepath we assume the
             # runtime options stores stream name 'name' so we'll do the same here
             stream_name = self._parameters.get("name", "")

--- a/unit_tests/sources/declarative/interpolation/test_macros.py
+++ b/unit_tests/sources/declarative/interpolation/test_macros.py
@@ -101,6 +101,18 @@ def test_macros_export(test_name, fn_name, found_in_macros):
             "%ms",
             "2022-01-01T01:01:01Z",
         ),
+        (
+            "2022-01-01T01:01:01+0100",
+            "%Y-%m-%dT%H:%M:%S.%f%z",
+            None,
+            "2022-01-01T00:01:01.000000+0000",
+        ),
+        (
+            "2022-01-01T01:01:01",
+            "%Y-%m-%dT%H:%M:%S.%f%z",
+            None,
+            "2022-01-01T01:01:01.000000+0000",
+        ),
     ],
     ids=[
         "test_datetime_string_to_date",
@@ -117,6 +129,8 @@ def test_macros_export(test_name, fn_name, found_in_macros):
         "test_timestamp_to_format_string",
         "test_timestamp_epoch_microseconds_to_format_string",
         "test_timestamp_ms_to_format_string",
+        "test_datetime_with_timezone",
+        "test_datetime_without_timezone_then_utc_is_inferred",
     ],
 )
 def test_format_datetime(input_value, format, input_format, expected_output):


### PR DESCRIPTION
## Context 
I had two tests issues:
* test_macros.test_format_datetime is using the timezone of your computer. In order to fix that, I'm forcing `utc`. This shouldn't change the behavior of the connector because we for UTC as a timezone for the docker images
* For whatever reason when running unit_tests not on the root level, `pkgutil` raise a value error during schema loading instead of a OSError (see blob below). In order to fix that, I handled both errors the same way. This would change the sources behavior only if we were to fail on ValueError before which I doubt it is a case and find the fallback appropriate anyway. Note that this seems to happen only when not running tests from `unit_tests` directly but running a more scope set of tests. Trying to change the working directory didn't help unfortunately...

```
Traceback (most recent call last):
  File "/Users/maxime/devel/code/airbyte-python-cdk/airbyte_cdk/connector_builder/test_reader/reader.py", line 389, in _read_stream
    yield from AirbyteEntrypoint(source).read(
  File "/Users/maxime/devel/code/airbyte-python-cdk/airbyte_cdk/entrypoint.py", line 244, in read
    for message in self.source.read(self.logger, config, catalog, state):
  File "/Users/maxime/devel/code/airbyte-python-cdk/airbyte_cdk/sources/declarative/concurrent_declarative_source.py", line 138, in read
    concurrent_streams, _ = self._group_streams(config=config)
  File "/Users/maxime/devel/code/airbyte-python-cdk/airbyte_cdk/sources/declarative/concurrent_declarative_source.py", line 333, in _group_streams
    declarative_stream.get_json_schema(),
  File "/Users/maxime/devel/code/airbyte-python-cdk/airbyte_cdk/sources/declarative/declarative_stream.py", line 170, in get_json_schema
    return self._schema_loader.get_json_schema()
  File "/Users/maxime/devel/code/airbyte-python-cdk/airbyte_cdk/sources/declarative/schema/default_schema_loader.py", line 39, in get_json_schema
    return self.default_loader.get_json_schema()
  File "/Users/maxime/devel/code/airbyte-python-cdk/airbyte_cdk/sources/declarative/schema/json_file_schema_loader.py", line 58, in get_json_schema
    raw_json_file = pkgutil.get_data(resource, schema_path)
  File "/Users/maxime/.pyenv/versions/3.10.14/lib/python3.10/pkgutil.py", line 621, in get_data
    spec = importlib.util.find_spec(package)
  File "/Users/maxime/.pyenv/versions/3.10.14/lib/python3.10/importlib/util.py", line 103, in find_spec
    return _find_spec(fullname, parent_path)
  File "<frozen importlib._bootstrap>", line 945, in _find_spec
  File "/Users/maxime/devel/code/airbyte-python-cdk/.venv/lib/python3.10/site-packages/_pytest/assertion/rewrite.py", line 110, in find_spec
    if self._early_rewrite_bailout(name, state):
  File "/Users/maxime/devel/code/airbyte-python-cdk/.venv/lib/python3.10/site-packages/_pytest/assertion/rewrite.py", line 211, in _early_rewrite_bailout
    path = PurePath(*parts).with_suffix(".py")
  File "/Users/maxime/.pyenv/versions/3.10.14/lib/python3.10/pathlib.py", line 782, in with_suffix
    raise ValueError("%r has an empty name" % (self,))
ValueError: PurePosixPath('.') has an empty name
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved datetime consistency so that all timestamps are now uniformly displayed in UTC.
	- Enhanced error resilience during configuration retrieval by expanding error handling to include additional exception types, resulting in a more robust experience.
  
- **Tests**
	- Added new test cases to ensure proper formatting of datetime objects with and without timezone information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->