### PR TITLE
fix: only check for file upload if stream is declarative

### DIFF
--- a/airbyte_cdk/sources/declarative/concurrent_declarative_source.py
+++ b/airbyte_cdk/sources/declarative/concurrent_declarative_source.py
@@ -211,8 +211,8 @@ class ConcurrentDeclarativeSource(ManifestDeclarativeSource, Generic[TState]):
             # so we need to treat them as synchronous
 
             supports_file_transfer = (
-                isinstance(declarative_stream, DeclarativeStream) and 
-                "file_uploader" in name_to_stream_mapping[declarative_stream.name]
+                isinstance(declarative_stream, DeclarativeStream)
+                and "file_uploader" in name_to_stream_mapping[declarative_stream.name]
             )
 
             if (

--- a/airbyte_cdk/sources/declarative/concurrent_declarative_source.py
+++ b/airbyte_cdk/sources/declarative/concurrent_declarative_source.py
@@ -211,6 +211,7 @@ class ConcurrentDeclarativeSource(ManifestDeclarativeSource, Generic[TState]):
             # so we need to treat them as synchronous
 
             supports_file_transfer = (
+                isinstance(declarative_stream, DeclarativeStream) and 
                 "file_uploader" in name_to_stream_mapping[declarative_stream.name]
             )
 


### PR DESCRIPTION
Given sources that are in transition from being declarative, we will have streams that are not in the manifest and therefore we will have a `KeyError: '<stream name>'` when grouping the streams

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved type checking to prevent errors when determining file transfer support for streams.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->