### PR TITLE
fix(cdk): determine state from manager if not received a state in per partition router

### DIFF
--- a/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -1485,7 +1485,6 @@ class ModelToComponentFactory:
             )
         )
 
-
         stream_state = self.apply_stream_state_migrations(stream_state_migrations, stream_state)
         # Per-partition state doesn't make sense for GroupingPartitionRouter, so force the global state
         use_global_cursor = isinstance(

--- a/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -1491,7 +1491,9 @@ class ModelToComponentFactory:
         ) or component_definition.get("global_substream_cursor", False)
 
         if not stream_state:
-            stream_state = self._connector_state_manager.get_stream_state(stream_name, stream_namespace)
+            stream_state = self._connector_state_manager.get_stream_state(
+                stream_name, stream_namespace
+            )
 
         # Return the concurrent cursor and state converter
         return ConcurrentPerPartitionCursor(

--- a/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -1484,16 +1484,17 @@ class ModelToComponentFactory:
                 stream_state_migrations=stream_state_migrations,
             )
         )
-        stream_state = self.apply_stream_state_migrations(stream_state_migrations, stream_state)
-        # Per-partition state doesn't make sense for GroupingPartitionRouter, so force the global state
-        use_global_cursor = isinstance(
-            partition_router, GroupingPartitionRouter
-        ) or component_definition.get("global_substream_cursor", False)
 
         if not stream_state:
             stream_state = self._connector_state_manager.get_stream_state(
                 stream_name, stream_namespace
             )
+
+        stream_state = self.apply_stream_state_migrations(stream_state_migrations, stream_state)
+        # Per-partition state doesn't make sense for GroupingPartitionRouter, so force the global state
+        use_global_cursor = isinstance(
+            partition_router, GroupingPartitionRouter
+        ) or component_definition.get("global_substream_cursor", False)
 
         # Return the concurrent cursor and state converter
         return ConcurrentPerPartitionCursor(

--- a/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -1485,10 +1485,6 @@ class ModelToComponentFactory:
             )
         )
 
-        if not stream_state:
-            stream_state = self._connector_state_manager.get_stream_state(
-                stream_name, stream_namespace
-            )
 
         stream_state = self.apply_stream_state_migrations(stream_state_migrations, stream_state)
         # Per-partition state doesn't make sense for GroupingPartitionRouter, so force the global state
@@ -1999,14 +1995,19 @@ class ModelToComponentFactory:
     ) -> Optional[StreamSlicer]:
         if model.incremental_sync and stream_slicer:
             if model.retriever.type == "AsyncRetriever":
+                stream_name = model.name or ""
+                stream_namespace = None
+                stream_state = self._connector_state_manager.get_stream_state(
+                    stream_name, stream_namespace
+                )
                 return self.create_concurrent_cursor_from_perpartition_cursor(  # type: ignore # This is a known issue that we are creating and returning a ConcurrentCursor which does not technically implement the (low-code) StreamSlicer. However, (low-code) StreamSlicer and ConcurrentCursor both implement StreamSlicer.stream_slices() which is the primary method needed for checkpointing
                     state_manager=self._connector_state_manager,
                     model_type=DatetimeBasedCursorModel,
                     component_definition=model.incremental_sync.__dict__,
-                    stream_name=model.name or "",
-                    stream_namespace=None,
+                    stream_name=stream_name,
+                    stream_namespace=stream_namespace,
                     config=config or {},
-                    stream_state={},
+                    stream_state=stream_state,
                     partition_router=stream_slicer,
                 )
 

--- a/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -1490,6 +1490,9 @@ class ModelToComponentFactory:
             partition_router, GroupingPartitionRouter
         ) or component_definition.get("global_substream_cursor", False)
 
+        if not stream_state:
+            stream_state = self._connector_state_manager.get_stream_state(stream_name, stream_namespace)
+
         # Return the concurrent cursor and state converter
         return ConcurrentPerPartitionCursor(
             cursor_factory=cursor_factory,

--- a/unit_tests/sources/declarative/parsers/resources/stream_with_incremental_and_aync_retriever_with_partition_router.yaml
+++ b/unit_tests/sources/declarative/parsers/resources/stream_with_incremental_and_aync_retriever_with_partition_router.yaml
@@ -1,0 +1,140 @@
+decoder:
+  type: JsonDecoder
+extractor:
+  type: DpathExtractor
+selector:
+  type: RecordSelector
+  record_filter:
+    type: RecordFilter
+    condition: "{{ record['id'] > stream_state['id'] }}"
+requester:
+  type: HttpRequester
+  name: "{{ parameters['name'] }}"
+  url_base: "https://api.sendgrid.com/v3/"
+  http_method: "GET"
+  authenticator:
+    type: SessionTokenAuthenticator
+    decoder:
+      type: JsonDecoder
+    expiration_duration: P10D
+    login_requester:
+      path: /session
+      type: HttpRequester
+      url_base: 'https://api.sendgrid.com'
+      http_method: POST
+      request_body_json:
+        password: '{{ config.apikey }}'
+        username: '{{ parameters.name }}'
+    session_token_path:
+      - id
+    request_authentication:
+      type: ApiKey
+      inject_into:
+        type: RequestOption
+        field_name: X-Metabase-Session
+        inject_into: header
+  request_parameters:
+    unit: "day"
+list_stream:
+  type: DeclarativeStream
+  name: lists
+  schema_loader:
+    type: JsonFileSchemaLoader
+    file_path: "./source_sendgrid/schemas/{{ parameters.name }}.json"
+  incremental_sync:
+    type: DatetimeBasedCursor
+    $parameters:
+      datetime_format: "%Y-%m-%dT%H:%M:%S%z"
+    start_datetime:
+      type: MinMaxDatetime
+      datetime: "{{ config['reports_start_date'] }}"
+      datetime_format: "%Y-%m-%d"
+    end_datetime:
+      type: MinMaxDatetime
+      datetime: "{{ format_datetime(now_utc(), '%Y-%m-%d') }}"
+      datetime_format: "%Y-%m-%d"
+    cursor_field: TimePeriod
+    cursor_datetime_formats:
+      - "%Y-%m-%dT%H:%M:%S%z"
+  retriever:
+    type: AsyncRetriever
+    name: "{{ parameters['name'] }}"
+    decoder:
+      $ref: "#/decoder"
+    partition_router:
+      type: ListPartitionRouter
+      values: "{{config['repos']}}"
+      cursor_field: a_key
+      request_option:
+        inject_into: header
+        field_name: a_key
+    status_mapping:
+      failed:
+        - Error
+      running:
+        - Pending
+      completed:
+        - Success
+      timeout: [ ]
+    status_extractor:
+      type: DpathExtractor
+      field_path:
+        - ReportRequestStatus
+        - Status
+    download_target_extractor:
+      type: DpathExtractor
+      field_path:
+        - ReportRequestStatus
+        - ReportDownloadUrl
+    creation_requester:
+      type: HttpRequester
+      url_base: https://reporting.api.bingads.microsoft.com/
+      path: Reporting/v13/GenerateReport/Submit
+      http_method: POST
+      request_headers:
+        Content-Type: application/json
+        DeveloperToken: "{{ config['developer_token'] }}"
+        CustomerId: "'{{ stream_partition['customer_id'] }}'"
+        CustomerAccountId: "'{{ stream_partition['account_id'] }}'"
+      request_body_json:
+        ReportRequest:
+          ExcludeColumnHeaders: false
+    polling_requester:
+      type: HttpRequester
+      url_base: https://fakerporting.api.bingads.microsoft.com/
+      path: Reporting/v13/GenerateReport/Poll
+      http_method: POST
+      request_headers:
+        Content-Type: application/json
+        DeveloperToken: "{{ config['developer_token'] }}"
+        CustomerId: "'{{ stream_partition['customer_id'] }}'"
+        CustomerAccountId: "'{{ stream_partition['account_id'] }}'"
+      request_body_json:
+        ReportRequestId: "'{{ creation_response['ReportRequestId'] }}'"
+    download_requester:
+      type: HttpRequester
+      url_base: "{{download_target}}"
+      http_method: GET
+    paginator:
+      type: DefaultPaginator
+      page_size_option:
+        inject_into: request_parameter
+        field_name: page_size
+      page_token_option:
+        inject_into: path
+        type: RequestPath
+      pagination_strategy:
+        type: "CursorPagination"
+        cursor_value: "{{ response._metadata.next }}"
+        page_size: 10
+    requester:
+      $ref: "#/requester"
+      path: "{{ next_page_token['next_page_url'] }}"
+    record_selector:
+      $ref: "#/selector"
+  $parameters:
+    name: "lists"
+    primary_key: "id"
+    extractor:
+      $ref: "#/extractor"
+      field_path: ["{{ parameters['name'] }}"]

--- a/unit_tests/sources/declarative/parsers/test_model_to_component_factory.py
+++ b/unit_tests/sources/declarative/parsers/test_model_to_component_factory.py
@@ -1,14 +1,17 @@
 #
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
+from copy import deepcopy
 
 # mypy: ignore-errors
 from datetime import datetime, timedelta, timezone
-from typing import Any, Iterable, Mapping
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Optional, Union
 
 import freezegun
 import pytest
 import requests
+from freezegun.api import FakeDatetime
 from pydantic.v1 import ValidationError
 
 from airbyte_cdk import AirbyteTracedException
@@ -42,6 +45,7 @@ from airbyte_cdk.sources.declarative.extractors.record_filter import (
     ClientSideIncrementalRecordFilterDecorator,
 )
 from airbyte_cdk.sources.declarative.incremental import (
+    ConcurrentPerPartitionCursor,
     CursorFactory,
     DatetimeBasedCursor,
     PerPartitionCursor,
@@ -166,7 +170,7 @@ from airbyte_cdk.sources.streams.concurrent.clamping import (
     MonthClampingStrategy,
     WeekClampingStrategy,
 )
-from airbyte_cdk.sources.streams.concurrent.cursor import ConcurrentCursor
+from airbyte_cdk.sources.streams.concurrent.cursor import ConcurrentCursor, CursorField
 from airbyte_cdk.sources.streams.concurrent.state_converters.datetime_stream_state_converter import (
     CustomFormatConcurrentStreamStateConverter,
 )
@@ -188,6 +192,21 @@ resolver = ManifestReferenceResolver()
 transformer = ManifestComponentTransformer()
 
 input_config = {"apikey": "verysecrettoken", "repos": ["airbyte", "airbyte-cloud"]}
+
+
+def get_factory_with_parameters(
+    connector_state_manager: Optional[ConnectorStateManager] = None,
+) -> ModelToComponentFactory:
+    return ModelToComponentFactory(
+        connector_state_manager=connector_state_manager,
+    )
+
+
+def read_yaml_file(resource_path: Union[str, Path]) -> str:
+    yaml_path = Path(__file__).parent / resource_path
+    with open(yaml_path, "r") as file:
+        content = file.read()
+    return content
 
 
 def test_create_check_stream():
@@ -923,6 +942,97 @@ list_stream:
     assert isinstance(list_stream_slicer, ListPartitionRouter)
     assert list_stream_slicer.values == ["airbyte", "airbyte-cloud"]
     assert list_stream_slicer._cursor_field.string == "a_key"
+
+
+@freezegun.freeze_time("2025-05-14")
+def test_stream_with_incremental_and_async_retriever_with_partition_router():
+    content = read_yaml_file(
+        "resources/stream_with_incremental_and_aync_retriever_with_partition_router.yaml"
+    )
+    parsed_manifest = YamlDeclarativeSource._parse(content)
+    resolved_manifest = resolver.preprocess_manifest(parsed_manifest)
+    stream_manifest = transformer.propagate_types_and_parameters(
+        "", resolved_manifest["list_stream"], {}
+    )
+    cursor_time_period_value = "2025-05-06T12:00:00+0000"
+    cursor_field_key = "TimePeriod"
+    parent_user_id = "102023653"
+    per_partition_key = {
+        "account_id": 999999999,
+        "parent_slice": {"parent_slice": {}, "user_id": parent_user_id},
+    }
+    stream_state = {
+        "use_global_cursor": False,
+        "states": [
+            {"partition": per_partition_key, "cursor": {cursor_field_key: cursor_time_period_value}}
+        ],
+        "state": {cursor_field_key: "2025-05-12T12:00:00+0000"},
+        "lookback_window": 46,
+    }
+    connector_state_manager = ConnectorStateManager(
+        state=[
+            AirbyteStateMessage(
+                type=AirbyteStateType.STREAM,
+                stream=AirbyteStreamState(
+                    stream_descriptor=StreamDescriptor(name="lists"),
+                    stream_state=AirbyteStateBlob(stream_state),
+                ),
+            )
+        ]
+    )
+
+    factory_with_parameters = get_factory_with_parameters(
+        connector_state_manager=connector_state_manager
+    )
+    connector_config = deepcopy(input_config)
+    connector_config["reports_start_date"] = "2025-01-01"
+    stream = factory_with_parameters.create_component(
+        model_type=DeclarativeStreamModel,
+        component_definition=stream_manifest,
+        config=connector_config,
+    )
+
+    assert isinstance(stream, DeclarativeStream)
+    assert isinstance(stream.retriever, AsyncRetriever)
+    stream_slicer = stream.retriever.stream_slicer.stream_slicer
+    assert isinstance(stream_slicer, ConcurrentPerPartitionCursor)
+    assert stream_slicer.state == stream_state
+    import json
+
+    cursor_perpartition = stream_slicer._cursor_per_partition
+    expected_cursor_perpartition_key = json.dumps(per_partition_key, sort_keys=True).replace(
+        " ", ""
+    )
+    assert (
+        cursor_perpartition[expected_cursor_perpartition_key].cursor_field.cursor_field_key
+        == cursor_field_key
+    )
+    assert cursor_perpartition[expected_cursor_perpartition_key].start == datetime(
+        2025, 5, 6, 12, 0, tzinfo=timezone.utc
+    )
+    assert (
+        cursor_perpartition[expected_cursor_perpartition_key].state[cursor_field_key]
+        == cursor_time_period_value
+    )
+
+    concurrent_cursor = cursor_perpartition[expected_cursor_perpartition_key]
+    assert concurrent_cursor._concurrent_state == {
+        "legacy": {cursor_field_key: cursor_time_period_value},
+        "slices": [
+            {
+                "end": FakeDatetime(2025, 5, 6, 12, 0, tzinfo=timezone.utc),
+                "most_recent_cursor_value": FakeDatetime(2025, 5, 6, 12, 0, tzinfo=timezone.utc),
+                "start": FakeDatetime(2025, 1, 1, 0, 0, tzinfo=timezone.utc),
+            }
+        ],
+        "state_type": "date-range",
+    }
+
+    stream_slices = list(concurrent_cursor.stream_slices())
+    expected_stream_slices = [
+        {"start_time": cursor_time_period_value, "end_time": "2025-05-14T00:00:00+0000"}
+    ]
+    assert stream_slices == expected_stream_slices
 
 
 def test_resumable_full_refresh_stream():


### PR DESCRIPTION
We found that indeed it seems we have an issue where state is not passed downstream for [this flow here](https://github.com/airbytehq/airbyte-python-cdk/blob/main/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py#L1996-L2005) when:
1. Stream uses async retriever
2. Asyc Retriever has a SubstreamPartitionRouter
3. Is incremental stream

I was able to reproduce for:

- source-bing-ads manifest [migration](https://github.com/airbytehq/airbyte/pull/59750/files#diff-e940c9c1127f2dfa6d01ef1e93b0ff7338d71d46fa225de7bd0d0aaf7cf2940aR125-R228).

   - I have a walkthrough Loom video debugging [here](https://www.loom.com/share/dbc07fbf95b947989ed363fa44685e92?sid=474b0c63-170d-4338-a572-e333eb9a9162).
   - I also added an integration test that reproduces the issue [here](https://github.com/airbytehq/airbyte/pull/59750/files#diff-1c231116365a62bb9bb5c81cc7156b7ad5d9d56b60cf875fdf24167b2135eb5fR156-R217).
- Current implementation of source-amazon-Ads, e.g., [sponsored_display_campaigns_report_stream_daily](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connectors/source-amazon-ads/source_amazon_ads/manifest.yaml#L1404-L1413).
   - I have another walkthrough loom video debugging [here](https://www.loom.com/share/164ba10d5bc049dfbbb63aeff8475406?sid=5f3f6f19-c4a3-4643-a9b1-7e7b8fa242e8).
   - A sample connection [here](https://cloud.airbyte.com/workspaces/3fe0e748-014b-4f17-8c85-911da22f9b85/connections/b2ef0722-1e13-4194-9bd5-3398a7a1b428/timeline).

Downstream, the state is never passed to [ConcurrentPerPartitionCursor._set_initial_state(stream_state) ](https://github.com/airbytehq/airbyte-python-cdk/blob/main/airbyte_cdk/sources/declarative/incremental/concurrent_partition_cursor.py#L116)then we don't have a self._cursor_per_partition [here](https://github.com/airbytehq/airbyte-python-cdk/blob/main/airbyte_cdk/sources/declarative/incremental/concurrent_partition_cursor.py#L419-L420). There is an [alternative flow ](https://github.com/airbytehq/airbyte-python-cdk/blob/main/airbyte_cdk/sources/declarative/incremental/concurrent_partition_cursor.py#L279-L283)when no cursor is present, which is also followed in the looms; neither seems to retrieve a state that can be used in the [ConcurrentCursor](https://github.com/airbytehq/airbyte-python-cdk/blob/main/airbyte_cdk/sources/streams/concurrent/cursor.py#L158).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for asynchronous data retrieval with partitioned request handling in declarative streams.
  - Introduced incremental sync capabilities with datetime-based cursors and dynamic pagination.
  - Enabled session token authentication with automatic token refresh and API key injection.
- **Bug Fixes**
  - Improved handling of stream state to ensure a valid state is always used when creating concurrent cursors, reducing the risk of errors when no stream state is provided.
  - Enhanced stream state migration application to maintain accurate and up-to-date stream states during incremental syncs.
- **Tests**
  - Added comprehensive tests verifying asynchronous retriever behavior with partitioned cursors and incremental sync functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->