### PR TITLE
Allow SessionTokenAuthenticator to be created as a subcomponent to a custom component

### DIFF
--- a/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -909,7 +909,7 @@ class ModelToComponentFactory:
         )
 
     def create_session_token_authenticator(
-        self, model: SessionTokenAuthenticatorModel, config: Config, name: str, **kwargs: Any
+        self, model: SessionTokenAuthenticatorModel, config: Config, *, name: str, **kwargs: Any
     ) -> Union[ApiKeyAuthenticator, BearerAuthenticator]:
         decoder = (
             self._create_component_from_model(model=model.decoder, config=config)


### PR DESCRIPTION
Change `name` argument in the function `create_session_token_authenticator` to a keyword-only argument so that it can be injected via `$parameters`. Other `name` arguments in the same module are already keyword-only.

Example manifest
```yaml
base_requester:
  type: HttpRequester
  url_base: ...
  authenticator:
    type: SigningAuthenticator
    hmac_key: "{{ config[\"hmac_key\"] }}"
    class_name: source_declarative_manifest.components.SigningAuthenticator
    token_authenticator:
      type: SessionTokenAuthenticator
      $parameters:
        name: some_name
      login_requester:
        type: HttpRequester
        url_base: ...
        authenticator:
          type: NoAuth
        http_method: GET
        request_parameters:
          app_key: "{{ config['client_id'] }}"
          app_secret: "{{ config['client_secret'] }}"
          grant_type: refresh_token
          refresh_token: "{{ config['refresh_token'] }}"
        request_headers: {}
      session_token_path:
        - access_token
      expiration_duration: PT1H
      request_authentication:
        type: ApiKey
        inject_into:
          type: RequestOption
          field_name: x-access-token
          inject_into: header
```

For context, `SigningAuthenticator` will leverage `SessionTokenAuthenticator` to refresh the access token in `__call__`, then signs the request according to the API provider's spec. Composition seems to be a hassle-free approach compared to inheritance.