### PR TITLE
ci: add `/poe` slash command for CDK PRs and Issues

### DIFF
--- a/.github/workflows/poe-command.yml
+++ b/.github/workflows/poe-command.yml
@@ -8,7 +8,6 @@ on:
         required: false
       pr:
         description: "PR Number"
-        type: number
         required: false
 
 permissions:

--- a/.github/workflows/poe-command.yml
+++ b/.github/workflows/poe-command.yml
@@ -1,0 +1,29 @@
+name: On-Demand Poe Task
+
+on:
+  workflow_dispatch:
+    inputs:
+      comment-id:
+        description: "Optional comment-id of the slash command. Ignore if not applicable."
+        required: false
+      pr:
+        description: "PR Number"
+        type: number
+        required: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  run-poe-command:
+    env:
+      GCP_GSM_CREDENTIALS: ${{ secrets.GCP_GSM_CREDENTIALS }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run Poe Slash Command Processor
+        uses: aaronsteers/poe-command-processor@v1
+        with:
+          pr: ${{ github.event.inputs.pr }}
+          comment-id: ${{ github.event.inputs.comment-id }}
+          github-token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}

--- a/.github/workflows/slash_command_dispatch.yml
+++ b/.github/workflows/slash_command_dispatch.yml
@@ -7,7 +7,6 @@ on:
 jobs:
   slashCommandDispatch:
     # Only allow slash commands on pull request (not on issues)
-    if: ${{ github.event.issue.pull_request }}
     runs-on: ubuntu-24.04
     steps:
       - name: Slash Command Dispatch
@@ -19,13 +18,14 @@ jobs:
           repository: ${{ github.repository }}
           token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
           dispatch-type: workflow
-          issue-type: pull-request
+          issue-type: both
           commands: |
             autofix
             test
             poetry-lock
+            poe
           static-args: |
-            pr=${{ github.event.issue.number }}
+            pr=${{ github.event.issue.pull_request != null && github.event.issue.number || '' }}
             comment-id=${{ github.event.comment.id }}
 
           # Only run for users with 'write' permission on the main repository

--- a/.github/workflows/slash_command_dispatch.yml
+++ b/.github/workflows/slash_command_dispatch.yml
@@ -19,17 +19,24 @@ jobs:
           token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
           dispatch-type: workflow
           issue-type: both
+
+          # Only run for users with 'write' permission on the main repository
+          permission: write
+
           commands: |
             autofix
             test
             poetry-lock
             poe
+
+          # Notes regarding static-args:
+          # - Slash commands can be invoked from both issues and comments.
+          # - If the slash command is invoked from an issue, we intentionally pass 'null' as the PR number.
+          # - Comment ID will always be sent, and this is sufficient to post back status updates to the originating comment.
           static-args: |
             pr=${{ github.event.issue.pull_request != null && github.event.issue.number || '' }}
             comment-id=${{ github.event.comment.id }}
 
-          # Only run for users with 'write' permission on the main repository
-          permission: write
 
       - name: Edit comment with error message
         if: steps.dispatch.outputs.error-message

--- a/.github/workflows/slash_command_dispatch.yml
+++ b/.github/workflows/slash_command_dispatch.yml
@@ -6,7 +6,6 @@ on:
 
 jobs:
   slashCommandDispatch:
-    # Only allow slash commands on pull request (not on issues)
     runs-on: ubuntu-24.04
     steps:
       - name: Slash Command Dispatch


### PR DESCRIPTION
Same as this PR but for the CDK:

- https://github.com/airbytehq/airbyte/pull/58622

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an on-demand workflow that can be manually triggered to process Poe commands.

- **Improvements**
  - Enhanced slash command support to work on both pull requests and issues.
  - Added recognition for the new "poe" command in slash command handling.
  - Restricted slash command execution to users with write access for improved security.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->