### PR TITLE
fix: yield partitions for unique stream slices in StreamSlicerPartitionGenerator

### DIFF
--- a/airbyte_cdk/sources/declarative/stream_slicers/declarative_partition_generator.py
+++ b/airbyte_cdk/sources/declarative/stream_slicers/declarative_partition_generator.py
@@ -99,7 +99,7 @@ class StreamSlicerPartitionGenerator(PartitionGenerator):
             yield self._partition_factory.create(stream_slice)
 
     @staticmethod
-    def _make_hashable(obj: Any) -> Hashable:
+    def _make_hashable(obj: Any) -> Any:
         if isinstance(obj, dict):
             return frozenset((k, StreamSlicerPartitionGenerator._make_hashable(v)) for k, v in obj.items())
         if isinstance(obj, list):

--- a/airbyte_cdk/sources/declarative/stream_slicers/declarative_partition_generator.py
+++ b/airbyte_cdk/sources/declarative/stream_slicers/declarative_partition_generator.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2024 Airbyte, Inc., all rights reserved.
 
-from typing import Any, Iterable, Mapping, Optional
+from typing import Any, Iterable, Mapping, Optional, Hashable
 
 from airbyte_cdk.sources.declarative.retrievers import Retriever
 from airbyte_cdk.sources.message import MessageRepository
@@ -89,5 +89,19 @@ class StreamSlicerPartitionGenerator(PartitionGenerator):
         self._stream_slicer = stream_slicer
 
     def generate(self) -> Iterable[Partition]:
+        # Yield partitions for unique stream slices, avoiding duplicates
+        seen_slices: set[Hashable] = set()
         for stream_slice in self._stream_slicer.stream_slices():
+            slice_key = self._make_hashable(stream_slice)
+            if slice_key in seen_slices:
+                continue
+            seen_slices.add(slice_key)
             yield self._partition_factory.create(stream_slice)
+
+    @staticmethod
+    def _make_hashable(obj: Any) -> Hashable:
+        if isinstance(obj, dict):
+            return frozenset((k, StreamSlicerPartitionGenerator._make_hashable(v)) for k, v in obj.items())
+        if isinstance(obj, list):
+            return tuple(StreamSlicerPartitionGenerator._make_hashable(i) for i in obj)
+        return obj


### PR DESCRIPTION
Some parent streams may return duplicate record IDs in the response. As a result, we can end up with several identical partitions. After one partition is processed, the next one causes an error because it is already closed.  

For example, in the `source-stripe` connector, the `payout_balance_transactions` stream depends on `balance_transactions`, which uses the `events` endpoint to fetch data incrementally. This can lead to multiple events for the same parent with the same state but different values in other fields.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved partition generation to eliminate duplicate partitions when identical stream slices are encountered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->