### PR TITLE
fix: Ensure page token 0 is being passed

### DIFF
--- a/airbyte_cdk/sources/declarative/retrievers/simple_retriever.py
+++ b/airbyte_cdk/sources/declarative/retrievers/simple_retriever.py
@@ -363,9 +363,7 @@ class SimpleRetriever(Retriever):
     ) -> Iterable[Record]:
         pagination_complete = False
         initial_token = self._paginator.get_initial_token()
-        next_page_token: Optional[Mapping[str, Any]] = (
-            {"next_page_token": initial_token} if initial_token else None
-        )
+        next_page_token: Optional[Mapping[str, Any]] = {"next_page_token": initial_token} if initial_token is not None else None
         while not pagination_complete:
             response = self._fetch_next_page(stream_state, stream_slice, next_page_token)
 

--- a/airbyte_cdk/sources/declarative/retrievers/simple_retriever.py
+++ b/airbyte_cdk/sources/declarative/retrievers/simple_retriever.py
@@ -363,7 +363,9 @@ class SimpleRetriever(Retriever):
     ) -> Iterable[Record]:
         pagination_complete = False
         initial_token = self._paginator.get_initial_token()
-        next_page_token: Optional[Mapping[str, Any]] = {"next_page_token": initial_token} if initial_token is not None else None
+        next_page_token: Optional[Mapping[str, Any]] = (
+            {"next_page_token": initial_token} if initial_token is not None else None
+        )
         while not pagination_complete:
             response = self._fetch_next_page(stream_state, stream_slice, next_page_token)
 

--- a/unit_tests/sources/declarative/retrievers/test_simple_retriever.py
+++ b/unit_tests/sources/declarative/retrievers/test_simple_retriever.py
@@ -841,7 +841,9 @@ def test_given_initial_token_is_zero_when_read_records_then_pass_initial_token()
         return_value=response,
     ) as fetch_next_page_mock:
         list(retriever.read_records(stream_slice=stream_slice, records_schema={}))
-        fetch_next_page_mock.assert_called_once_with(cursor.get_stream_state(), stream_slice, {"next_page_token": 0})
+        fetch_next_page_mock.assert_called_once_with(
+            cursor.get_stream_state(), stream_slice, {"next_page_token": 0}
+        )
 
 
 def _generate_slices(number_of_slices):

--- a/unit_tests/sources/declarative/retrievers/test_simple_retriever.py
+++ b/unit_tests/sources/declarative/retrievers/test_simple_retriever.py
@@ -810,6 +810,40 @@ def test_given_stream_data_is_not_record_when_read_records_then_update_slice_wit
         cursor.close_slice.assert_called_once_with(stream_slice, None)
 
 
+def test_given_initial_token_is_zero_when_read_records_then_pass_initial_token():
+    record_selector = MagicMock()
+    record_selector.select_records.return_value = []
+    cursor = MagicMock(spec=DeclarativeCursor)
+    paginator = MagicMock()
+    paginator.get_initial_token.return_value = 0
+    paginator.next_page_token.return_value = None
+
+    retriever = SimpleRetriever(
+        name="stream_name",
+        primary_key=primary_key,
+        requester=MagicMock(),
+        paginator=paginator,
+        record_selector=record_selector,
+        stream_slicer=cursor,
+        cursor=cursor,
+        parameters={},
+        config={},
+    )
+    stream_slice = StreamSlice(cursor_slice={}, partition={})
+
+    response = requests.Response()
+    response.status_code = 200
+    response._content = "{}".encode()
+
+    with patch.object(
+        SimpleRetriever,
+        "_fetch_next_page",
+        return_value=response,
+    ) as fetch_next_page_mock:
+        list(retriever.read_records(stream_slice=stream_slice, records_schema={}))
+        fetch_next_page_mock.assert_called_once_with(cursor.get_stream_state(), stream_slice, {"next_page_token": 0})
+
+
 def _generate_slices(number_of_slices):
     return [{"date": f"2022-01-0{day + 1}"} for day in range(number_of_slices)]
 


### PR DESCRIPTION
## What

Following a couple of tickets, it seems like the injection on the first page stopped working. Here are some of the tickets:
* https://github.com/airbytehq/airbyte/issues/51505
* https://github.com/airbytehq/airbyte/issues/53140

## How

This was caused by the first token being `0` which gets evaluated as `False` and therefore is not injected. We now validate `None` explicitly instead


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of pagination tokens to correctly support cases where the initial token is zero.
- **Tests**
	- Added a test to ensure pagination works properly when the initial token is zero.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->