### PR TITLE
fix: (CDK) (BaseModelWithDeprecations) - filter the warnings to be shown, ignore the `SyntaxWarning`

### DIFF
--- a/airbyte_cdk/sources/declarative/models/base_model_with_deprecations.py
+++ b/airbyte_cdk/sources/declarative/models/base_model_with_deprecations.py
@@ -14,6 +14,9 @@ from airbyte_cdk.connector_builder.models import LogMessage as ConnectorBuilderL
 warnings.formatwarning = (
     lambda message, category, *args, **kwargs: f"{category.__name__}: {message}"
 )
+# ignore the SyntaxWarning in the Airbyte log messages, during the string evaluation
+warnings.filterwarnings("ignore", category=SyntaxWarning)
+
 
 FIELDS_TAG = "__fields__"
 DEPRECATED = "deprecated"

--- a/airbyte_cdk/sources/declarative/models/base_model_with_deprecations.py
+++ b/airbyte_cdk/sources/declarative/models/base_model_with_deprecations.py
@@ -4,6 +4,10 @@
 # WHEN DEPRECATED FIELDS ARE ACCESSED
 
 import warnings
+
+# ignore the SyntaxWarning in the Airbyte log messages, during the string evaluation
+warnings.filterwarnings("ignore", category=SyntaxWarning)
+
 from typing import Any, List
 
 from pydantic.v1 import BaseModel
@@ -12,10 +16,8 @@ from airbyte_cdk.connector_builder.models import LogMessage as ConnectorBuilderL
 
 # format the warning message
 warnings.formatwarning = (
-    lambda message, category, *args, **kwargs: f"{category.__name__}: {message}"
+    lambda message, category, *args, **kwargs: f"{category.__name__}: {message}\n"
 )
-# ignore the SyntaxWarning in the Airbyte log messages, during the string evaluation
-warnings.filterwarnings("ignore", category=SyntaxWarning)
 
 
 FIELDS_TAG = "__fields__"


### PR DESCRIPTION
## What
- During the `string interpolation` the `SyntaxWarning` message is printed to `stdout` making the platform to think the `RECORD` is malformed; thus the record gets filtered out, causing `record count mismatch`.

## How
- added the warnings filtering, to filter out the `SyntaxWarning` being printed to `stdout`
- added the `\n` to the formatted message, to be able to ignore sudden warnings in the stdout by the platform

## User Impact
No impact is expected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Suppressed display of all SyntaxWarning messages globally.
  - Adjusted formatting of warning messages for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->