### PR TITLE
fix(OffsetIncrement Pagination Strategy): Fix bug where streams that use record filtering do not paginate correctly

### DIFF
--- a/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -2054,6 +2054,7 @@ class ModelToComponentFactory:
         config: Config,
         *,
         url_base: str,
+        extractor_model: Optional[Union[CustomRecordExtractorModel, DpathExtractorModel]] = None,
         decoder: Optional[Decoder] = None,
         cursor_used_for_stop_condition: Optional[DeclarativeCursor] = None,
     ) -> Union[DefaultPaginator, PaginatorTestReadDecorator]:
@@ -2075,7 +2076,10 @@ class ModelToComponentFactory:
             else None
         )
         pagination_strategy = self._create_component_from_model(
-            model=model.pagination_strategy, config=config, decoder=decoder_to_use
+            model=model.pagination_strategy,
+            config=config,
+            decoder=decoder_to_use,
+            extractor_model=extractor_model,
         )
         if cursor_used_for_stop_condition:
             pagination_strategy = StopConditionPaginationStrategyDecorator(
@@ -2572,7 +2576,12 @@ class ModelToComponentFactory:
         )
 
     def create_offset_increment(
-        self, model: OffsetIncrementModel, config: Config, decoder: Decoder, **kwargs: Any
+        self,
+        model: OffsetIncrementModel,
+        config: Config,
+        decoder: Decoder,
+        extractor_model: Optional[Union[CustomRecordExtractorModel, DpathExtractorModel]] = None,
+        **kwargs: Any,
     ) -> OffsetIncrement:
         if isinstance(decoder, PaginationDecoderDecorator):
             inner_decoder = decoder.decoder
@@ -2587,10 +2596,24 @@ class ModelToComponentFactory:
                 self._UNSUPPORTED_DECODER_ERROR.format(decoder_type=type(inner_decoder))
             )
 
+        # Ideally we would instantiate the runtime extractor from highest most level (in this case the SimpleRetriever)
+        # so that it can be shared by OffSetIncrement and RecordSelector. However, due to how we instantiate the
+        # decoder with various decorators here, but not in create_record_selector, it is simpler to retain existing
+        # behavior by having two separate extractors with identical behavior since they use the same extractor model.
+        # When we have more time to investigate we can look into reusing the same component.
+        extractor = (
+            self._create_component_from_model(
+                model=extractor_model, config=config, decoder=decoder_to_use
+            )
+            if extractor_model
+            else None
+        )
+
         return OffsetIncrement(
             page_size=model.page_size,
             config=config,
             decoder=decoder_to_use,
+            extractor=extractor,
             inject_on_first_request=model.inject_on_first_request or False,
             parameters=model.parameters or {},
         )
@@ -2954,6 +2977,7 @@ class ModelToComponentFactory:
                 model=model.paginator,
                 config=config,
                 url_base=url_base,
+                extractor_model=model.record_selector.extractor,
                 decoder=decoder,
                 cursor_used_for_stop_condition=cursor_used_for_stop_condition,
             )

--- a/unit_tests/sources/declarative/requesters/paginators/test_offset_increment.py
+++ b/unit_tests/sources/declarative/requesters/paginators/test_offset_increment.py
@@ -8,19 +8,25 @@ from typing import Any, Optional
 import pytest
 import requests
 
+from airbyte_cdk.sources.declarative.extractors import DpathExtractor
 from airbyte_cdk.sources.declarative.requesters.paginators.strategies.offset_increment import (
     OffsetIncrement,
 )
 
 
 @pytest.mark.parametrize(
-    "page_size, parameters, last_page_size, last_record, last_page_token_value, expected_next_page_token, expected_offset",
+    "page_size, parameters, response_results, last_page_size, last_record, last_page_token_value, expected_next_page_token, expected_offset",
     [
-        pytest.param("2", {}, 2, {"id": 1}, 4, 6, 2, id="test_same_page_size"),
-        pytest.param(2, {}, 2, {"id": 1}, 4, 6, 2, id="test_same_page_size"),
+        pytest.param(
+            "2", {}, [{"id": 1}, {"id": 2}], 2, {"id": 2}, 4, 6, 2, id="test_same_page_size"
+        ),
+        pytest.param(
+            2, {}, [{"id": 1}, {"id": 2}], 2, {"id": 2}, 4, 6, 2, id="test_same_page_size"
+        ),
         pytest.param(
             "{{ parameters['page_size'] }}",
             {"page_size": 3},
+            [{"id": 1}, {"id": 2}],
             2,
             {"id": 1},
             3,
@@ -28,37 +34,54 @@ from airbyte_cdk.sources.declarative.requesters.paginators.strategies.offset_inc
             0,
             id="test_larger_page_size",
         ),
-        pytest.param(None, {}, 0, [], 3, None, 0, id="test_stop_if_no_records"),
+        pytest.param(None, {}, [], 0, [], 3, None, 0, id="test_stop_if_no_records"),
         pytest.param(
             "{{ response['page_metadata']['limit'] }}",
             {},
+            [{"id": 1}, {"id": 2}],
             2,
-            {"id": 1},
+            {"id": 2},
             3,
             None,
             0,
             id="test_page_size_from_response",
         ),
         pytest.param(
-            2, {}, 2, {"id": 1}, None, 2, 2, id="test_get_second_page_with_first_page_not_injected"
+            2,
+            {},
+            [{"id": 1}, {"id": 2}],
+            2,
+            {"id": 2},
+            None,
+            2,
+            2,
+            id="test_get_second_page_with_first_page_not_injected",
         ),
     ],
 )
 def test_offset_increment_paginator_strategy(
     page_size,
     parameters,
+    response_results,
     last_page_size,
     last_record,
     last_page_token_value,
     expected_next_page_token,
     expected_offset,
 ):
-    paginator_strategy = OffsetIncrement(page_size=page_size, parameters=parameters, config={})
+    extractor = DpathExtractor(field_path=["results"], parameters={}, config={})
+    paginator_strategy = OffsetIncrement(
+        page_size=page_size, extractor=extractor, parameters=parameters, config={}
+    )
 
     response = requests.Response()
 
     response.headers = {"A_HEADER": "HEADER_VALUE"}
-    response_body = {"next": "https://airbyte.io/next_url", "page_metadata": {"limit": 5}}
+    response_body = {
+        "results": response_results,
+        "next": "https://airbyte.io/next_url",
+        "page_metadata": {"limit": 5},
+    }
     response._content = json.dumps(response_body).encode("utf-8")
 
     next_page_token = paginator_strategy.next_page_token(
@@ -73,9 +96,28 @@ def test_offset_increment_paginator_strategy(
     assert expected_next_page_token == next_page_token
 
 
+def test_offset_increment_response_without_record_path():
+    extractor = DpathExtractor(field_path=["results"], parameters={}, config={})
+    paginator_strategy = OffsetIncrement(page_size=2, extractor=extractor, parameters={}, config={})
+
+    response = requests.Response()
+
+    response.headers = {"A_HEADER": "HEADER_VALUE"}
+    response_body = {"next": "https://airbyte.io/next_url", "page_metadata": {"limit": 5}}
+    response._content = json.dumps(response_body).encode("utf-8")
+
+    next_page_token = paginator_strategy.next_page_token(response, 2, None, 4)
+    assert next_page_token is None
+
+    # Validate that the PaginationStrategy is stateless and calling next_page_token() again returns the same result
+    next_page_token = paginator_strategy.next_page_token(response, 2, None, 4)
+    assert next_page_token is None
+
+
 def test_offset_increment_paginator_strategy_rises():
     paginator_strategy = OffsetIncrement(
         page_size="{{ parameters['page_size'] }}",
+        extractor=DpathExtractor(field_path=["results"], parameters={}, config={}),
         parameters={"page_size": "invalid value"},
         config={},
     )
@@ -94,8 +136,13 @@ def test_offset_increment_paginator_strategy_rises():
 def test_offset_increment_paginator_strategy_initial_token(
     inject_on_first_request: bool, expected_initial_token: Optional[Any]
 ):
+    extractor = DpathExtractor(field_path=[""], parameters={}, config={})
     paginator_strategy = OffsetIncrement(
-        page_size=20, parameters={}, config={}, inject_on_first_request=inject_on_first_request
+        page_size=20,
+        extractor=extractor,
+        parameters={},
+        config={},
+        inject_on_first_request=inject_on_first_request,
     )
 
     assert paginator_strategy.initial_token == expected_initial_token


### PR DESCRIPTION
## What

While migrating `source-hubspot` @tolik0 identified a bug in how we perform OffsetIncrement pagination. When we perform record filtering, we can potentially end up with fewer records than the amount returned in the API response. The paginator then falsely thinks the paging is complete because received records is smaller than the max page size.

## How

This PR fixes the said problem above by utilizing the existing `RecordExtractor` model defined by the developer and utilizes it in the `OffsetIncrement` pagination strategy. While determine if there are more pages to read in `next_page_token()` we have the extractor parse the `response` parameter (which will not perform filtering) to get the accurate count.

We opted for this solution because reusing an extractor is more accurate than recreating the dpath parsing behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Pagination strategies now support extracting records from responses using an extractor, improving handling of paginated data.

- **Bug Fixes**
  - Pagination logic now correctly handles cases where the expected record path is missing in the response.

- **Tests**
  - Enhanced test coverage for pagination, including realistic response scenarios and validation of extractor integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->