### PR TITLE
feat(low-code): added key_transformation to DpathFlattenFields

### DIFF
--- a/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -2307,6 +2307,33 @@ definitions:
       $parameters:
         type: object
         additionalProperties: true
+  KeyTransformation:
+    title: Transformation to apply for extracted object keys by Dpath Flatten Fields
+    type: object
+    required:
+      - type
+    properties:
+      type:
+        type: string
+        enum: [ KeyTransformation ]
+      prefix:
+        title: Key Prefix
+        description: Prefix to add for object keys. If not provided original keys remain unchanged.
+        type: string
+        examples:
+          - flattened_
+      suffix:
+        title: Key Suffix
+        description: Suffix to add for object keys. If not provided original keys remain unchanged.
+        type: string
+        examples:
+          - _flattened
+      custom:
+        title: Custom Transformation for keys
+        description: Custom transformation. Can be used with {{ key }} as a original value for key name. If not provided original keys remain unchanged.
+        type: string
+        examples:
+          - flattened_{{ key }}
   DpathFlattenFields:
     title: Dpath Flatten Fields
     description: A transformation that flatten field values to the to top of the record.
@@ -2338,9 +2365,8 @@ definitions:
       key_transformation:
         title: Key transformation
         description: Transformation for object keys. If not provided, original key will be used.
-        type: string
-        examples:
-          - "flattened_{{ key }}"
+        type: object
+        "$ref": "#/definitions/KeyTransformation"
       $parameters:
         type: object
         additionalProperties: true

--- a/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -2335,6 +2335,12 @@ definitions:
         title: Replace Origin Record
         description: Whether to replace the origin record or not. Default is False.
         type: boolean
+      key_transformation:
+        title: Key transformation
+        description: Transformation for object keys. If not provided, original key will be used.
+        type: string
+        examples:
+          - "flattened_{{ key }}"
       $parameters:
         type: object
         additionalProperties: true

--- a/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -2328,12 +2328,6 @@ definitions:
         type: string
         examples:
           - _flattened
-      custom:
-        title: Custom Transformation for keys
-        description: Custom transformation. Can be used with {{ key }} as a original value for key name. If not provided original keys remain unchanged.
-        type: string
-        examples:
-          - flattened_{{ key }}
   DpathFlattenFields:
     title: Dpath Flatten Fields
     description: A transformation that flatten field values to the to top of the record.

--- a/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
+++ b/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
@@ -897,6 +897,14 @@ class DpathFlattenFields(BaseModel):
         description="Whether to replace the origin record or not. Default is False.",
         title="Replace Origin Record",
     )
+    key_transformation: Optional[str] = Field(
+        None,
+        description="Transformation for object keys. If not provided, original key will be used.",
+        examples=[
+            "flattened_{{ key }}",
+        ],
+        title="Key transformation",
+    )
     parameters: Optional[Dict[str, Any]] = Field(None, alias="$parameters")
 
 

--- a/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
+++ b/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
@@ -896,14 +896,6 @@ class KeyTransformation(BaseModel):
         ],
         title="Key Suffix",
     )
-    custom: Optional[Union[str, None]] = Field(
-        None,
-        description="Custom transformation. Can be used with {{ key }} as a original value for key name. If not provided original keys remain unchanged.",
-        examples=[
-            "flattened_{{ key }}",
-        ],
-        title="Custom Transformation for keys",
-    )
 
 
 class DpathFlattenFields(BaseModel):

--- a/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
+++ b/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
@@ -879,6 +879,33 @@ class FlattenFields(BaseModel):
     parameters: Optional[Dict[str, Any]] = Field(None, alias="$parameters")
 
 
+class KeyTransformation(BaseModel):
+    prefix: Optional[Union[str, None]] = Field(
+        None,
+        description="Prefix to add for object keys. If not provided original keys remain unchanged.",
+        examples=[
+            "flattened_",
+        ],
+        title="Key Prefix",
+    )
+    suffix: Optional[Union[str, None]] = Field(
+        None,
+        description="Suffix to add for object keys. If not provided original keys remain unchanged.",
+        examples=[
+            "_flattened",
+        ],
+        title="Key Suffix",
+    )
+    custom: Optional[Union[str, None]] = Field(
+        None,
+        description="Custom transformation. Can be used with {{ key }} as a original value for key name. If not provided original keys remain unchanged.",
+        examples=[
+            "flattened_{{ key }}",
+        ],
+        title="Custom Transformation for keys",
+    )
+
+
 class DpathFlattenFields(BaseModel):
     type: Literal["DpathFlattenFields"]
     field_path: List[str] = Field(
@@ -897,12 +924,9 @@ class DpathFlattenFields(BaseModel):
         description="Whether to replace the origin record or not. Default is False.",
         title="Replace Origin Record",
     )
-    key_transformation: Optional[str] = Field(
+    key_transformation: Optional[Union[KeyTransformation, None]] = Field(
         None,
         description="Transformation for object keys. If not provided, original key will be used.",
-        examples=[
-            "flattened_{{ key }}",
-        ],
         title="Key transformation",
     )
     parameters: Optional[Dict[str, Any]] = Field(None, alias="$parameters")

--- a/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -793,6 +793,7 @@ class ModelToComponentFactory:
         model_field_path: List[Union[InterpolatedString, str]] = [x for x in model.field_path]
         key_transformation = (
             KeyTransformation(
+                config=config,
                 prefix=model.key_transformation.prefix,
                 suffix=model.key_transformation.suffix,
                 parameters=model.parameters or {},

--- a/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -795,7 +795,7 @@ class ModelToComponentFactory:
             KeyTransformation(
                 prefix=model.key_transformation.prefix,
                 suffix=model.key_transformation.suffix,
-                custom=model.key_transformation.custom,
+                parameters=model.parameters or {},
             )
             if model.key_transformation is not None
             else None

--- a/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -498,6 +498,7 @@ from airbyte_cdk.sources.declarative.transformations import (
 from airbyte_cdk.sources.declarative.transformations.add_fields import AddedFieldDefinition
 from airbyte_cdk.sources.declarative.transformations.dpath_flatten_fields import (
     DpathFlattenFields,
+    KeyTransformation,
 )
 from airbyte_cdk.sources.declarative.transformations.flatten_fields import (
     FlattenFields,
@@ -790,6 +791,15 @@ class ModelToComponentFactory:
         self, model: DpathFlattenFieldsModel, config: Config, **kwargs: Any
     ) -> DpathFlattenFields:
         model_field_path: List[Union[InterpolatedString, str]] = [x for x in model.field_path]
+        key_transformation = (
+            KeyTransformation(
+                prefix=model.key_transformation.prefix,
+                suffix=model.key_transformation.suffix,
+                custom=model.key_transformation.custom,
+            )
+            if model.key_transformation is not None
+            else None
+        )
         return DpathFlattenFields(
             config=config,
             field_path=model_field_path,
@@ -797,7 +807,7 @@ class ModelToComponentFactory:
             if model.delete_origin_value is not None
             else False,
             replace_record=model.replace_record if model.replace_record is not None else False,
-            key_transformation=model.key_transformation,
+            key_transformation=key_transformation,
             parameters=model.parameters or {},
         )
 

--- a/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -797,6 +797,7 @@ class ModelToComponentFactory:
             if model.delete_origin_value is not None
             else False,
             replace_record=model.replace_record if model.replace_record is not None else False,
+            key_transformation=model.key_transformation,
             parameters=model.parameters or {},
         )
 

--- a/airbyte_cdk/sources/declarative/transformations/dpath_flatten_fields.py
+++ b/airbyte_cdk/sources/declarative/transformations/dpath_flatten_fields.py
@@ -17,9 +17,13 @@ class KeyTransformation:
 
     def __post_init__(self, parameters: Mapping[str, Any]) -> None:
         if self.prefix is not None:
-            self.prefix = InterpolatedString.create(self.prefix, parameters=parameters).eval(self.config)
+            self.prefix = InterpolatedString.create(self.prefix, parameters=parameters).eval(
+                self.config
+            )
         if self.suffix is not None:
-            self.suffix = InterpolatedString.create(self.suffix, parameters=parameters).eval(self.config)
+            self.suffix = InterpolatedString.create(self.suffix, parameters=parameters).eval(
+                self.config
+            )
 
 
 @dataclass
@@ -55,10 +59,16 @@ class DpathFlattenFields(RecordTransformation):
     def _apply_key_transformation(self, extracted: Mapping[str, Any]) -> Mapping[str, Any]:
         if self.key_transformation:
             if self.key_transformation.prefix:
-                extracted = {f"{self.key_transformation.prefix}{key}": value for key, value in extracted.items()}
+                extracted = {
+                    f"{self.key_transformation.prefix}{key}": value
+                    for key, value in extracted.items()
+                }
 
             if self.key_transformation.suffix:
-                extracted = {f"{key}{self.key_transformation.suffix}": value for key, value in extracted.items()}
+                extracted = {
+                    f"{key}{self.key_transformation.suffix}": value
+                    for key, value in extracted.items()
+                }
 
         return extracted
 

--- a/airbyte_cdk/sources/declarative/transformations/dpath_flatten_fields.py
+++ b/airbyte_cdk/sources/declarative/transformations/dpath_flatten_fields.py
@@ -12,8 +12,8 @@ from airbyte_cdk.sources.types import Config, StreamSlice, StreamState
 class KeyTransformation:
     config: Config
     parameters: InitVar[Mapping[str, Any]]
-    prefix: Union[InterpolatedString, str, None] = None
-    suffix: Union[InterpolatedString, str, None] = None
+    prefix: Optional[str] = None
+    suffix: Optional[str] = None
 
     def __post_init__(self, parameters: Mapping[str, Any]) -> None:
         if self.prefix is not None:

--- a/unit_tests/sources/declarative/transformations/test_dpath_flatten_fields.py
+++ b/unit_tests/sources/declarative/transformations/test_dpath_flatten_fields.py
@@ -9,6 +9,7 @@ _DO_NOT_DELETE_ORIGIN_VALUE = False
 _DO_NOT_REPLACE_WITH_VALUE = False
 _NO_KEY_TRANSFORMATIONS = None
 
+
 @pytest.mark.parametrize(
     [
         "input_record",
@@ -173,7 +174,13 @@ _NO_KEY_TRANSFORMATIONS = None
     ],
 )
 def test_dpath_flatten_lists(
-    input_record, config, field_path, delete_origin_value, replace_record, key_transformation, expected_record
+    input_record,
+    config,
+    field_path,
+    delete_origin_value,
+    replace_record,
+    key_transformation,
+    expected_record,
 ):
     flattener = DpathFlattenFields(
         field_path=field_path,

--- a/unit_tests/sources/declarative/transformations/test_dpath_flatten_fields.py
+++ b/unit_tests/sources/declarative/transformations/test_dpath_flatten_fields.py
@@ -7,7 +7,7 @@ _DELETE_ORIGIN_VALUE = True
 _REPLACE_WITH_VALUE = True
 _DO_NOT_DELETE_ORIGIN_VALUE = False
 _DO_NOT_REPLACE_WITH_VALUE = False
-
+_NO_KEY_TRANSFORMATIONS = None
 
 @pytest.mark.parametrize(
     [
@@ -16,6 +16,7 @@ _DO_NOT_REPLACE_WITH_VALUE = False
         "field_path",
         "delete_origin_value",
         "replace_record",
+        "key_transformation",
         "expected_record",
     ],
     [
@@ -25,6 +26,7 @@ _DO_NOT_REPLACE_WITH_VALUE = False
             ["field2"],
             _DO_NOT_DELETE_ORIGIN_VALUE,
             _DO_NOT_REPLACE_WITH_VALUE,
+            _NO_KEY_TRANSFORMATIONS,
             {"field1": _ANY_VALUE, "field2": {"field3": _ANY_VALUE}, "field3": _ANY_VALUE},
             id="flatten by dpath, don't delete origin value",
         ),
@@ -34,6 +36,7 @@ _DO_NOT_REPLACE_WITH_VALUE = False
             ["field2"],
             _DELETE_ORIGIN_VALUE,
             _DO_NOT_REPLACE_WITH_VALUE,
+            _NO_KEY_TRANSFORMATIONS,
             {"field1": _ANY_VALUE, "field3": _ANY_VALUE},
             id="flatten by dpath, delete origin value",
         ),
@@ -46,6 +49,7 @@ _DO_NOT_REPLACE_WITH_VALUE = False
             ["field2", "*", "field4"],
             _DO_NOT_DELETE_ORIGIN_VALUE,
             _DO_NOT_REPLACE_WITH_VALUE,
+            _NO_KEY_TRANSFORMATIONS,
             {
                 "field1": _ANY_VALUE,
                 "field2": {"field3": {"field4": {"field5": _ANY_VALUE}}},
@@ -62,6 +66,7 @@ _DO_NOT_REPLACE_WITH_VALUE = False
             ["field2", "*", "field4"],
             _DELETE_ORIGIN_VALUE,
             _DO_NOT_REPLACE_WITH_VALUE,
+            _NO_KEY_TRANSFORMATIONS,
             {"field1": _ANY_VALUE, "field2": {"field3": {}}, "field5": _ANY_VALUE},
             id="flatten by dpath with *, delete origin value",
         ),
@@ -71,6 +76,7 @@ _DO_NOT_REPLACE_WITH_VALUE = False
             ["{{ config['field_path'] }}"],
             _DO_NOT_DELETE_ORIGIN_VALUE,
             _DO_NOT_REPLACE_WITH_VALUE,
+            _NO_KEY_TRANSFORMATIONS,
             {"field1": _ANY_VALUE, "field2": {"field3": _ANY_VALUE}, "field3": _ANY_VALUE},
             id="flatten by dpath from config, don't delete origin value",
         ),
@@ -80,6 +86,7 @@ _DO_NOT_REPLACE_WITH_VALUE = False
             ["non-existing-field"],
             _DO_NOT_DELETE_ORIGIN_VALUE,
             _DO_NOT_REPLACE_WITH_VALUE,
+            _NO_KEY_TRANSFORMATIONS,
             {"field1": _ANY_VALUE, "field2": {"field3": _ANY_VALUE}},
             id="flatten by non-existing dpath, don't delete origin value",
         ),
@@ -89,6 +96,7 @@ _DO_NOT_REPLACE_WITH_VALUE = False
             ["*", "non-existing-field"],
             _DO_NOT_DELETE_ORIGIN_VALUE,
             _DO_NOT_REPLACE_WITH_VALUE,
+            _NO_KEY_TRANSFORMATIONS,
             {"field1": _ANY_VALUE, "field2": {"field3": _ANY_VALUE}},
             id="flatten by non-existing dpath with *, don't delete origin value",
         ),
@@ -98,6 +106,7 @@ _DO_NOT_REPLACE_WITH_VALUE = False
             ["field2"],
             _DO_NOT_DELETE_ORIGIN_VALUE,
             _DO_NOT_REPLACE_WITH_VALUE,
+            _NO_KEY_TRANSFORMATIONS,
             {"field1": _ANY_VALUE, "field2": {"field3": _ANY_VALUE}, "field3": _ANY_VALUE},
             id="flatten by dpath, not to update when record has field conflicts, don't delete origin value",
         ),
@@ -107,6 +116,7 @@ _DO_NOT_REPLACE_WITH_VALUE = False
             ["field2"],
             _DO_NOT_DELETE_ORIGIN_VALUE,
             _DO_NOT_REPLACE_WITH_VALUE,
+            _NO_KEY_TRANSFORMATIONS,
             {"field1": _ANY_VALUE, "field2": {"field3": _ANY_VALUE}, "field3": _ANY_VALUE},
             id="flatten by dpath, not to update when record has field conflicts, delete origin value",
         ),
@@ -116,6 +126,7 @@ _DO_NOT_REPLACE_WITH_VALUE = False
             ["field2"],
             _DO_NOT_DELETE_ORIGIN_VALUE,
             _REPLACE_WITH_VALUE,
+            _NO_KEY_TRANSFORMATIONS,
             {"field3": _ANY_VALUE},
             id="flatten by dpath, replace with value",
         ),
@@ -125,13 +136,44 @@ _DO_NOT_REPLACE_WITH_VALUE = False
             ["field2"],
             _DELETE_ORIGIN_VALUE,
             _REPLACE_WITH_VALUE,
+            _NO_KEY_TRANSFORMATIONS,
             {"field3": _ANY_VALUE},
             id="flatten by dpath, delete_origin_value do not affect to replace_record",
+        ),
+        pytest.param(
+            {"field1": _ANY_VALUE, "field2": {"field3": _ANY_VALUE}},
+            {},
+            ["field2"],
+            _DO_NOT_DELETE_ORIGIN_VALUE,
+            _DO_NOT_REPLACE_WITH_VALUE,
+            "field2_{{ key }}",
+            {"field1": _ANY_VALUE, "field2": {"field3": _ANY_VALUE}, "field2_field3": _ANY_VALUE},
+            id="flatten by dpath, not delete origin value, add keys transformation",
+        ),
+        pytest.param(
+            {"field1": _ANY_VALUE, "field2": {"field3": _ANY_VALUE}},
+            {},
+            ["field2"],
+            _DELETE_ORIGIN_VALUE,
+            _DO_NOT_REPLACE_WITH_VALUE,
+            "field2_{{ key }}",
+            {"field1": _ANY_VALUE, "field2_field3": _ANY_VALUE},
+            id="flatten by dpath, delete origin value, add keys transformation",
+        ),
+        pytest.param(
+            {"field1": _ANY_VALUE, "field2": {"field3": _ANY_VALUE}},
+            {},
+            ["field2"],
+            _DO_NOT_DELETE_ORIGIN_VALUE,
+            _REPLACE_WITH_VALUE,
+            "field2_{{ key }}",
+            {"field2_field3": _ANY_VALUE},
+            id="flatten by dpath, not delete origin value, replace record, add keys transformation",
         ),
     ],
 )
 def test_dpath_flatten_lists(
-    input_record, config, field_path, delete_origin_value, replace_record, expected_record
+    input_record, config, field_path, delete_origin_value, replace_record, key_transformation, expected_record
 ):
     flattener = DpathFlattenFields(
         field_path=field_path,
@@ -139,6 +181,7 @@ def test_dpath_flatten_lists(
         config=config,
         delete_origin_value=delete_origin_value,
         replace_record=replace_record,
+        key_transformation=key_transformation,
     )
     flattener.transform(input_record)
     assert input_record == expected_record

--- a/unit_tests/sources/declarative/transformations/test_dpath_flatten_fields.py
+++ b/unit_tests/sources/declarative/transformations/test_dpath_flatten_fields.py
@@ -12,7 +12,6 @@ _DO_NOT_DELETE_ORIGIN_VALUE = False
 _DO_NOT_REPLACE_WITH_VALUE = False
 _NO_KEY_PREFIX = None
 _NO_KEY_SUFFIX = None
-_NO_CUSTOM_TRANSFORMATION = None
 _NO_KEY_TRANSFORMATIONS = None
 
 
@@ -152,38 +151,8 @@ _NO_KEY_TRANSFORMATIONS = None
             {},
             ["field2"],
             _DO_NOT_DELETE_ORIGIN_VALUE,
-            _DO_NOT_REPLACE_WITH_VALUE,
-            (_NO_KEY_PREFIX, _NO_KEY_SUFFIX, "field2_{{ key }}"),
-            {"field1": _ANY_VALUE, "field2": {"field3": _ANY_VALUE}, "field2_field3": _ANY_VALUE},
-            id="flatten by dpath, not delete origin value, add keys custom transformation",
-        ),
-        pytest.param(
-            {"field1": _ANY_VALUE, "field2": {"field3": _ANY_VALUE}},
-            {},
-            ["field2"],
-            _DELETE_ORIGIN_VALUE,
-            _DO_NOT_REPLACE_WITH_VALUE,
-            (_NO_KEY_PREFIX, _NO_KEY_SUFFIX, "field2_{{ key }}"),
-            {"field1": _ANY_VALUE, "field2_field3": _ANY_VALUE},
-            id="flatten by dpath, delete origin value, add keys custom transformation",
-        ),
-        pytest.param(
-            {"field1": _ANY_VALUE, "field2": {"field3": _ANY_VALUE}},
-            {},
-            ["field2"],
-            _DO_NOT_DELETE_ORIGIN_VALUE,
             _REPLACE_WITH_VALUE,
-            (_NO_KEY_PREFIX, _NO_KEY_SUFFIX, "field2_{{ key }}"),
-            {"field2_field3": _ANY_VALUE},
-            id="flatten by dpath, not delete origin value, replace record, add keys custom transformation",
-        ),
-        pytest.param(
-            {"field1": _ANY_VALUE, "field2": {"field3": _ANY_VALUE}},
-            {},
-            ["field2"],
-            _DO_NOT_DELETE_ORIGIN_VALUE,
-            _REPLACE_WITH_VALUE,
-            ("prefix_", _NO_KEY_SUFFIX, _NO_CUSTOM_TRANSFORMATION),
+            ("prefix_", _NO_KEY_SUFFIX),
             {"prefix_field3": _ANY_VALUE},
             id="flatten by dpath, not delete origin value, replace record, add keys prefix",
         ),
@@ -193,7 +162,7 @@ _NO_KEY_TRANSFORMATIONS = None
             ["field2"],
             _DO_NOT_DELETE_ORIGIN_VALUE,
             _REPLACE_WITH_VALUE,
-            (_NO_KEY_PREFIX, "_suffix", _NO_CUSTOM_TRANSFORMATION),
+            (_NO_KEY_PREFIX, "_suffix"),
             {"field3_suffix": _ANY_VALUE},
             id="flatten by dpath, not delete origin value, replace record, add keys suffix",
         ),
@@ -203,19 +172,9 @@ _NO_KEY_TRANSFORMATIONS = None
             ["field2"],
             _DO_NOT_DELETE_ORIGIN_VALUE,
             _REPLACE_WITH_VALUE,
-            ("prefix_", "_suffix", _NO_CUSTOM_TRANSFORMATION),
+            ("prefix_", "_suffix"),
             {"prefix_field3_suffix": _ANY_VALUE},
             id="flatten by dpath, not delete origin value, replace record, add keys prefix and suffix",
-        ),
-        pytest.param(
-            {"field1": _ANY_VALUE, "field2": {"field3": _ANY_VALUE}},
-            {},
-            ["field2"],
-            _DO_NOT_DELETE_ORIGIN_VALUE,
-            _REPLACE_WITH_VALUE,
-            ("prefix_", "_suffix", "{{ key|upper }}"),
-            {"PREFIX_FIELD3_SUFFIX": _ANY_VALUE},
-            id="flatten by dpath, not delete origin value, replace record, add keys prefix and suffix with custom to upper case",
         ),
     ],
 )
@@ -229,7 +188,7 @@ def test_dpath_flatten_lists(
     expected_record,
 ):
     if key_transformation:
-        key_transformation = KeyTransformation(*key_transformation)
+        key_transformation = KeyTransformation({}, *key_transformation)
 
     flattener = DpathFlattenFields(
         field_path=field_path,

--- a/unit_tests/sources/declarative/transformations/test_dpath_flatten_fields.py
+++ b/unit_tests/sources/declarative/transformations/test_dpath_flatten_fields.py
@@ -188,7 +188,7 @@ def test_dpath_flatten_lists(
     expected_record,
 ):
     if key_transformation:
-        key_transformation = KeyTransformation({}, *key_transformation)
+        key_transformation = KeyTransformation(config, {}, *key_transformation)
 
     flattener = DpathFlattenFields(
         field_path=field_path,

--- a/unit_tests/sources/declarative/transformations/test_dpath_flatten_fields.py
+++ b/unit_tests/sources/declarative/transformations/test_dpath_flatten_fields.py
@@ -1,12 +1,18 @@
 import pytest
 
-from airbyte_cdk.sources.declarative.transformations.dpath_flatten_fields import DpathFlattenFields
+from airbyte_cdk.sources.declarative.transformations.dpath_flatten_fields import (
+    DpathFlattenFields,
+    KeyTransformation,
+)
 
 _ANY_VALUE = -1
 _DELETE_ORIGIN_VALUE = True
 _REPLACE_WITH_VALUE = True
 _DO_NOT_DELETE_ORIGIN_VALUE = False
 _DO_NOT_REPLACE_WITH_VALUE = False
+_NO_KEY_PREFIX = None
+_NO_KEY_SUFFIX = None
+_NO_CUSTOM_TRANSFORMATION = None
 _NO_KEY_TRANSFORMATIONS = None
 
 
@@ -147,9 +153,9 @@ _NO_KEY_TRANSFORMATIONS = None
             ["field2"],
             _DO_NOT_DELETE_ORIGIN_VALUE,
             _DO_NOT_REPLACE_WITH_VALUE,
-            "field2_{{ key }}",
+            (_NO_KEY_PREFIX, _NO_KEY_SUFFIX, "field2_{{ key }}"),
             {"field1": _ANY_VALUE, "field2": {"field3": _ANY_VALUE}, "field2_field3": _ANY_VALUE},
-            id="flatten by dpath, not delete origin value, add keys transformation",
+            id="flatten by dpath, not delete origin value, add keys custom transformation",
         ),
         pytest.param(
             {"field1": _ANY_VALUE, "field2": {"field3": _ANY_VALUE}},
@@ -157,9 +163,9 @@ _NO_KEY_TRANSFORMATIONS = None
             ["field2"],
             _DELETE_ORIGIN_VALUE,
             _DO_NOT_REPLACE_WITH_VALUE,
-            "field2_{{ key }}",
+            (_NO_KEY_PREFIX, _NO_KEY_SUFFIX, "field2_{{ key }}"),
             {"field1": _ANY_VALUE, "field2_field3": _ANY_VALUE},
-            id="flatten by dpath, delete origin value, add keys transformation",
+            id="flatten by dpath, delete origin value, add keys custom transformation",
         ),
         pytest.param(
             {"field1": _ANY_VALUE, "field2": {"field3": _ANY_VALUE}},
@@ -167,9 +173,49 @@ _NO_KEY_TRANSFORMATIONS = None
             ["field2"],
             _DO_NOT_DELETE_ORIGIN_VALUE,
             _REPLACE_WITH_VALUE,
-            "field2_{{ key }}",
+            (_NO_KEY_PREFIX, _NO_KEY_SUFFIX, "field2_{{ key }}"),
             {"field2_field3": _ANY_VALUE},
-            id="flatten by dpath, not delete origin value, replace record, add keys transformation",
+            id="flatten by dpath, not delete origin value, replace record, add keys custom transformation",
+        ),
+        pytest.param(
+            {"field1": _ANY_VALUE, "field2": {"field3": _ANY_VALUE}},
+            {},
+            ["field2"],
+            _DO_NOT_DELETE_ORIGIN_VALUE,
+            _REPLACE_WITH_VALUE,
+            ("prefix_", _NO_KEY_SUFFIX, _NO_CUSTOM_TRANSFORMATION),
+            {"prefix_field3": _ANY_VALUE},
+            id="flatten by dpath, not delete origin value, replace record, add keys prefix",
+        ),
+        pytest.param(
+            {"field1": _ANY_VALUE, "field2": {"field3": _ANY_VALUE}},
+            {},
+            ["field2"],
+            _DO_NOT_DELETE_ORIGIN_VALUE,
+            _REPLACE_WITH_VALUE,
+            (_NO_KEY_PREFIX, "_suffix", _NO_CUSTOM_TRANSFORMATION),
+            {"field3_suffix": _ANY_VALUE},
+            id="flatten by dpath, not delete origin value, replace record, add keys suffix",
+        ),
+        pytest.param(
+            {"field1": _ANY_VALUE, "field2": {"field3": _ANY_VALUE}},
+            {},
+            ["field2"],
+            _DO_NOT_DELETE_ORIGIN_VALUE,
+            _REPLACE_WITH_VALUE,
+            ("prefix_", "_suffix", _NO_CUSTOM_TRANSFORMATION),
+            {"prefix_field3_suffix": _ANY_VALUE},
+            id="flatten by dpath, not delete origin value, replace record, add keys prefix and suffix",
+        ),
+        pytest.param(
+            {"field1": _ANY_VALUE, "field2": {"field3": _ANY_VALUE}},
+            {},
+            ["field2"],
+            _DO_NOT_DELETE_ORIGIN_VALUE,
+            _REPLACE_WITH_VALUE,
+            ("prefix_", "_suffix", "{{ key|upper }}"),
+            {"PREFIX_FIELD3_SUFFIX": _ANY_VALUE},
+            id="flatten by dpath, not delete origin value, replace record, add keys prefix and suffix with custom to upper case",
         ),
     ],
 )
@@ -182,6 +228,9 @@ def test_dpath_flatten_lists(
     key_transformation,
     expected_record,
 ):
+    if key_transformation:
+        key_transformation = KeyTransformation(*key_transformation)
+
     flattener = DpathFlattenFields(
         field_path=field_path,
         parameters={},


### PR DESCRIPTION
### What
neede for source-hubspot migration to low code. 
We already have `DpathFlattenFields` to extract object fields, but with current implementation we can't customize extracted object keys. 
[Current implementation in hubspot with RecordUnnester.](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connectors/source-hubspot/source_hubspot/streams.py#L121)
### How
added `key_transformation` option to `DpathFlattenFields`.
Example:
```
      - type: DpathFlattenFields
        key_transformation:
          type: KeyTransformation
          prefix: merged_from_email_
        field_path:
          - merged_from_email
      - type: DpathFlattenFields
        key_transformation:
          type: KeyTransformation
          prefix: merged_to_email_
        field_path:
          - merged_to_email
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced a configurable key transformation option that allows dynamic renaming of keys during field removal and flatten operations, with support for prefixes, suffixes, and custom formats. If no transformation is provided, original keys remain unchanged.

- **Tests**
	- Expanded test coverage to ensure the new key transformation behavior works correctly under various scenarios, including new test cases for specific transformation formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->