### PR TITLE
feat: do not reset semaphore when duplicate partitions

### DIFF
--- a/airbyte_cdk/sources/declarative/incremental/concurrent_partition_cursor.py
+++ b/airbyte_cdk/sources/declarative/incremental/concurrent_partition_cursor.py
@@ -281,12 +281,10 @@ class ConcurrentPerPartitionCursor(Cursor):
                 self._number_of_partitions += 1
                 self._cursor_per_partition[partition_key] = cursor
 
-        if (
-            not self._IS_PARTITION_DUPLICATION_LOGGED
-            and partition_key in self._semaphore_per_partition
-        ):
-            logger.warning(f"Partition duplication detected for stream {self._stream_name}")
-            self._IS_PARTITION_DUPLICATION_LOGGED = True
+        if partition_key in self._semaphore_per_partition:
+            if not self._IS_PARTITION_DUPLICATION_LOGGED:
+                logger.warning(f"Partition duplication detected for stream {self._stream_name}")
+                self._IS_PARTITION_DUPLICATION_LOGGED = True
         else:
             self._semaphore_per_partition[partition_key] = threading.Semaphore(0)
 

--- a/airbyte_cdk/sources/declarative/incremental/concurrent_partition_cursor.py
+++ b/airbyte_cdk/sources/declarative/incremental/concurrent_partition_cursor.py
@@ -65,6 +65,7 @@ class ConcurrentPerPartitionCursor(Cursor):
     _NO_CURSOR_STATE: Mapping[str, Any] = {}
     _GLOBAL_STATE_KEY = "state"
     _PERPARTITION_STATE_KEY = "states"
+    _IS_PARTITION_DUPLICATION_LOGGED = False
     _KEY = 0
     _VALUE = 1
 
@@ -279,7 +280,12 @@ class ConcurrentPerPartitionCursor(Cursor):
             with self._lock:
                 self._number_of_partitions += 1
                 self._cursor_per_partition[partition_key] = cursor
-        self._semaphore_per_partition[partition_key] = threading.Semaphore(0)
+
+        if not self._IS_PARTITION_DUPLICATION_LOGGED and partition_key in self._semaphore_per_partition:
+            logger.warning(f"Partition duplication detected for stream {self._stream_name}")
+            self._IS_PARTITION_DUPLICATION_LOGGED = True
+        else:
+            self._semaphore_per_partition[partition_key] = threading.Semaphore(0)
 
         with self._lock:
             if (

--- a/airbyte_cdk/sources/declarative/incremental/concurrent_partition_cursor.py
+++ b/airbyte_cdk/sources/declarative/incremental/concurrent_partition_cursor.py
@@ -281,7 +281,10 @@ class ConcurrentPerPartitionCursor(Cursor):
                 self._number_of_partitions += 1
                 self._cursor_per_partition[partition_key] = cursor
 
-        if not self._IS_PARTITION_DUPLICATION_LOGGED and partition_key in self._semaphore_per_partition:
+        if (
+            not self._IS_PARTITION_DUPLICATION_LOGGED
+            and partition_key in self._semaphore_per_partition
+        ):
             logger.warning(f"Partition duplication detected for stream {self._stream_name}")
             self._IS_PARTITION_DUPLICATION_LOGGED = True
         else:


### PR DESCRIPTION
Some parent streams may return duplicate record IDs in the response. As a result, we can end up with several identical partitions. After one partition is processed, the next one causes an error because it is already closed.  

For example, in the `source-stripe` connector, the `payout_balance_transactions` stream depends on `balance_transactions`, which uses the `events` endpoint to fetch data incrementally. This can lead to multiple events for the same parent with the same state but different values in other fields.

This PR skip semaphore reset if duplicate partitions detected. 
