### PR TITLE
fix(low-code cdk): pass state_migrations when creating concurrent cursor in _group_streams

### DIFF
--- a/airbyte_cdk/sources/declarative/concurrent_declarative_source.py
+++ b/airbyte_cdk/sources/declarative/concurrent_declarative_source.py
@@ -305,6 +305,7 @@ class ConcurrentDeclarativeSource(ManifestDeclarativeSource, Generic[TState]):
                                 stream_name=declarative_stream.name,
                                 stream_namespace=declarative_stream.namespace,
                                 config=config or {},
+                                stream_state_migrations=declarative_stream.state_migrations,
                             )
                         partition_generator = StreamSlicerPartitionGenerator(
                             partition_factory=DeclarativePartitionFactory(


### PR DESCRIPTION
Added missing state migration to `create_concurrent_cursor_from_datetime_based_cursor` when creating cursor in `ConcurrentDeclarativeSource`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of stream state migrations during concurrent incremental syncs using datetime-based cursors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->