### PR TITLE
tests: handle case of `acceptance-test-config.yml` with no valid test cases

### DIFF
--- a/airbyte_cdk/test/entrypoint_wrapper.py
+++ b/airbyte_cdk/test/entrypoint_wrapper.py
@@ -83,6 +83,10 @@ class EntrypointOutput:
         return self._get_message_by_types([Type.STATE])
 
     @property
+    def spec_messages(self) -> List[AirbyteMessage]:
+        return self._get_message_by_types([Type.SPEC])
+
+    @property
     def connection_status_messages(self) -> List[AirbyteMessage]:
         return self._get_message_by_types([Type.CONNECTION_STATUS])
 

--- a/airbyte_cdk/test/standard_tests/_job_runner.py
+++ b/airbyte_cdk/test/standard_tests/_job_runner.py
@@ -121,7 +121,7 @@ def run_test_job(
     result: entrypoint_wrapper.EntrypointOutput = entrypoint_wrapper._run_command(  # noqa: SLF001  # Non-public API
         source=connector_obj,  # type: ignore [arg-type]
         args=args,
-        expecting_exception=False if not test_scenario else expect_exception,
+        expecting_exception=expect_exception,
     )
     if result.errors and not expect_exception:
         raise AssertionError(

--- a/airbyte_cdk/test/standard_tests/connector_base.py
+++ b/airbyte_cdk/test/standard_tests/connector_base.py
@@ -163,11 +163,13 @@ class ConnectorTestSuiteBase(abc.ABC):
             ):
                 continue
 
-            test_scenarios.extend([
-                ConnectorTestScenario.model_validate(test)
-                for test in all_tests_config["acceptance_tests"][category]["tests"]
-                if "config_path" in test and "iam_role" not in test["config_path"]
-            ])
+            test_scenarios.extend(
+                [
+                    ConnectorTestScenario.model_validate(test)
+                    for test in all_tests_config["acceptance_tests"][category]["tests"]
+                    if "config_path" in test and "iam_role" not in test["config_path"]
+                ]
+            )
 
         connector_root = cls.get_connector_root_dir().absolute()
         for test in test_scenarios:

--- a/airbyte_cdk/test/standard_tests/connector_base.py
+++ b/airbyte_cdk/test/standard_tests/connector_base.py
@@ -89,7 +89,7 @@ class ConnectorTestSuiteBase(abc.ABC):
     @classmethod
     def create_connector(
         cls,
-        scenario: ConnectorTestScenario,
+        scenario: ConnectorTestScenario | None,
     ) -> IConnector:
         """Instantiate the connector class."""
         connector = cls.connector  # type: ignore
@@ -147,7 +147,7 @@ class ConnectorTestSuiteBase(abc.ABC):
         This has to be a separate function because pytest does not allow
         parametrization of fixtures with arguments from the test class itself.
         """
-        category = "connection"
+        categories = ["connection", "spec"]
         all_tests_config = yaml.safe_load(cls.acceptance_test_config_path.read_text())
         if "acceptance_tests" not in all_tests_config:
             raise ValueError(
@@ -155,22 +155,25 @@ class ConnectorTestSuiteBase(abc.ABC):
                 f" Found only: {str(all_tests_config)}."
             )
 
-        if (
-            category not in all_tests_config["acceptance_tests"]
-            or "tests" not in all_tests_config["acceptance_tests"][category]
-        ):
-            return []
+        test_scenarios: list[ConnectorTestScenario] = []
+        for category in categories:
+            if (
+                category not in all_tests_config["acceptance_tests"]
+                or "tests" not in all_tests_config["acceptance_tests"][category]
+            ):
+                continue
 
-        tests_scenarios = [
-            ConnectorTestScenario.model_validate(test)
-            for test in all_tests_config["acceptance_tests"][category]["tests"]
-            if "iam_role" not in test["config_path"]
-        ]
+            test_scenarios.extend([
+                ConnectorTestScenario.model_validate(test)
+                for test in all_tests_config["acceptance_tests"][category]["tests"]
+                if "config_path" in test and "iam_role" not in test["config_path"]
+            ])
+
         connector_root = cls.get_connector_root_dir().absolute()
-        for test in tests_scenarios:
+        for test in test_scenarios:
             if test.config_path:
                 test.config_path = connector_root / test.config_path
             if test.configured_catalog_path:
                 test.configured_catalog_path = connector_root / test.configured_catalog_path
 
-        return tests_scenarios
+        return test_scenarios

--- a/airbyte_cdk/test/standard_tests/connector_base.py
+++ b/airbyte_cdk/test/standard_tests/connector_base.py
@@ -154,10 +154,12 @@ class ConnectorTestSuiteBase(abc.ABC):
                 f"Acceptance tests config not found in {cls.acceptance_test_config_path}."
                 f" Found only: {str(all_tests_config)}."
             )
-        if category not in all_tests_config["acceptance_tests"]:
+
+        if (
+            category not in all_tests_config["acceptance_tests"]
+            or "tests" not in all_tests_config["acceptance_tests"][category]
+        ):
             return []
-        if "tests" not in all_tests_config["acceptance_tests"][category]:
-            raise ValueError(f"No tests found for category {category}")
 
         tests_scenarios = [
             ConnectorTestScenario.model_validate(test)

--- a/airbyte_cdk/test/standard_tests/declarative_sources.py
+++ b/airbyte_cdk/test/standard_tests/declarative_sources.py
@@ -64,7 +64,7 @@ class DeclarativeSourceTestSuite(SourceTestSuiteBase):
     @classmethod
     def create_connector(
         cls,
-        scenario: ConnectorTestScenario,
+        scenario: ConnectorTestScenario | None,
     ) -> IConnector:
         """Create a connector scenario for the test suite.
 
@@ -73,9 +73,13 @@ class DeclarativeSourceTestSuite(SourceTestSuiteBase):
 
         Subclasses should not need to override this method.
         """
-        config: dict[str, Any] = scenario.get_config_dict()
-
         manifest_dict = yaml.safe_load(cls.manifest_yaml_path.read_text())
+        config = {
+            "__injected_manifest": manifest_dict,
+        }
+        if scenario:
+            config.update(scenario.get_config_dict())
+
         if cls.components_py_path and cls.components_py_path.exists():
             os.environ["AIRBYTE_ENABLE_UNSAFE_CODE"] = "true"
             config["__injected_components_py"] = cls.components_py_path.read_text()

--- a/airbyte_cdk/test/standard_tests/declarative_sources.py
+++ b/airbyte_cdk/test/standard_tests/declarative_sources.py
@@ -73,12 +73,12 @@ class DeclarativeSourceTestSuite(SourceTestSuiteBase):
 
         Subclasses should not need to override this method.
         """
+        scenario = scenario or ConnectorTestScenario()  # Use default (empty) scenario if None
         manifest_dict = yaml.safe_load(cls.manifest_yaml_path.read_text())
         config = {
             "__injected_manifest": manifest_dict,
         }
-        if scenario:
-            config.update(scenario.get_config_dict())
+        config.update(scenario.get_config_dict(empty_if_missing=True))
 
         if cls.components_py_path and cls.components_py_path.exists():
             os.environ["AIRBYTE_ENABLE_UNSAFE_CODE"] = "true"

--- a/airbyte_cdk/test/standard_tests/models/scenario.py
+++ b/airbyte_cdk/test/standard_tests/models/scenario.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Any, Literal, cast
 
 import yaml
+from numpy import empty
 from pydantic import BaseModel
 
 
@@ -43,17 +44,28 @@ class ConnectorTestScenario(BaseModel):
     file_types: AcceptanceTestFileTypes | None = None
     status: Literal["succeed", "failed"] | None = None
 
-    def get_config_dict(self) -> dict[str, Any]:
+    def get_config_dict(
+        self,
+        *,
+        empty_if_missing: bool,
+    ) -> dict[str, Any]:
         """Return the config dictionary.
 
         If a config dictionary has already been loaded, return it. Otherwise, load
         the config file and return the dictionary.
+
+        If `self.config_dict` and `self.config_path` are both `None`:
+        - return an empty dictionary if `empty_if_missing` is True
+        - raise a ValueError if `empty_if_missing` is False
         """
-        if self.config_dict:
+        if self.config_dict is not None:
             return self.config_dict
 
-        if self.config_path:
+        if self.config_path is not None:
             return cast(dict[str, Any], yaml.safe_load(self.config_path.read_text()))
+
+        if empty_if_missing:
+            return {}
 
         raise ValueError("No config dictionary or path provided.")
 

--- a/airbyte_cdk/test/standard_tests/models/scenario.py
+++ b/airbyte_cdk/test/standard_tests/models/scenario.py
@@ -13,7 +13,6 @@ from pathlib import Path
 from typing import Any, Literal, cast
 
 import yaml
-from numpy import empty
 from pydantic import BaseModel
 
 

--- a/airbyte_cdk/test/standard_tests/source_base.py
+++ b/airbyte_cdk/test/standard_tests/source_base.py
@@ -69,8 +69,8 @@ class SourceTestSuiteBase(ConnectorTestSuiteBase):
 
         This test does not require a `scenario` input, since `spec`
         does not require any inputs.
-        
-        We assume `spec` should always succeed and it should always generate 
+
+        We assume `spec` should always succeed and it should always generate
         a valid `SPEC` message.
 
         Note: the parsing of messages by type also implicitly validates that

--- a/airbyte_cdk/test/standard_tests/source_base.py
+++ b/airbyte_cdk/test/standard_tests/source_base.py
@@ -64,11 +64,18 @@ class SourceTestSuiteBase(ConnectorTestSuiteBase):
             test_scenario=scenario,
         )
 
-    def test_spec(
-        self,
-        # scenario: ConnectorTestScenario,  # No inputs needed for spec test
-    ) -> None:
-        """Standard test for `spec`."""
+    def test_spec(self) -> None:
+        """Standard test for `spec`.
+
+        This test does not require a `scenario` input, since `spec`
+        does not require any inputs.
+        
+        We assume `spec` should always succeed and it should always generate 
+        a valid `SPEC` message.
+
+        Note: the parsing of messages by type also implicitly validates that
+        the generated `SPEC` message is valid JSON.
+        """
         result = run_test_job(
             verb="spec",
             test_scenario=None,

--- a/airbyte_cdk/test/standard_tests/source_base.py
+++ b/airbyte_cdk/test/standard_tests/source_base.py
@@ -64,6 +64,26 @@ class SourceTestSuiteBase(ConnectorTestSuiteBase):
             test_scenario=scenario,
         )
 
+    def test_spec(
+        self,
+        # scenario: ConnectorTestScenario,  # No inputs needed for spec test
+    ) -> None:
+        """Standard test for `spec`."""
+        result = run_test_job(
+            verb="spec",
+            test_scenario=None,
+            connector=self.create_connector(scenario=None),
+        )
+        if result.errors:
+            raise AssertionError(
+                f"Expected no errors but got {len(result.errors)}: \n"
+                + "\n".join([str(e) for e in result.errors])
+            )
+        assert len(result.spec_messages) == 1, (
+            "Expected exactly 1 spec message but got {len(result.spec_messages)}",
+            result.errors,
+        )
+
     def test_basic_read(
         self,
         scenario: ConnectorTestScenario,

--- a/airbyte_cdk/test/standard_tests/source_base.py
+++ b/airbyte_cdk/test/standard_tests/source_base.py
@@ -81,11 +81,8 @@ class SourceTestSuiteBase(ConnectorTestSuiteBase):
             test_scenario=None,
             connector=self.create_connector(scenario=None),
         )
-        if result.errors:
-            raise AssertionError(
-                f"Expected no errors but got {len(result.errors)}: \n"
-                + "\n".join([str(e) for e in result.errors])
-            )
+        # If an error occurs, it will be raised above.
+
         assert len(result.spec_messages) == 1, (
             "Expected exactly 1 spec message but got {len(result.spec_messages)}",
             result.errors,


### PR DESCRIPTION
This PR handles the case of missing config in `acceptance-test-config.yml`. Specifically, it now runs successfully on `source-7shift`, which has the following definition:

```yml
# See [Connector Acceptance Tests](https://docs.airbyte.com/connector-development/testing-connectors/connector-acceptance-tests-reference)
# for more information about how to configure these tests
connector_image: airbyte/source-7shifts:dev
acceptance_tests:
  spec:
    tests:
      - spec_path: "manifest.yaml"
  connection:
    bypass_reason: "This is a builder contribution, and we do not have secrets at this time"
  discovery:
    bypass_reason: "This is a builder contribution, and we do not have secrets at this time"
  basic_read:
    bypass_reason: "This is a builder contribution, and we do not have secrets at this time"
  incremental:
    bypass_reason: "This is a builder contribution, and we do not have secrets at this time"
  full_refresh:
    bypass_reason: "This is a builder contribution, and we do not have secrets at this time"
```

This test config file is especially useless because `spec` is not the same as `manifest.yml` and so it's not really helpful at all in defining test cases.

Nevertheless, we test what we can and the tests succeed now:

<img width="1022" alt="image" src="https://github.com/user-attachments/assets/29d1585e-6836-4e08-892f-166e39f09622" />


## Summary by CodeRabbit

- **Tests**
  - Improved handling of missing test scenarios in acceptance test configuration, returning an empty list instead of raising an error when no tests are found for a category.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new standard test for validating connector specification output.
  - Added a property to easily access specification messages in test results.

- **Bug Fixes**
  - Improved handling of test scenarios to support cases where no scenario is provided.
  - Enhanced test scenario aggregation to include multiple categories and handle missing data more gracefully.
  - Expanded test job support to include the "spec" verb and optional test scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->