### PR TITLE
ci: add connector-test-summary job

### DIFF
--- a/.github/workflows/connector-tests.yml
+++ b/.github/workflows/connector-tests.yml
@@ -235,10 +235,10 @@ jobs:
 
   connectors_ci_summary:
     # This job simply asserts that nothing failed in the matrix.
-    # This allows us to make this step required while the preceeding
+    # This allows us to make this step required while the preceding
     # dynamic steps do not need to be individually reported if they
     # are skipped.
-    name: Connectors Tests Check (Matrix Summary)
+    name: Connector Tests Completion Check
     needs: [connectors_ci]
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/connector-tests.yml
+++ b/.github/workflows/connector-tests.yml
@@ -232,3 +232,16 @@ jobs:
         with:
           name: ${{matrix.connector}}-job-output
           path: airbyte/airbyte-ci/connectors/pipelines/pipeline_reports
+
+  connectors_ci_summary:
+    # This job simply asserts that nothing failed in the matrix.
+    # This allows us to make this step required while the preceeding
+    # dynamic steps do not need to be individually reported if they
+    # are skipped.
+    name: Connectors Tests Check (Matrix Summary)
+    needs: [connectors_ci]
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Success
+        run: |
+          echo "If this job runs, it means the matrix job succeeded! 🙌"


### PR DESCRIPTION
This allows us to set a CI "required" condition on the summary, meaning fail if any item in the matrix fails, but don't penalize for skipped items.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Added a summary job to the workflow to confirm successful completion of all connector tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->