### PR TITLE
fix(property chunking): fix delimiter count since commas are encoded as three characters

### DIFF
--- a/airbyte_cdk/sources/declarative/requesters/query_properties/property_chunking.py
+++ b/airbyte_cdk/sources/declarative/requesters/query_properties/property_chunking.py
@@ -55,7 +55,7 @@ class PropertyChunking:
             # todo: Add ability to specify parameter delimiter representation and take into account in property_field_size
             property_field_size = (
                 len(property_field)
-                + 2  # The +2 represents the extra characters for encoding the delimiter in between properties
+                + 3  # The +3 represents the extra characters for encoding the delimiter in between properties
                 if self.property_limit_type == PropertyLimitType.characters
                 else 1
             )

--- a/airbyte_cdk/sources/declarative/requesters/query_properties/property_chunking.py
+++ b/airbyte_cdk/sources/declarative/requesters/query_properties/property_chunking.py
@@ -55,7 +55,7 @@ class PropertyChunking:
             # todo: Add ability to specify parameter delimiter representation and take into account in property_field_size
             property_field_size = (
                 len(property_field)
-                + 1  # The +1 represents the extra character for the delimiter in between properties
+                + 2  # The +2 represents the extra characters for encoding the delimiter in between properties
                 if self.property_limit_type == PropertyLimitType.characters
                 else 1
             )

--- a/unit_tests/sources/declarative/requesters/query_properties/test_property_chunking.py
+++ b/unit_tests/sources/declarative/requesters/query_properties/test_property_chunking.py
@@ -43,7 +43,7 @@ CONFIG = {}
             ["kate", "laurie", "jaclyn"],
             None,
             PropertyLimitType.characters,
-            18,
+            20,
             [["kate", "laurie"], ["jaclyn"]],
             id="test_property_chunking_limit_characters",
         ),
@@ -51,7 +51,7 @@ CONFIG = {}
             ["laurie", "jaclyn", "kaitlin"],
             None,
             PropertyLimitType.characters,
-            14,  # laurie%2jaclyn%2 == 14
+            17,  # laurie%2Cjaclyn%2C == 18, so this will create separate chunks
             [["laurie"], ["jaclyn"], ["kaitlin"]],
             id="test_property_chunking_includes_extra_delimiter",
         ),

--- a/unit_tests/sources/declarative/requesters/query_properties/test_property_chunking.py
+++ b/unit_tests/sources/declarative/requesters/query_properties/test_property_chunking.py
@@ -43,7 +43,7 @@ CONFIG = {}
             ["kate", "laurie", "jaclyn"],
             None,
             PropertyLimitType.characters,
-            15,
+            18,
             [["kate", "laurie"], ["jaclyn"]],
             id="test_property_chunking_limit_characters",
         ),
@@ -51,7 +51,7 @@ CONFIG = {}
             ["laurie", "jaclyn", "kaitlin"],
             None,
             PropertyLimitType.characters,
-            12,
+            14,  # laurie%2jaclyn%2 == 14
             [["laurie"], ["jaclyn"], ["kaitlin"]],
             id="test_property_chunking_includes_extra_delimiter",
         ),


### PR DESCRIPTION
Commas are encoded as `%2C` so we need to increment the count by 3 instead of 1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved accuracy of property chunking when character limits are applied, ensuring correct handling of delimiters between properties.  
- **Tests**
  - Updated test cases to reflect changes in character limit calculations for property chunking, ensuring tests align with the revised logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->