### PR TITLE
fix(file-api): fix schema field for file name

### DIFF
--- a/airbyte_cdk/sources/file_based/file_record_data.py
+++ b/airbyte_cdk/sources/file_based/file_record_data.py
@@ -14,7 +14,7 @@ class FileRecordData(BaseModel):
     """
 
     folder: str
-    filename: str
+    file_name: str
     bytes: int
     source_uri: str
     id: Optional[str] = None

--- a/unit_tests/sources/file_based/stream/test_default_file_based_stream.py
+++ b/unit_tests/sources/file_based/stream/test_default_file_based_stream.py
@@ -285,7 +285,7 @@ class DefaultFileBasedStreamFileTransferTest(unittest.TestCase):
     _NOW = datetime(2022, 10, 22, tzinfo=timezone.utc)
     _A_FILE_RECORD_DATA = FileRecordData(
         folder="/absolute/path/",
-        filen_ame="file.csv",
+        file_name="file.csv",
         bytes=10,
         source_uri="file:///absolute/path/file.csv",
     )

--- a/unit_tests/sources/file_based/stream/test_default_file_based_stream.py
+++ b/unit_tests/sources/file_based/stream/test_default_file_based_stream.py
@@ -285,7 +285,7 @@ class DefaultFileBasedStreamFileTransferTest(unittest.TestCase):
     _NOW = datetime(2022, 10, 22, tzinfo=timezone.utc)
     _A_FILE_RECORD_DATA = FileRecordData(
         folder="/absolute/path/",
-        filename="file.csv",
+        filen_ame="file.csv",
         bytes=10,
         source_uri="file:///absolute/path/file.csv",
     )
@@ -337,7 +337,7 @@ class DefaultFileBasedStreamFileTransferTest(unittest.TestCase):
             assert list(map(lambda message: message.record.data, messages)) == [
                 {
                     "bytes": 10,
-                    "filename": "file.csv",
+                    "file_name": "file.csv",
                     "folder": "/absolute/path/",
                     "source_uri": "file:///absolute/path/file.csv",
                 }


### PR DESCRIPTION
Fix the file name field to the one in the schema:

```
file_transfer_schema = {
    "type": "object",
    "properties": {
        "folder": {"type": "string"},
        "file_name": {"type": "string"},
        "source_uri": {"type": "string"},
        "bytes": {"type": "integer"},
        "id": {"type": ["null", "string"]},
        "created_at": {"type": ["null", "string"]},
        "updated_at": {"type": ["null", "string"]},
        "mime_type": {"type": ["null", "string"]},
    },
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated the file name attribute in record data from "filename" to "file_name" throughout the application.

- **Tests**
  - Adjusted tests to reflect the updated attribute name for file records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->