### PR TITLE
feat(AsyncRetriever): slice information during the polling request, Support creation_response interpolation in body

### DIFF
--- a/airbyte_cdk/sources/declarative/requesters/http_job_repository.py
+++ b/airbyte_cdk/sources/declarative/requesters/http_job_repository.py
@@ -320,14 +320,14 @@ class AsyncHttpJobRepository(AsyncJobRepository):
         return polling_response_context
 
     def _get_create_job_stream_slice(self, job: AsyncJob) -> StreamSlice:
-        stream_slice = StreamSlice(
-            partition={},
-            cursor_slice={},
-            extra_fields={
+        return StreamSlice(
+            partition=job.job_parameters().partition,
+            cursor_slice=job.job_parameters().cursor_slice,
+            extra_fields=dict(job.job_parameters().extra_fields)
+            | {
                 "creation_response": self._get_creation_response_interpolation_context(job),
             },
         )
-        return stream_slice
 
     def _get_download_targets(self, job: AsyncJob) -> Iterable[str]:
         if not self.download_target_requester:

--- a/airbyte_cdk/sources/declarative/requesters/request_options/interpolated_nested_request_input_provider.py
+++ b/airbyte_cdk/sources/declarative/requesters/request_options/interpolated_nested_request_input_provider.py
@@ -11,6 +11,7 @@ from airbyte_cdk.sources.declarative.interpolation.interpolated_nested_mapping i
 )
 from airbyte_cdk.sources.declarative.interpolation.interpolated_string import InterpolatedString
 from airbyte_cdk.sources.types import Config, StreamSlice
+from airbyte_cdk.utils.mapping_helpers import get_interpolation_context
 
 
 @dataclass
@@ -52,8 +53,8 @@ class InterpolatedNestedRequestInputProvider:
         :param next_page_token: The pagination token
         :return: The request inputs to set on an outgoing HTTP request
         """
-        kwargs = {
-            "stream_slice": stream_slice,
-            "next_page_token": next_page_token,
-        }
+        kwargs = get_interpolation_context(
+            stream_slice=stream_slice,
+            next_page_token=next_page_token,
+        )
         return self._interpolator.eval(self.config, **kwargs)  # type: ignore  # self._interpolator is always initialized with a value and will not be None

--- a/airbyte_cdk/sources/declarative/requesters/request_options/interpolated_request_input_provider.py
+++ b/airbyte_cdk/sources/declarative/requesters/request_options/interpolated_request_input_provider.py
@@ -8,6 +8,7 @@ from typing import Any, Mapping, Optional, Tuple, Type, Union
 from airbyte_cdk.sources.declarative.interpolation.interpolated_mapping import InterpolatedMapping
 from airbyte_cdk.sources.declarative.interpolation.interpolated_string import InterpolatedString
 from airbyte_cdk.sources.types import Config, StreamSlice, StreamState
+from airbyte_cdk.utils.mapping_helpers import get_interpolation_context
 
 
 @dataclass
@@ -51,10 +52,10 @@ class InterpolatedRequestInputProvider:
         :param valid_value_types: A tuple of types that the interpolator should allow
         :return: The request inputs to set on an outgoing HTTP request
         """
-        kwargs = {
-            "stream_slice": stream_slice,
-            "next_page_token": next_page_token,
-        }
+        kwargs = get_interpolation_context(
+            stream_slice=stream_slice,
+            next_page_token=next_page_token,
+        )
         interpolated_value = self._interpolator.eval(  # type: ignore # self._interpolator is always initialized with a value and will not be None
             self.config,
             valid_key_types=valid_key_types,


### PR DESCRIPTION
* AsyncRetriever:
  * Having access to slice information during the polling request
  * Support `creation_response` interpolation in body

Resolves: https://github.com/airbytehq/airbyte-internal-issues/issues/12875

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved internal logic for building request contexts and stream slices, resulting in more consistent handling of job parameters and interpolation contexts.

- **Tests**
  - Refactored test setup for better maintainability.
  - Added a new test to verify correct handling of stream slice information during job status updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->