### PR TITLE
fix: no longer require token expiration from the OAuth resource server

### DIFF
--- a/airbyte_cdk/sources/declarative/auth/oauth.py
+++ b/airbyte_cdk/sources/declarative/auth/oauth.py
@@ -239,8 +239,8 @@ class DeclarativeOauth2Authenticator(AbstractOauth2Authenticator, DeclarativeAut
     def _has_access_token_been_initialized(self) -> bool:
         return self._access_token is not None
 
-    def set_token_expiry_date(self, value: Union[str, int]) -> None:
-        self._token_expiry_date = self._parse_token_expiration_date(value)
+    def set_token_expiry_date(self, value: AirbyteDateTime) -> None:
+        self._token_expiry_date = value
 
     def get_assertion_name(self) -> str:
         return self.assertion_name

--- a/airbyte_cdk/sources/declarative/auth/oauth.py
+++ b/airbyte_cdk/sources/declarative/auth/oauth.py
@@ -239,7 +239,7 @@ class DeclarativeOauth2Authenticator(AbstractOauth2Authenticator, DeclarativeAut
     def _has_access_token_been_initialized(self) -> bool:
         return self._access_token is not None
 
-    def set_token_expiry_date(self, value: Union[str, int]) -> None:
+    def set_token_expiry_date(self, value: AirbyteDateTime) -> None:
         self._token_expiry_date = self._parse_token_expiration_date(value)
 
     def get_assertion_name(self) -> str:

--- a/airbyte_cdk/sources/declarative/auth/oauth.py
+++ b/airbyte_cdk/sources/declarative/auth/oauth.py
@@ -239,7 +239,7 @@ class DeclarativeOauth2Authenticator(AbstractOauth2Authenticator, DeclarativeAut
     def _has_access_token_been_initialized(self) -> bool:
         return self._access_token is not None
 
-    def set_token_expiry_date(self, value: AirbyteDateTime) -> None:
+    def set_token_expiry_date(self, value: Union[str, int]) -> None:
         self._token_expiry_date = self._parse_token_expiration_date(value)
 
     def get_assertion_name(self) -> str:

--- a/airbyte_cdk/sources/streams/http/requests_native_auth/abstract_oauth.py
+++ b/airbyte_cdk/sources/streams/http/requests_native_auth/abstract_oauth.py
@@ -361,7 +361,7 @@ class AbstractOauth2Authenticator(AuthBase):
         """
         if current_depth > max_depth:
             # this is needed to avoid an inf loop, possible with a very deep nesting observed.
-            message = f"The maximum level of recursion is reached. Couldn't find the speficied `{key_name}` in the response."
+            message = f"The maximum level of recursion is reached. Couldn't find the specified `{key_name}` in the response."
             raise ResponseKeysMaxRecurtionReached(
                 internal_message=message, message=message, failure_type=FailureType.config_error
             )

--- a/airbyte_cdk/sources/streams/http/requests_native_auth/abstract_oauth.py
+++ b/airbyte_cdk/sources/streams/http/requests_native_auth/abstract_oauth.py
@@ -147,7 +147,7 @@ class AbstractOauth2Authenticator(AuthBase):
     # ----------------
     # PRIVATE METHODS
     # ----------------
-    
+
     def _default_token_expiry_date(self) -> str:
         """
         Returns the default token expiry date
@@ -327,7 +327,9 @@ class AbstractOauth2Authenticator(AuthBase):
         Returns:
             The extracted token_expiry_date or None if not found.
         """
-        expires_in = self._find_and_get_value_from_response(response_data, self.get_expires_in_name())
+        expires_in = self._find_and_get_value_from_response(
+            response_data, self.get_expires_in_name()
+        )
         # If the access token expires in is None, we do not know when the token will expire
         # 1 hour was chosen as a middle ground to avoid unnecessary frequent refreshes and token expiration
         if expires_in is None:

--- a/airbyte_cdk/sources/streams/http/requests_native_auth/abstract_oauth.py
+++ b/airbyte_cdk/sources/streams/http/requests_native_auth/abstract_oauth.py
@@ -130,7 +130,7 @@ class AbstractOauth2Authenticator(AuthBase):
         headers = self.get_refresh_request_headers()
         return headers if headers else None
 
-    def refresh_access_token(self) -> Tuple[str, Optional[str]]:
+    def refresh_access_token(self) -> Tuple[str, Union[str, int]]:
         """
         Returns the refresh token and its expiration datetime
 

--- a/airbyte_cdk/sources/streams/http/requests_native_auth/abstract_oauth.py
+++ b/airbyte_cdk/sources/streams/http/requests_native_auth/abstract_oauth.py
@@ -329,12 +329,12 @@ class AbstractOauth2Authenticator(AuthBase):
         )
         if expires_in is not None:
             return self._parse_token_expiration_date(expires_in)
-        
+
         # expires_in is None
         existing_expiry_date = self.get_token_expiry_date()
         if existing_expiry_date and not self.token_has_expired():
             return existing_expiry_date
-        
+
         return self._default_token_expiry_date()
 
     def _find_and_get_value_from_response(

--- a/airbyte_cdk/sources/streams/http/requests_native_auth/abstract_oauth.py
+++ b/airbyte_cdk/sources/streams/http/requests_native_auth/abstract_oauth.py
@@ -153,7 +153,7 @@ class AbstractOauth2Authenticator(AuthBase):
         Returns the default token expiry date
         """
         # 1 hour was chosen as a middle ground to avoid unnecessary frequent refreshes and token expiration
-        default_token_expiry_duration_hours = 1 # 1 hour
+        default_token_expiry_duration_hours = 1  # 1 hour
         return ab_datetime_now() + timedelta(hours=default_token_expiry_duration_hours)
 
     def _wrap_refresh_token_exception(
@@ -315,7 +315,7 @@ class AbstractOauth2Authenticator(AuthBase):
     def _extract_token_expiry_date(self, response_data: Mapping[str, Any]) -> AirbyteDateTime:
         """
         Extracts the token_expiry_date, like `expires_in` or `expires_at`, etc from the given response data.
-        
+
         If the token_expiry_date is not found, it will return an existing token expiry date if set, or a default token expiry date.
 
         Args:

--- a/airbyte_cdk/sources/streams/http/requests_native_auth/abstract_oauth.py
+++ b/airbyte_cdk/sources/streams/http/requests_native_auth/abstract_oauth.py
@@ -327,15 +327,15 @@ class AbstractOauth2Authenticator(AuthBase):
         expires_in = self._find_and_get_value_from_response(
             response_data, self.get_expires_in_name()
         )
-        # If the access token expires in is None, we do not know when the token will expire
-        if expires_in is None:
-            # If the token expiry date is set and the token is not expired, continue using the existing token expiry date
-            if self.get_token_expiry_date() and not self.token_has_expired():
-                return self.get_token_expiry_date()
-            else:
-                return self._default_token_expiry_date()
-        else:
+        if expires_in is not None:
             return self._parse_token_expiration_date(expires_in)
+        
+        # expires_in is None
+        existing_expiry_date = self.get_token_expiry_date()
+        if existing_expiry_date and not self.token_has_expired():
+            return existing_expiry_date
+        
+        return self._default_token_expiry_date()
 
     def _find_and_get_value_from_response(
         self,

--- a/airbyte_cdk/sources/streams/http/requests_native_auth/oauth.py
+++ b/airbyte_cdk/sources/streams/http/requests_native_auth/oauth.py
@@ -355,7 +355,7 @@ class SingleUseRefreshTokenOauth2Authenticator(Oauth2Authenticator):
             self._emit_control_message()
         return self.access_token
 
-    def refresh_access_token(self) -> Tuple[str, str, str]:  # type: ignore[override]
+    def refresh_access_token(self) -> Tuple[str, Optional[str], str]:  # type: ignore[override]
         """
         Refreshes the access token by making a handled request and extracting the necessary token information.
 

--- a/airbyte_cdk/sources/streams/http/requests_native_auth/oauth.py
+++ b/airbyte_cdk/sources/streams/http/requests_native_auth/oauth.py
@@ -355,7 +355,7 @@ class SingleUseRefreshTokenOauth2Authenticator(Oauth2Authenticator):
             self._emit_control_message()
         return self.access_token
 
-    def refresh_access_token(self) -> Tuple[str, Optional[str], str]:  # type: ignore[override]
+    def refresh_access_token(self) -> Tuple[str, str, str]:  # type: ignore[override]
         """
         Refreshes the access token by making a handled request and extracting the necessary token information.
 

--- a/unit_tests/sources/declarative/auth/test_oauth.py
+++ b/unit_tests/sources/declarative/auth/test_oauth.py
@@ -203,6 +203,7 @@ class TestOauth2Authenticator:
                 grant_type="refresh_token",
             )
 
+    @freezegun.freeze_time("2022-01-01")
     def test_refresh_access_token(self, mocker):
         oauth = DeclarativeOauth2Authenticator(
             token_refresh_endpoint="{{ config['refresh_endpoint'] }}",
@@ -225,13 +226,15 @@ class TestOauth2Authenticator:
             resp, "json", return_value={"access_token": "access_token", "expires_in": 1000}
         )
         mocker.patch.object(requests, "request", side_effect=mock_request, autospec=True)
-        token = oauth.refresh_access_token()
+        access_token, token_expiry_date = oauth.refresh_access_token()
 
-        assert ("access_token", 1000) == token
+        assert access_token == "access_token"
+        assert token_expiry_date == ab_datetime_now() + timedelta(seconds=1000)
 
         filtered = filter_secrets("access_token")
         assert filtered == "****"
 
+    @freezegun.freeze_time("2022-01-01")
     def test_refresh_access_token_when_headers_provided(self, mocker):
         expected_headers = {
             "Authorization": "Bearer some_access_token",
@@ -256,9 +259,10 @@ class TestOauth2Authenticator:
         mocked_request = mocker.patch.object(
             requests, "request", side_effect=mock_request, autospec=True
         )
-        token = oauth.refresh_access_token()
+        access_token, token_expiry_date = oauth.refresh_access_token()
 
-        assert ("access_token", 1000) == token
+        assert access_token == "access_token"
+        assert token_expiry_date == ab_datetime_now() + timedelta(seconds=1000)
 
         assert mocked_request.call_args.kwargs["headers"] == expected_headers
 
@@ -314,6 +318,7 @@ class TestOauth2Authenticator:
         assert isinstance(oauth._token_expiry_date, AirbyteDateTime)
         assert oauth.get_token_expiry_date() == ab_datetime_parse(expected_date)
 
+    @freezegun.freeze_time("2022-01-01")
     def test_given_no_access_token_but_expiry_in_the_future_when_refresh_token_then_fetch_access_token(
         self,
     ) -> None:
@@ -335,12 +340,55 @@ class TestOauth2Authenticator:
                     url="https://refresh_endpoint.com/",
                     body="grant_type=client&client_id=some_client_id&client_secret=some_client_secret&refresh_token=some_refresh_token",
                 ),
-                HttpResponse(body=json.dumps({"access_token": "new_access_token"})),
+                HttpResponse(body=json.dumps({"access_token": "new_access_token", "expires_in": 1000})),
             )
             oauth.get_access_token()
 
         assert oauth.access_token == "new_access_token"
-        assert oauth._token_expiry_date == expiry_date
+        assert oauth._token_expiry_date == ab_datetime_now() + timedelta(seconds=1000)
+        
+    @freezegun.freeze_time("2022-01-01")
+    @pytest.mark.parametrize(
+        "initial_expiry_date_delta, expected_new_expiry_date_delta, expected_access_token",
+        [
+            (timedelta(days=1), timedelta(days=1), "some_access_token"),
+            (timedelta(days=-1), timedelta(hours=1), "new_access_token"),
+            (None, timedelta(hours=1), "new_access_token"),
+        ],
+        ids=["initial_expiry_date_in_future", "initial_expiry_date_in_past", "no_initial_expiry_date"],
+    )
+    def test_no_expiry_date_provided_by_auth_server(
+        self,
+        initial_expiry_date_delta,
+        expected_new_expiry_date_delta,
+        expected_access_token,
+    ) -> None:
+        initial_expiry_date = ab_datetime_now().add(initial_expiry_date_delta).isoformat() if initial_expiry_date_delta else None
+        expected_new_expiry_date = ab_datetime_now().add(expected_new_expiry_date_delta)
+        oauth = DeclarativeOauth2Authenticator(
+            token_refresh_endpoint="https://refresh_endpoint.com/",
+            client_id="some_client_id",
+            client_secret="some_client_secret",
+            token_expiry_date=initial_expiry_date,
+            access_token_value="some_access_token",
+            refresh_token="some_refresh_token",
+            config={},
+            parameters={},
+            grant_type="client",
+        )
+
+        with HttpMocker() as http_mocker:
+            http_mocker.post(
+                HttpRequest(
+                    url="https://refresh_endpoint.com/",
+                    body="grant_type=client&client_id=some_client_id&client_secret=some_client_secret&refresh_token=some_refresh_token",
+                ),
+                HttpResponse(body=json.dumps({"access_token": "new_access_token"})),
+            )
+            oauth.get_access_token()
+
+        assert oauth.access_token == expected_access_token
+        assert oauth._token_expiry_date == expected_new_expiry_date
 
     @pytest.mark.parametrize(
         "expires_in_response, token_expiry_date_format",
@@ -443,6 +491,7 @@ class TestOauth2Authenticator:
             assert "access_token" == token
             assert oauth.get_token_expiry_date() == ab_datetime_parse(next_day)
 
+    @freezegun.freeze_time("2022-01-01")
     def test_profile_assertion(self, mocker):
         with HttpMocker() as http_mocker:
             jwt = JwtAuthenticator(
@@ -477,7 +526,7 @@ class TestOauth2Authenticator:
 
             token = oauth.refresh_access_token()
 
-        assert ("access_token", 1000) == token
+        assert ("access_token", ab_datetime_now().add(timedelta(seconds=1000))) == token
 
         filtered = filter_secrets("access_token")
         assert filtered == "****"

--- a/unit_tests/sources/declarative/auth/test_oauth.py
+++ b/unit_tests/sources/declarative/auth/test_oauth.py
@@ -340,13 +340,15 @@ class TestOauth2Authenticator:
                     url="https://refresh_endpoint.com/",
                     body="grant_type=client&client_id=some_client_id&client_secret=some_client_secret&refresh_token=some_refresh_token",
                 ),
-                HttpResponse(body=json.dumps({"access_token": "new_access_token", "expires_in": 1000})),
+                HttpResponse(
+                    body=json.dumps({"access_token": "new_access_token", "expires_in": 1000})
+                ),
             )
             oauth.get_access_token()
 
         assert oauth.access_token == "new_access_token"
         assert oauth._token_expiry_date == ab_datetime_now() + timedelta(seconds=1000)
-        
+
     @freezegun.freeze_time("2022-01-01")
     @pytest.mark.parametrize(
         "initial_expiry_date_delta, expected_new_expiry_date_delta, expected_access_token",
@@ -355,7 +357,11 @@ class TestOauth2Authenticator:
             (timedelta(days=-1), timedelta(hours=1), "new_access_token"),
             (None, timedelta(hours=1), "new_access_token"),
         ],
-        ids=["initial_expiry_date_in_future", "initial_expiry_date_in_past", "no_initial_expiry_date"],
+        ids=[
+            "initial_expiry_date_in_future",
+            "initial_expiry_date_in_past",
+            "no_initial_expiry_date",
+        ],
     )
     def test_no_expiry_date_provided_by_auth_server(
         self,
@@ -363,7 +369,11 @@ class TestOauth2Authenticator:
         expected_new_expiry_date_delta,
         expected_access_token,
     ) -> None:
-        initial_expiry_date = ab_datetime_now().add(initial_expiry_date_delta).isoformat() if initial_expiry_date_delta else None
+        initial_expiry_date = (
+            ab_datetime_now().add(initial_expiry_date_delta).isoformat()
+            if initial_expiry_date_delta
+            else None
+        )
         expected_new_expiry_date = ab_datetime_now().add(expected_new_expiry_date_delta)
         oauth = DeclarativeOauth2Authenticator(
             token_refresh_endpoint="https://refresh_endpoint.com/",

--- a/unit_tests/sources/streams/http/requests_native_auth/test_requests_native_auth.py
+++ b/unit_tests/sources/streams/http/requests_native_auth/test_requests_native_auth.py
@@ -406,7 +406,14 @@ class TestOauth2Authenticator:
             (None, None, AirbyteDateTime(year=2022, month=1, day=1, hour=1)),
             (None, "YYYY-MM-DD", AirbyteDateTime(year=2022, month=1, day=1, hour=1)),
         ],
-        ids=["seconds", "string_of_seconds", "simple_date", "simple_datetime", "default_behavior", "default_behavior_with_format"],
+        ids=[
+            "seconds",
+            "string_of_seconds",
+            "simple_date",
+            "simple_datetime",
+            "default_behavior",
+            "default_behavior_with_format",
+        ],
     )
     @freezegun.freeze_time("2022-01-01")
     def test_parse_refresh_token_lifespan(

--- a/unit_tests/sources/streams/http/requests_native_auth/test_requests_native_auth.py
+++ b/unit_tests/sources/streams/http/requests_native_auth/test_requests_native_auth.py
@@ -6,7 +6,7 @@ import json
 import logging
 from datetime import timedelta
 from typing import Optional, Union
-from unittest.mock import Mock, PropertyMock
+from unittest.mock import Mock
 
 import freezegun
 import pytest

--- a/unit_tests/sources/streams/http/requests_native_auth/test_requests_native_auth.py
+++ b/unit_tests/sources/streams/http/requests_native_auth/test_requests_native_auth.py
@@ -83,6 +83,7 @@ def test_multiple_token_authenticator():
     assert {"Authorization": "Bearer token1"} == header3
 
 
+@freezegun.freeze_time("2022-01-01")
 class TestOauth2Authenticator:
     """
     Test class for OAuth2Authenticator.
@@ -104,8 +105,9 @@ class TestOauth2Authenticator:
             refresh_token=TestOauth2Authenticator.refresh_token,
         )
 
+        expires_in = ab_datetime_now().add(timedelta(seconds=1000))
         mocker.patch.object(
-            Oauth2Authenticator, "refresh_access_token", return_value=("access_token", 1000)
+            Oauth2Authenticator, "refresh_access_token", return_value=("access_token", expires_in)
         )
         header = oauth.get_auth_header()
         assert {"Authorization": "Bearer access_token"} == header
@@ -121,15 +123,15 @@ class TestOauth2Authenticator:
             refresh_token=TestOauth2Authenticator.refresh_token,
         )
 
-        expire_immediately = 0
+        already_expired = ab_datetime_now() - timedelta(seconds=100)
         mocker.patch.object(
             Oauth2Authenticator,
             "refresh_access_token",
-            return_value=("access_token_1", expire_immediately),
+            return_value=("access_token_1", already_expired),
         )
         oauth.get_auth_header()  # Set the first expired token.
 
-        valid_100_secs = 100
+        valid_100_secs = ab_datetime_now() + timedelta(seconds=100)
         mocker.patch.object(
             Oauth2Authenticator,
             "refresh_access_token",
@@ -236,7 +238,6 @@ class TestOauth2Authenticator:
         }
         assert body == expected
 
-    @freezegun.freeze_time("2022-01-01")
     def test_refresh_access_token(self, mocker):
         oauth = Oauth2Authenticator(
             token_refresh_endpoint="https://refresh_endpoint.com",
@@ -251,6 +252,21 @@ class TestOauth2Authenticator:
                 "scopes": ["no_override"],
             },
         )
+        
+        oauth_with_expired_token= Oauth2Authenticator(
+            token_refresh_endpoint="https://refresh_endpoint.com",
+            client_id="some_client_id",
+            client_secret="some_client_secret",
+            refresh_token="some_refresh_token",
+            scopes=["scope1", "scope2"],
+            token_expiry_date=ab_datetime_now() - timedelta(days=3),
+            refresh_request_body={
+                "custom_field": "in_outbound_request",
+                "another_field": "exists_in_body",
+                "scopes": ["no_override"],
+            },
+        )
+        
 
         resp.status_code = 200
         mocker.patch.object(
@@ -259,8 +275,9 @@ class TestOauth2Authenticator:
         mocker.patch.object(requests, "request", side_effect=mock_request, autospec=True)
         token, expires_in = oauth.refresh_access_token()
 
-        assert isinstance(expires_in, int)
-        assert ("access_token", 1000) == (token, expires_in)
+        assert isinstance(expires_in, AirbyteDateTime)
+        assert expires_in == ab_datetime_now().add(timedelta(seconds=1000))
+        assert token == "access_token"
 
         # Test with expires_in as str(int)
         mocker.patch.object(
@@ -268,28 +285,40 @@ class TestOauth2Authenticator:
         )
         token, expires_in = oauth.refresh_access_token()
 
-        assert isinstance(expires_in, str)
-        assert ("access_token", "2000") == (token, expires_in)
-
+        assert isinstance(expires_in, AirbyteDateTime)
+        assert expires_in == ab_datetime_now().add(timedelta(seconds=2000))
+        assert token == "access_token"
+        
         # Test with expires_in as datetime(str)
         mocker.patch.object(
             resp,
             "json",
             return_value={"access_token": "access_token", "expires_in": "2022-04-24T00:00:00Z"},
         )
-        token, expires_in = oauth.refresh_access_token()
-
-        assert isinstance(expires_in, str)
-        assert ("access_token", "2022-04-24T00:00:00Z") == (token, expires_in)
-
-        # Test with no expires_in
+        # This should raise a ValueError because the token_expiry_is_time_of_expiration is False by default
+        with pytest.raises(ValueError):
+            token, expires_in = oauth.refresh_access_token()
+            
+        # Test with no expires_in 
         mocker.patch.object(
             resp,
             "json",
             return_value={"access_token": "access_token"},
         )
+        
+        # Since the initialized token is not expired (now + 3 days), we don't expect the expiration date to be updated
         token, expires_in = oauth.refresh_access_token()
-        assert expires_in == "3600"
+        
+        assert isinstance(expires_in, AirbyteDateTime)
+        assert expires_in == ab_datetime_now().add(timedelta(days=3))
+        assert token == "access_token"
+        
+        # Since the initialized token is expired (now - 3 days), we expect the expiration date to be updated to the default value (now + 1 hour)
+        token, expires_in = oauth_with_expired_token.refresh_access_token()
+        
+        assert isinstance(expires_in, AirbyteDateTime)
+        assert expires_in == ab_datetime_now().add(timedelta(hours=1))
+        assert token == "access_token"
 
         # Test with nested access_token and expires_in as str(int)
         mocker.patch.object(
@@ -299,8 +328,9 @@ class TestOauth2Authenticator:
         )
         token, expires_in = oauth.refresh_access_token()
 
-        assert isinstance(expires_in, str)
-        assert ("access_token_nested", "2001") == (token, expires_in)
+        assert isinstance(expires_in, AirbyteDateTime)
+        assert expires_in == ab_datetime_now().add(timedelta(seconds=2001))
+        assert token == "access_token_nested"
 
         # Test with multiple nested levels access_token and expires_in as str(int)
         mocker.patch.object(
@@ -326,9 +356,10 @@ class TestOauth2Authenticator:
             },
         )
         token, expires_in = oauth.refresh_access_token()
-
-        assert isinstance(expires_in, str)
-        assert ("access_token_deeply_nested", "2002") == (token, expires_in)
+        
+        assert isinstance(expires_in, AirbyteDateTime)
+        assert expires_in == ab_datetime_now().add(timedelta(seconds=2002))
+        assert token == "access_token_deeply_nested"
 
         # Test with max nested levels access_token and expires_in as str(int)
         mocker.patch.object(
@@ -358,7 +389,7 @@ class TestOauth2Authenticator:
         )
         with pytest.raises(ResponseKeysMaxRecurtionReached) as exc_info:
             oauth.refresh_access_token()
-        error_message = "The maximum level of recursion is reached. Couldn't find the speficied `access_token` in the response."
+        error_message = "The maximum level of recursion is reached. Couldn't find the specified `access_token` in the response."
         assert exc_info.value.internal_message == error_message
         assert exc_info.value.message == error_message
         assert exc_info.value.failure_type == FailureType.config_error
@@ -387,8 +418,9 @@ class TestOauth2Authenticator:
         )
         token, expires_in = oauth.refresh_access_token()
 
-        assert isinstance(expires_in, int)
-        assert ("access_token", 1000) == (token, expires_in)
+        assert isinstance(expires_in, AirbyteDateTime)
+        assert expires_in == ab_datetime_now().add(timedelta(seconds=1000))
+        assert token == "access_token"
 
         assert mocked_request.call_args.kwargs["headers"] == expected_headers
 
@@ -415,7 +447,6 @@ class TestOauth2Authenticator:
             "default_behavior_with_format",
         ],
     )
-    @freezegun.freeze_time("2022-01-01")
     def test_parse_refresh_token_lifespan(
         self,
         mocker,
@@ -446,14 +477,11 @@ class TestOauth2Authenticator:
             return_value={"access_token": "access_token", "expires_in": expires_in_response},
         )
         mocker.patch.object(requests, "request", side_effect=mock_request, autospec=True)
-        token, expire_in = oauth.refresh_access_token()
-        expires_datetime = oauth._parse_token_expiration_date(expire_in)
+        token, expires_datetime = oauth.refresh_access_token()
 
         assert isinstance(expires_datetime, AirbyteDateTime)
-        assert ("access_token", expected_token_expiry_date) == (
-            token,
-            expires_datetime,
-        )
+        assert expires_datetime == expected_token_expiry_date
+        assert token == "access_token"
 
     @pytest.mark.usefixtures("mock_sleep")
     @pytest.mark.parametrize("error_code", (429, 500, 502, 504))
@@ -473,8 +501,9 @@ class TestOauth2Authenticator:
             ],
         )
         token, expires_in = oauth.refresh_access_token()
-        assert isinstance(expires_in, int)
-        assert (token, expires_in) == ("token", 10)
+        assert isinstance(expires_in, AirbyteDateTime)
+        assert token == "token"
+        assert expires_in == ab_datetime_now().add(timedelta(seconds=10))
         assert requests_mock.call_count == 3
 
     def test_auth_call_method(self, mocker):
@@ -485,8 +514,9 @@ class TestOauth2Authenticator:
             refresh_token=TestOauth2Authenticator.refresh_token,
         )
 
+        expires_in = ab_datetime_now().add(timedelta(seconds=1000))
         mocker.patch.object(
-            Oauth2Authenticator, "refresh_access_token", return_value=("access_token", 1000)
+            Oauth2Authenticator, "refresh_access_token", return_value=("access_token", expires_in)
         )
         prepared_request = requests.PreparedRequest()
         prepared_request.headers = {}
@@ -549,7 +579,7 @@ class TestOauth2Authenticator:
             assert exc_info.value.message == error_message
             assert exc_info.value.failure_type == FailureType.config_error
 
-
+@freezegun.freeze_time("2022-12-31")
 class TestSingleUseRefreshTokenOauth2Authenticator:
     @pytest.fixture
     def connector_config(self):
@@ -570,7 +600,7 @@ class TestSingleUseRefreshTokenOauth2Authenticator:
     def test_init(self, connector_config):
         authenticator = SingleUseRefreshTokenOauth2Authenticator(
             connector_config,
-            token_refresh_endpoint="foobar",
+            token_refresh_endpoint="https://refresh_endpoint.com",
             client_id=connector_config["credentials"]["client_id"],
             client_secret=connector_config["credentials"]["client_secret"],
         )
@@ -580,7 +610,6 @@ class TestSingleUseRefreshTokenOauth2Authenticator:
             connector_config["credentials"]["token_expiry_date"]
         )
 
-    @freezegun.freeze_time("2022-12-31")
     @pytest.mark.parametrize(
         "test_name, expires_in_value, expiry_date_format, expected_expiry_date",
         [
@@ -601,14 +630,20 @@ class TestSingleUseRefreshTokenOauth2Authenticator:
     ):
         authenticator = SingleUseRefreshTokenOauth2Authenticator(
             connector_config,
-            token_refresh_endpoint="foobar",
+            token_refresh_endpoint="https://refresh_endpoint.com",
             client_id=connector_config["credentials"]["client_id"],
             client_secret=connector_config["credentials"]["client_secret"],
             token_expiry_date_format=expiry_date_format,
+            token_expiry_is_time_of_expiration=bool(expiry_date_format),
         )
-        authenticator.refresh_access_token = mocker.Mock(
-            return_value=("new_access_token", expires_in_value, "new_refresh_token")
+        
+        # Mock the response from the refresh token endpoint
+        resp.status_code = 200
+        mocker.patch.object(
+            resp, "json", return_value={"access_token": "new_access_token", "expires_in": expires_in_value, "refresh_token": "new_refresh_token"}
         )
+        mocker.patch.object(requests, "request", side_effect=mock_request, autospec=True)
+        
         authenticator.token_has_expired = mocker.Mock(return_value=True)
         access_token = authenticator.get_access_token()
         captured = capsys.readouterr()
@@ -639,9 +674,16 @@ class TestSingleUseRefreshTokenOauth2Authenticator:
             token_expiry_date_format="YYYY-MM-DD",
             message_repository=message_repository,
         )
-        authenticator.refresh_access_token = mocker.Mock(
-            return_value=("new_access_token", "2023-04-04", "new_refresh_token")
+        # Mock the response from the refresh token endpoint
+        resp.status_code = 200
+        mocker.patch.object(
+            resp, "json", return_value={"access_token": "new_access_token", "expires_in": "2023-04-04", "refresh_token": "new_refresh_token"}
         )
+        mocker.patch.object(requests, "request", side_effect=mock_request, autospec=True)
+        
+        # authenticator.refresh_access_token = mocker.Mock(
+        #     return_value=("new_access_token", "2023-04-04", "new_refresh_token")
+        # )
         authenticator.token_has_expired = mocker.Mock(return_value=True)
 
         authenticator.get_access_token()


### PR DESCRIPTION
fixes https://github.com/airbytehq/airbyte/issues/54198

question: what sort of larger integration / end-to-end testing should be done on this? Should I run a sync for instance?

The proposal is to create a default expiration (currently 1 hour) that we use if we do not receive a token expiration back from the resource server when requesting / refreshing access tokens. This number is somewhat arbitrary but set to be a middle ground to avoid overly aggressive refreshes and a case where an access token expires before our fabricated expiration.  

a future improvement would be to check several places for the token expiration (potentially another API endpoint or within the access token JWT)

Also, in writing this, I opted to try to make as small a change as possible to minimally interfere with the existing code paths. As a result I updated the extraction method as opposed to adding code to an existing method that does expiration date parsing `_parse_token_expiration_date` which is not used by all code paths. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced default token expiration handling to improve token refresh behavior when expiration details are missing.

- **Tests**
  - Enhanced test coverage with scenarios for missing or expired token expiration fields.
  - Added fixed-time decorators for consistent expiry date testing.
  - Improved realism in token refresh tests by mocking HTTP responses.
  - Added parameterized tests for token expiry absence and updated expiry assertions for accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->