### PR TITLE
chore: revert generate unique partitions added in #508

### DIFF
--- a/airbyte_cdk/sources/declarative/stream_slicers/declarative_partition_generator.py
+++ b/airbyte_cdk/sources/declarative/stream_slicers/declarative_partition_generator.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2024 Airbyte, Inc., all rights reserved.
 
-from typing import Any, Hashable, Iterable, Mapping, Optional
+from typing import Any, Iterable, Mapping, Optional
 
 from airbyte_cdk.sources.declarative.retrievers import Retriever
 from airbyte_cdk.sources.message import MessageRepository
@@ -89,21 +89,5 @@ class StreamSlicerPartitionGenerator(PartitionGenerator):
         self._stream_slicer = stream_slicer
 
     def generate(self) -> Iterable[Partition]:
-        # Yield partitions for unique stream slices, avoiding duplicates
-        seen_slices: set[Hashable] = set()
         for stream_slice in self._stream_slicer.stream_slices():
-            slice_key = self._make_hashable(stream_slice)
-            if slice_key in seen_slices:
-                continue
-            seen_slices.add(slice_key)
             yield self._partition_factory.create(stream_slice)
-
-    @staticmethod
-    def _make_hashable(obj: Any) -> Any:
-        if isinstance(obj, dict):
-            return frozenset(
-                (k, StreamSlicerPartitionGenerator._make_hashable(v)) for k, v in obj.items()
-            )
-        if isinstance(obj, list):
-            return tuple(StreamSlicerPartitionGenerator._make_hashable(i) for i in obj)
-        return obj


### PR DESCRIPTION
This revert changes added in https://github.com/airbytehq/airbyte-python-cdk/pull/508

PR #508 attempted to address an issue where some parent streams could return duplicate record IDs, resulting in multiple identical partitions. Once one partition was processed and closed, subsequent attempts to process a duplicate partition would cause errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated partition generation to include all stream slices, removing previous duplicate filtering logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->