### PR TITLE
ci(hotfix): update version detection format in workflow

### DIFF
--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Detect Prerelease Version using Dunamai
         uses: mtkennerly/dunamai-action@v1
         with:
-          args: --style pep440 --format "{base}.post{distance}.dev0{commit}"
+          args: --format "{base}.post{distance}.dev0{commit}"
           env-var: DETECTED_VERSION
 
       - name: Detect Release Tag Version from git ref ('${{ github.ref_name }}')

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Detect Prerelease Version using Dunamai
         uses: mtkennerly/dunamai-action@v1
         with:
-          args: --format "{base}.post{distance}.dev0{commit}"
+          args: --format "{base}.post{distance}.dev${{ github.run_id }}"
           env-var: DETECTED_VERSION
 
       - name: Detect Release Tag Version from git ref ('${{ github.ref_name }}')

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -9,8 +9,8 @@ name: CDK Publish
 
 on:
   push:
-    tags:
-      - "v*"
+    # tags:
+    #   - "v*"
   workflow_dispatch:
     inputs:
       version:
@@ -51,7 +51,7 @@ jobs:
       - name: Detect Prerelease Version using Dunamai
         uses: mtkennerly/dunamai-action@v1
         with:
-          args: --style pep440
+          args: --style pep440 --format "{base}.post{distance}.dev0{commit}"
           env-var: DETECTED_VERSION
 
       - name: Detect Release Tag Version from git ref ('${{ github.ref_name }}')

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -80,8 +80,8 @@ jobs:
           INPUT_VERSION="${INPUT_VERSION#v}"
           # Fail if detected version is non-empty and different from the input version
           if [ -n "${DETECTED_VERSION:-}" ] && [ -n "${INPUT_VERSION:-}" ] && [ "${DETECTED_VERSION}" != "${INPUT_VERSION}" ]; then
-            echo "Error: Version input '${INPUT_VERSION}' does not match detected version '${DETECTED_VERSION}'."
-            exit 1
+            echo "Warning: Version input '${INPUT_VERSION}' does not match detected version '${DETECTED_VERSION}'."
+            echo "Using input version '${INPUT_VERSION}' instead."
           fi
           # Set the version to the input version if non-empty, otherwise the detected version
           VERSION="${INPUT_VERSION:-$DETECTED_VERSION}"

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -9,8 +9,8 @@ name: CDK Publish
 
 on:
   push:
-    # tags:
-    #   - "v*"
+    tags:
+      - "v*"
   workflow_dispatch:
     inputs:
       version:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ version = "0.0.0"  # Version will be calculated dynamically.
 
 [tool.poetry-dynamic-versioning]
 enable = true
-style = "pep440"  # Ensures compatibility with PyPI
 
 [tool.poetry.dependencies]
 python = ">=3.10,<3.13"


### PR DESCRIPTION
Modify the version detection format in the workflow to include additional formatting options and comment out the tag trigger.