### PR TITLE
tests: re-enable file-based connector (google-drive) in CDK downstream connector tests

### DIFF
--- a/.github/workflows/connector-tests.yml
+++ b/.github/workflows/connector-tests.yml
@@ -75,7 +75,7 @@ jobs:
           # Chargebee is being flaky:
           # - connector: source-chargebee
           #   cdk_extra: n/a
-          # This one is behind in CDK updates and can't be used as tests until they are updated:
+          # This one is behind in CDK updates and can't be used as tests until it is updated:
           # - connector: destination-pinecone
           #   cdk_extra: vector-db-based
           - connector: source-google-drive

--- a/.github/workflows/connector-tests.yml
+++ b/.github/workflows/connector-tests.yml
@@ -78,7 +78,7 @@ jobs:
           # This one is behind in CDK updates and can't be used as tests until they are updated:
           # - connector: destination-pinecone
           #   cdk_extra: vector-db-based
-          - connector: source-s3
+          - connector: source-google-drive
             cdk_extra: file-based
           - connector: destination-motherduck
             cdk_extra: sql

--- a/.github/workflows/connector-tests.yml
+++ b/.github/workflows/connector-tests.yml
@@ -75,11 +75,11 @@ jobs:
           # Chargebee is being flaky:
           # - connector: source-chargebee
           #   cdk_extra: n/a
-          # These two are behind in CDK updates and can't be used as tests until they are updated:
-          # - connector: source-s3
-          #   cdk_extra: file-based
+          # This one is behind in CDK updates and can't be used as tests until they are updated:
           # - connector: destination-pinecone
           #   cdk_extra: vector-db-based
+          - connector: source-s3
+            cdk_extra: file-based
           - connector: destination-motherduck
             cdk_extra: sql
           # ZenDesk currently failing (as of 2024-12-02)

--- a/airbyte_cdk/sources/file_based/discovery_policy/__init__.py
+++ b/airbyte_cdk/sources/file_based/discovery_policy/__init__.py
@@ -6,3 +6,5 @@ from airbyte_cdk.sources.file_based.discovery_policy.default_discovery_policy im
 )
 
 __all__ = ["AbstractDiscoveryPolicy", "DefaultDiscoveryPolicy"]
+
+# dummy change (revert me)

--- a/airbyte_cdk/sources/file_based/discovery_policy/__init__.py
+++ b/airbyte_cdk/sources/file_based/discovery_policy/__init__.py
@@ -6,5 +6,3 @@ from airbyte_cdk.sources.file_based.discovery_policy.default_discovery_policy im
 )
 
 __all__ = ["AbstractDiscoveryPolicy", "DefaultDiscoveryPolicy"]
-
-# dummy change (revert me)


### PR DESCRIPTION
This PR re-enables testing for the ~~source-s3~~ `source-google-drive` connector in automated workflows. Previously this was commented out because it was too-far behind the latest version of the CDK. Now that the connector is caught up, this addition in the CDK will help us detect unexpected breakages.

Test running here:

- https://github.com/airbytehq/airbyte-python-cdk/actions/runs/14541520650/job/40800309340

UPDATE: The above failed due to disk space. I don't know if that was an interim hiccup or something more serious. However it worked find for `source-google-drive` so I'm using that connector as suggested by @aldogonzalez8 in DM.

Success log here:

<img width="751" alt="image" src="https://github.com/user-attachments/assets/f35db4f6-9e2e-4311-941f-0c72c9b4bf25" />

I will only merge if the test completes successfully, and will revert my dummy commit if so.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated workflow comments for accuracy regarding connector status.
  - Added source-google-drive connector to the test matrix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->