### PR TITLE
feat(cli): add support for building images for java connectors

### DIFF
--- a/airbyte_cdk/utils/docker.py
+++ b/airbyte_cdk/utils/docker.py
@@ -346,8 +346,7 @@ def verify_connector_image(
                             found_spec_output = True
 
                     except json.JSONDecodeError as e:
-                        logger.error(f"Invalid JSON output from spec command: {e}: {line}")
-                        return False
+                        logger.warning(f"Invalid JSON output from spec command: {e}: {line}")
 
             if not found_spec_output:
                 logger.error("No valid JSON output found for spec command.")

--- a/airbyte_cdk/utils/docker.py
+++ b/airbyte_cdk/utils/docker.py
@@ -63,9 +63,20 @@ def _build_image(
 
     Raises: ConnectorImageBuildError if the build fails.
     """
+    connector_name = metadata.data.dockerRepository.split("/")[-1]
     if metadata.data.language == ConnectorLanguage.JAVA:
         # For Java connectors, the context directory is the repo root.
         context_dir = context_dir.parent.parent.parent
+        # For Java connectors, we need to build the connector tar file first.
+        response: subprocess.CompletedProcess[str] = subprocess.run(
+            [
+                "./gradlew",
+                f":airbyte-integrations:connectors:{connector_name}:distTar",
+            ],
+            cwd=context_dir,
+            text=True,
+            check=True,
+        )
 
     docker_args: list[str] = [
         "docker",

--- a/airbyte_cdk/utils/docker_image_templates.py
+++ b/airbyte_cdk/utils/docker_image_templates.py
@@ -107,7 +107,6 @@ ENTRYPOINT ["python", "./main.py"]
 
 JAVA_CONNECTOR_DOCKERFILE_TEMPLATE = """
 # Java connector Dockerfile for Airbyte
-# This Dockerfile replicates the dagger-based build process for Java connectors
 
 # Build arguments
 ARG BASE_IMAGE

--- a/airbyte_cdk/utils/docker_image_templates.py
+++ b/airbyte_cdk/utils/docker_image_templates.py
@@ -14,8 +14,9 @@ These templates are used to generate connector images.
 DOCKERIGNORE_TEMPLATE: str = "\n".join(
     [
         "# This file is auto-generated. Do not edit.",
-        # "*,"
+        "*," # Ignore everything not explicitly allowed below
         "build/",
+        "!build/distributions/*.tar",
         ".venv/",
         "secrets/",
         "!setup.py",
@@ -162,7 +163,7 @@ ENV AIRBYTE_ENTRYPOINT="/airbyte/base.sh"
 ENV APPLICATION="${CONNECTOR_KEBAB_NAME}"
 
 # Add the connector TAR file and extract it
-COPY airbyte-integrations/connectors/${CONNECTOR_KEBAB_NAME}/build/distributions/${CONNECTOR_KEBAB_NAME}.tar /tmp/${CONNECTOR_KEBAB_NAME}.tar
+COPY ./build/distributions/${CONNECTOR_KEBAB_NAME}.tar /tmp/${CONNECTOR_KEBAB_NAME}.tar
 RUN tar xf /tmp/${CONNECTOR_KEBAB_NAME}.tar --strip-components=1 -C /airbyte && \
     rm -rf /tmp/${CONNECTOR_KEBAB_NAME}.tar && \
     chown -R airbyte:airbyte /airbyte

--- a/airbyte_cdk/utils/docker_image_templates.py
+++ b/airbyte_cdk/utils/docker_image_templates.py
@@ -37,7 +37,7 @@ DOCKERIGNORE_TEMPLATE: str = "\n".join(
 # PYTHON CONNECTOR IMAGE ##
 ###########################
 
-PYTHON_CONNECTOR_DOCKERFILE_TEMPLATE = """
+PYTHON_CONNECTOR_DOCKERFILE_TEMPLATE = r"""
 # syntax=docker/dockerfile:1
 # check=skip=all
 ARG BASE_IMAGE

--- a/airbyte_cdk/utils/docker_image_templates.py
+++ b/airbyte_cdk/utils/docker_image_templates.py
@@ -121,8 +121,6 @@ ARG CONNECTOR_KEBAB_NAME
 RUN chmod +x /airbyte/base.sh /airbyte/javabase.sh && \
     chown airbyte:airbyte /airbyte/base.sh /airbyte/javabase.sh /airbyte/dd-java-agent.jar
 
-# base.sh will set the classpath for the connector and invoke javabase.sh
-# using one of the above commands.
 ENV AIRBYTE_ENTRYPOINT="/airbyte/base.sh"
 ENV APPLICATION="${CONNECTOR_KEBAB_NAME}"
 
@@ -137,8 +135,4 @@ USER airbyte
 
 # Set entrypoint
 ENTRYPOINT ["/airbyte/base.sh"]
-
-# Add labels
-LABEL io.airbyte.version="0.1.0"
-LABEL io.airbyte.name="airbyte/${CONNECTOR_KEBAB_NAME}"
 """

--- a/airbyte_cdk/utils/docker_image_templates.py
+++ b/airbyte_cdk/utils/docker_image_templates.py
@@ -14,7 +14,7 @@ These templates are used to generate connector images.
 DOCKERIGNORE_TEMPLATE: str = "\n".join(
     [
         "# This file is auto-generated. Do not edit.",
-        "*," # Ignore everything not explicitly allowed below
+        "*,"  # Ignore everything not explicitly allowed below
         "build/",
         "!build/distributions/*.tar",
         ".venv/",

--- a/airbyte_cdk/utils/docker_image_templates.py
+++ b/airbyte_cdk/utils/docker_image_templates.py
@@ -149,11 +149,15 @@ RUN chmod +x /airbyte/base.sh /airbyte/javabase.sh && \
     chown airbyte:airbyte /airbyte/base.sh /airbyte/javabase.sh /airbyte/dd-java-agent.jar
 
 # Set environment variables
+# These variables tell base.sh what to do:
 ENV AIRBYTE_SPEC_CMD="/airbyte/javabase.sh --spec"
 ENV AIRBYTE_CHECK_CMD="/airbyte/javabase.sh --check"
 ENV AIRBYTE_DISCOVER_CMD="/airbyte/javabase.sh --discover"
 ENV AIRBYTE_READ_CMD="/airbyte/javabase.sh --read"
 ENV AIRBYTE_WRITE_CMD="/airbyte/javabase.sh --write"
+
+# base.sh will set the classpath for the connector and invoke javabase.sh
+# using one of the above commands.
 ENV AIRBYTE_ENTRYPOINT="/airbyte/base.sh"
 ENV APPLICATION="${CONNECTOR_KEBAB_NAME}"
 

--- a/airbyte_cdk/utils/docker_image_templates.py
+++ b/airbyte_cdk/utils/docker_image_templates.py
@@ -99,3 +99,77 @@ COPY . ./
 ENV AIRBYTE_ENTRYPOINT="python ./main.py"
 ENTRYPOINT ["python", "./main.py"]
 """
+
+#########################
+# JAVA CONNECTOR IMAGE ##
+#########################
+
+JAVA_CONNECTOR_DOCKERFILE_TEMPLATE = """
+# Java connector Dockerfile for Airbyte
+# This Dockerfile replicates the dagger-based build process for Java connectors
+
+# Build arguments
+ARG JDK_VERSION=21-al2023
+
+# Base image - using Amazon Corretto (Amazon's distribution of OpenJDK)
+FROM amazoncorretto:${JDK_VERSION}
+ARG CONNECTOR_KEBAB_NAME
+
+# Install required packages and set up the non-root user
+RUN set -o xtrace && \
+    yum install -y shadow-utils tar openssl findutils && \
+    yum update -y --security && \
+    yum clean all && \
+    rm -rf /var/cache/yum && \
+    echo "Creating airbyte user and group..." && \
+    groupadd --gid 1000 airbyte && \
+    useradd --uid 1000 --gid airbyte --shell /bin/bash --create-home airbyte && \
+    echo "Creating directories..." && \
+    mkdir /secrets && \
+    mkdir /config && \
+    mkdir --mode 755 /airbyte && \
+    mkdir --mode 755 /custom_cache && \
+    echo "Setting permissions..." && \
+    chown -R airbyte:airbyte /airbyte && \
+    chown -R airbyte:airbyte /custom_cache && \
+    chown -R airbyte:airbyte /secrets && \
+    chown -R airbyte:airbyte /config && \
+    chown -R airbyte:airbyte /usr/share/pki/ca-trust-source && \
+    chown -R airbyte:airbyte /etc/pki/ca-trust && \
+    chown -R airbyte:airbyte /tmp
+
+# Download required scripts
+WORKDIR /airbyte
+ADD https://raw.githubusercontent.com/airbytehq/airbyte/6d8a3a2bc4f4ca79f10164447a90fdce5c9ad6f9/airbyte-integrations/bases/base/base.sh /airbyte/base.sh
+ADD https://raw.githubusercontent.com/airbytehq/airbyte/6d8a3a2bc4f4ca79f10164447a90fdce5c9ad6f9/airbyte-integrations/bases/base-java/javabase.sh /airbyte/javabase.sh
+ADD https://dtdg.co/latest-java-tracer /airbyte/dd-java-agent.jar
+
+# Set permissions for downloaded files
+RUN chmod +x /airbyte/base.sh /airbyte/javabase.sh && \
+    chown airbyte:airbyte /airbyte/base.sh /airbyte/javabase.sh /airbyte/dd-java-agent.jar
+
+# Set environment variables
+ENV AIRBYTE_SPEC_CMD="/airbyte/javabase.sh --spec"
+ENV AIRBYTE_CHECK_CMD="/airbyte/javabase.sh --check"
+ENV AIRBYTE_DISCOVER_CMD="/airbyte/javabase.sh --discover"
+ENV AIRBYTE_READ_CMD="/airbyte/javabase.sh --read"
+ENV AIRBYTE_WRITE_CMD="/airbyte/javabase.sh --write"
+ENV AIRBYTE_ENTRYPOINT="/airbyte/base.sh"
+ENV APPLICATION="${CONNECTOR_KEBAB_NAME}"
+
+# Add the connector TAR file and extract it
+COPY airbyte-integrations/connectors/${CONNECTOR_KEBAB_NAME}/build/distributions/${CONNECTOR_KEBAB_NAME}.tar /tmp/${CONNECTOR_KEBAB_NAME}.tar
+RUN tar xf /tmp/${CONNECTOR_KEBAB_NAME}.tar --strip-components=1 -C /airbyte && \
+    rm -rf /tmp/${CONNECTOR_KEBAB_NAME}.tar && \
+    chown -R airbyte:airbyte /airbyte
+
+# Set the non-root user
+USER airbyte
+
+# Set entrypoint
+ENTRYPOINT ["/airbyte/base.sh"]
+
+# Add labels
+LABEL io.airbyte.version="0.1.0"
+LABEL io.airbyte.name="airbyte/${CONNECTOR_KEBAB_NAME}"
+"""

--- a/airbyte_cdk/utils/docker_image_templates.py
+++ b/airbyte_cdk/utils/docker_image_templates.py
@@ -110,8 +110,7 @@ JAVA_CONNECTOR_DOCKERFILE_TEMPLATE = """
 # This Dockerfile replicates the dagger-based build process for Java connectors
 
 # Build arguments
-ARG JDK_VERSION=21-al2023
-ARG BASE_IMAGE=amazoncorretto:${JDK_VERSION}
+ARG BASE_IMAGE
 
 # Base image - using Amazon Corretto (Amazon's distribution of OpenJDK)
 FROM ${BASE_IMAGE}


### PR DESCRIPTION
This add the ability to build Java connector images.

```bash
# Test building from the dev version of the CDK:
poetry run airbyte-cdk image build --connector-directory=../airbyte/airbyte-integrations/connectors/source-mysql

# Future syntax with the prefix (after release):
cd /airbyte/airbyte-integrations/connectors/source-mysql
airbyte-cdk image build

# Prove the image works:
docker run --rm airbyte/source-mysql:dev spec
```

This _does not_ fully harden the image nor does it test every scenario needed to allow this to (yet) replace the `airbyte-ci` build and publish process. In future iterations, we would hopefully gain increasing confidence over time until we're ready to turn off the current Dagger-based processes.

Combined with this PR, we'd be able to run FAST tests on _any_ connector via docker, regardless of language:

- https://github.com/airbytehq/airbyte-python-cdk/pull/524


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Added support for building and running Java connectors within the Docker build process.
- **Improvements**
	- Enhanced verification of connector images by improving JSON output parsing for increased robustness.
	- Updated Dockerfile and ignore rules to optimize Java connector packaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->