### PR TITLE
feat: remove 1-or-more stream validation

### DIFF
--- a/airbyte_cdk/sources/declarative/manifest_declarative_source.py
+++ b/airbyte_cdk/sources/declarative/manifest_declarative_source.py
@@ -283,13 +283,6 @@ class ManifestDeclarativeSource(DeclarativeSource):
                 f"Failed to read manifest component json schema required for validation: {e}"
             )
 
-        streams = self._source_config.get("streams")
-        dynamic_streams = self._source_config.get("dynamic_streams")
-        if not (streams or dynamic_streams):
-            raise ValidationError(
-                f"A valid manifest should have at least one stream defined. Got {streams}"
-            )
-
         try:
             validate(self._source_config, declarative_component_schema)
         except ValidationError as e:

--- a/unit_tests/sources/declarative/test_manifest_declarative_source.py
+++ b/unit_tests/sources/declarative/test_manifest_declarative_source.py
@@ -1015,46 +1015,6 @@ class TestManifestDeclarativeSource:
         with pytest.raises(FileNotFoundError):
             source.spec(logger)
 
-    def test_manifest_without_at_least_one_stream(self):
-        manifest = {
-            "version": "0.29.3",
-            "definitions": {
-                "schema_loader": {
-                    "name": "{{ parameters.stream_name }}",
-                    "file_path": "./source_sendgrid/schemas/{{ parameters.name }}.yaml",
-                },
-                "retriever": {
-                    "paginator": {
-                        "type": "DefaultPaginator",
-                        "page_size": 10,
-                        "page_size_option": {
-                            "type": "RequestOption",
-                            "inject_into": "request_body",
-                            "field_path": ["variables", "page_size"],
-                        },
-                        "page_token_option": {"type": "RequestPath"},
-                        "pagination_strategy": {
-                            "type": "CursorPagination",
-                            "cursor_value": "{{ response._metadata.next }}",
-                        },
-                    },
-                    "requester": {
-                        "path": "/v3/marketing/lists",
-                        "authenticator": {
-                            "type": "BearerAuthenticator",
-                            "api_token": "{{ config.apikey }}",
-                        },
-                        "request_parameters": {"page_size": 10},
-                    },
-                    "record_selector": {"extractor": {"field_path": ["result"]}},
-                },
-            },
-            "streams": [],
-            "check": {"type": "CheckStream", "stream_names": ["lists"]},
-        }
-        with pytest.raises(ValidationError):
-            ManifestDeclarativeSource(source_config=manifest)
-
     @patch("airbyte_cdk.sources.declarative.declarative_source.DeclarativeSource.read")
     def test_given_debug_when_read_then_set_log_level(self, declarative_source_read):
         any_valid_manifest = {


### PR DESCRIPTION
Removes the requirement that at least one stream must exist for the manifest to be valid; this supports https://github.com/airbytehq/airbyte-internal-issues/issues/12079, and the ability to test OAuth from the builder without defining a stream

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Removed the explicit validation requiring at least one stream in the manifest configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->