### PR TITLE
fix(low-code): set transform_before_filtering from manifest if client_side_incremental_sync=true

### DIFF
--- a/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -2827,13 +2827,9 @@ class ModelToComponentFactory:
             else None
         )
 
-        if model.transform_before_filtering is None:
-            # default to False if not set
-            model.transform_before_filtering = False
-
-        assert model.transform_before_filtering is not None  # for mypy
-
-        transform_before_filtering = model.transform_before_filtering
+        transform_before_filtering = (
+            False if model.transform_before_filtering is None else model.transform_before_filtering
+        )
         if client_side_incremental_sync:
             record_filter = ClientSideIncrementalRecordFilterDecorator(
                 config=config,
@@ -2843,7 +2839,11 @@ class ModelToComponentFactory:
                 else None,
                 **client_side_incremental_sync,
             )
-            transform_before_filtering = True
+            transform_before_filtering = (
+                True
+                if model.transform_before_filtering is None
+                else model.transform_before_filtering
+            )
 
         if model.schema_normalization is None:
             # default to no schema normalization if not set

--- a/unit_tests/sources/declarative/test_concurrent_declarative_source.py
+++ b/unit_tests/sources/declarative/test_concurrent_declarative_source.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2024 Airbyte, Inc., all rights reserved.
 #
 
-import pytest
 import copy
 import json
 import math
@@ -12,6 +11,7 @@ from unittest.mock import patch
 
 import freezegun
 import isodate
+import pytest
 from typing_extensions import deprecated
 
 from airbyte_cdk.models import (

--- a/unit_tests/sources/declarative/test_concurrent_declarative_source.py
+++ b/unit_tests/sources/declarative/test_concurrent_declarative_source.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2024 Airbyte, Inc., all rights reserved.
 #
 
+import pytest
 import copy
 import json
 import math
@@ -1874,6 +1875,69 @@ def test_stream_using_is_client_side_incremental_has_cursor_state():
     client_side_incremental_cursor_state = record_filter._cursor._cursor
 
     assert client_side_incremental_cursor_state == expected_cursor_value
+
+
+@pytest.mark.parametrize(
+    "expected_transform_before_filtering",
+    [
+        pytest.param(
+            True,
+            id="transform before filtering",
+        ),
+        pytest.param(
+            False,
+            id="transform after filtering",
+        ),
+        pytest.param(
+            None,
+            id="default transform before filtering",
+        ),
+    ],
+)
+def test_stream_using_is_client_side_incremental_has_transform_before_filtering_according_to_manifest(
+    expected_transform_before_filtering,
+):
+    expected_cursor_value = "2024-07-01"
+    state = [
+        AirbyteStateMessage(
+            type=AirbyteStateType.STREAM,
+            stream=AirbyteStreamState(
+                stream_descriptor=StreamDescriptor(name="locations", namespace=None),
+                stream_state=AirbyteStateBlob(updated_at=expected_cursor_value),
+            ),
+        )
+    ]
+
+    manifest_with_stream_state_interpolation = copy.deepcopy(_MANIFEST)
+
+    # Enable semi-incremental on the locations stream
+    manifest_with_stream_state_interpolation["definitions"]["locations_stream"]["incremental_sync"][
+        "is_client_side_incremental"
+    ] = True
+
+    if expected_transform_before_filtering is not None:
+        manifest_with_stream_state_interpolation["definitions"]["locations_stream"]["retriever"][
+            "record_selector"
+        ]["transform_before_filtering"] = expected_transform_before_filtering
+
+    source = ConcurrentDeclarativeSource(
+        source_config=manifest_with_stream_state_interpolation,
+        config=_CONFIG,
+        catalog=_CATALOG,
+        state=state,
+    )
+    concurrent_streams, synchronous_streams = source._group_streams(config=_CONFIG)
+
+    locations_stream = concurrent_streams[2]
+    assert isinstance(locations_stream, DefaultStream)
+
+    simple_retriever = locations_stream._stream_partition_generator._partition_factory._retriever
+    record_selector = simple_retriever.record_selector
+
+    if expected_transform_before_filtering is not None:
+        assert record_selector.transform_before_filtering == expected_transform_before_filtering
+    else:
+        assert record_selector.transform_before_filtering is True
 
 
 def create_wrapped_stream(stream: DeclarativeStream) -> Stream:


### PR DESCRIPTION
For client side incremental sync use `transform_before_filtering` from manifest, default True if not provided 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of the `transform_before_filtering` setting to ensure consistent behavior based on configuration without altering internal state.

- **Tests**
  - Added tests to verify the correct behavior of the `transform_before_filtering` option with client-side incremental syncs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->