### PR TITLE
docs: add today_with_timezone and min to macros

### DIFF
--- a/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -4262,6 +4262,14 @@ interpolation:
       examples:
         - "'{{ today_utc() }}' -> '2021-09-01'"
         - "'{{ today_utc().strftime('%Y/%m/%d')}}' -> '2021/09/01'"
+    - title: today_with_timezone
+      description: Returns the current date in the specified timezone. The output is a date object.
+      arguments:
+        timezone: timezone expressed as IANA keys format.
+      return_type: Date
+      examples:
+        - "'{{ today_with_timezone('Australia/Sydney') }}' -> '2021-09-01'"
+        - "'{{ today_with_timezone('Europe/Lisbon') }}' -> '2021-08-01'"
     - title: timestamp
       description: Converts a number or a string representing a datetime (formatted as ISO8601) to a timestamp. If the input is a number, it is converted to an int. If no timezone is specified, the string is interpreted as UTC.
       arguments:
@@ -4273,6 +4281,13 @@ interpolation:
         - "'{{ timestamp('2022-02-28T00:00:00Z') }}' -> 1646006400"
         - "'{{ timestamp('2022-02-28 00:00:00Z') }}' -> 1646006400"
         - "'{{ timestamp('2022-02-28T00:00:00-08:00') }}' -> 1646035200"
+    - title: min
+      description: Returns the smallest object of a iterable, or or two or more arguments.
+      arguments:
+        args: iterable or a sequence of two or more arguments
+      examples:
+        - "'{{ min(2, 3) }}' -> 2"
+        - "'{{ min([2, 3]) }}' -> 2"
     - title: max
       description: Returns the largest object of a iterable, or or two or more arguments.
       arguments:


### PR DESCRIPTION
This commit adds the `today_with_timezone` and `min` macros to the list of macros defined in `declarative_component_schema.yaml`. This is important because this file is used to generate the YAML reference in Airbyte's documentation.

See the [fetchSchema](https://github.com/airbytehq/airbyte/blob/4d1de74eb8d8782656506aac1be6b1c88c518909/docusaurus/src/scripts/fetchSchema.js#L1-L14) script in main repository for details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a macro to obtain the current date adjusted for a specified timezone.
  - Added a utility macro to determine the smallest value from a list or a set of arguments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->