### PR TITLE
fix(cdk): pass transformations to concurrent cursor and fix transformation

### DIFF
--- a/airbyte_cdk/sources/declarative/migrations/legacy_to_per_partition_state_migration.py
+++ b/airbyte_cdk/sources/declarative/migrations/legacy_to_per_partition_state_migration.py
@@ -78,19 +78,20 @@ class LegacyToPerPartitionStateMigration(StateMigration):
           "<cursor_field>" : "<cursor_value>"
         }
         """
-        if stream_state:
-            for key, value in stream_state.items():
-                if isinstance(value, dict):
-                    keys = list(value.keys())
-                    if len(keys) != 1:
-                        # The input partitioned state should only have one key
-                        return False
-                    if keys[0] != self._cursor_field:
-                        # Unexpected key. Found {keys[0]}. Expected {self._cursor.cursor_field}
-                        return False
-                # it is expected the internal value to be a dictionary according to docstring
-                else:
-                    return False
+        if not stream_state:
+            return False
+        for key, value in stream_state.items():
+            # it is expected the internal value to be a dictionary according to docstring
+            if not isinstance(value, dict):
+                return False
+            keys = list(value.keys())
+            if len(keys) != 1:
+                # The input partitioned state should only have one key
+                return False
+            if keys[0] != self._cursor_field:
+                # Unexpected key. Found {keys[0]}. Expected {self._cursor.cursor_field}
+                return False
+
         return True
 
     def migrate(self, stream_state: Mapping[str, Any]) -> Mapping[str, Any]:

--- a/airbyte_cdk/sources/declarative/migrations/legacy_to_per_partition_state_migration.py
+++ b/airbyte_cdk/sources/declarative/migrations/legacy_to_per_partition_state_migration.py
@@ -88,6 +88,9 @@ class LegacyToPerPartitionStateMigration(StateMigration):
                     if keys[0] != self._cursor_field:
                         # Unexpected key. Found {keys[0]}. Expected {self._cursor.cursor_field}
                         return False
+                # it is expected the internal value to be a dictionary according to docstring
+                else:
+                    return False
         return True
 
     def migrate(self, stream_state: Mapping[str, Any]) -> Mapping[str, Any]:

--- a/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -928,9 +928,9 @@ class ModelToComponentFactory:
         declarative_stream: DeclarativeStreamModel,
     ) -> LegacyToPerPartitionStateMigration:
         retriever = declarative_stream.retriever
-        if not isinstance(retriever, SimpleRetrieverModel):
+        if not isinstance(retriever, (SimpleRetrieverModel, AsyncRetrieverModel)):
             raise ValueError(
-                f"LegacyToPerPartitionStateMigrations can only be applied on a DeclarativeStream with a SimpleRetriever. Got {type(retriever)}"
+                f"LegacyToPerPartitionStateMigrations can only be applied on a DeclarativeStream with a SimpleRetriever or AsyncRetriever. Got {type(retriever)}"
             )
         partition_router = retriever.partition_router
         if not isinstance(
@@ -1999,6 +1999,17 @@ class ModelToComponentFactory:
                 stream_state = self._connector_state_manager.get_stream_state(
                     stream_name, stream_namespace
                 )
+                state_transformations = (
+                    [
+                        self._create_component_from_model(
+                            state_migration, config, declarative_stream=model
+                        )
+                        for state_migration in model.state_migrations
+                    ]
+                    if model.state_migrations
+                    else []
+                )
+
                 return self.create_concurrent_cursor_from_perpartition_cursor(  # type: ignore # This is a known issue that we are creating and returning a ConcurrentCursor which does not technically implement the (low-code) StreamSlicer. However, (low-code) StreamSlicer and ConcurrentCursor both implement StreamSlicer.stream_slices() which is the primary method needed for checkpointing
                     state_manager=self._connector_state_manager,
                     model_type=DatetimeBasedCursorModel,
@@ -2007,6 +2018,7 @@ class ModelToComponentFactory:
                     stream_namespace=stream_namespace,
                     config=config or {},
                     stream_state=stream_state,
+                    stream_state_migrations=state_transformations,
                     partition_router=stream_slicer,
                 )
 

--- a/unit_tests/sources/declarative/migrations/test_legacy_to_per_partition_migration.py
+++ b/unit_tests/sources/declarative/migrations/test_legacy_to_per_partition_migration.py
@@ -193,6 +193,10 @@ def test_migrate_a_valid_legacy_state_to_per_partition():
             {"last_changed": "2022-12-27T08:34:39+00:00"},
             id="test_should_not_migrate_if_the_partitioned_state_is_not_in_correct_format",
         ),
+        pytest.param(
+            {},
+            id="test_should_not_migrate_if_not_state_is_passed",
+        ),
     ],
 )
 def test_should_not_migrate(input_state):

--- a/unit_tests/sources/declarative/migrations/test_legacy_to_per_partition_migration.py
+++ b/unit_tests/sources/declarative/migrations/test_legacy_to_per_partition_migration.py
@@ -189,6 +189,10 @@ def test_migrate_a_valid_legacy_state_to_per_partition():
             },
             id="test_should_not_migrate_if_the_partitioned_state_key_is_not_the_cursor_field",
         ),
+        pytest.param(
+            {"last_changed": "2022-12-27T08:34:39+00:00"},
+            id="test_should_not_migrate_if_the_partitioned_state_is_not_in_correct_format",
+        ),
     ],
 )
 def test_should_not_migrate(input_state):
@@ -277,7 +281,7 @@ def _migrator_with_multiple_parent_streams():
             CustomPartitionRouter,
             True,
             ValueError,
-            "LegacyToPerPartitionStateMigrations can only be applied on a DeclarativeStream with a SimpleRetriever. Got <class 'unittest.mock.MagicMock'>",
+            "LegacyToPerPartitionStateMigrations can only be applied on a DeclarativeStream with a SimpleRetriever or AsyncRetriever. Got <class 'unittest.mock.MagicMock'>",
         ),
         (
             SimpleRetriever,

--- a/unit_tests/sources/declarative/parsers/resources/stream_with_incremental_and_aync_retriever_with_partition_router.yaml
+++ b/unit_tests/sources/declarative/parsers/resources/stream_with_incremental_and_aync_retriever_with_partition_router.yaml
@@ -56,18 +56,60 @@ list_stream:
     cursor_field: TimePeriod
     cursor_datetime_formats:
       - "%Y-%m-%dT%H:%M:%S%z"
+  state_migrations:
+    - type: LegacyToPerPartitionStateMigration
   retriever:
     type: AsyncRetriever
     name: "{{ parameters['name'] }}"
     decoder:
       $ref: "#/decoder"
     partition_router:
-      type: ListPartitionRouter
-      values: "{{config['repos']}}"
-      cursor_field: a_key
-      request_option:
-        inject_into: header
-        field_name: a_key
+      type: SubstreamPartitionRouter
+      parent_stream_configs:
+        - type: ParentStreamConfig
+          parent_key: Id
+          partition_field: account_id
+          stream:
+            type: DeclarativeStream
+            name: lists_parent
+            schema_loader:
+              type: JsonFileSchemaLoader
+              file_path: "./source_sendgrid/schemas/{{ parameters.name }}.json"
+            retriever:
+              type: SimpleRetriever
+              name: "{{ parameters['name'] }}"
+              decoder:
+                $ref: "#/decoder"
+              partition_router:
+                type: ListPartitionRouter
+                values: "{{config['repos']}}"
+                cursor_field: a_key
+                request_option:
+                  inject_into: header
+                  field_name: a_key
+              paginator:
+                type: DefaultPaginator
+                page_size_option:
+                  inject_into: request_parameter
+                  field_name: page_size
+                page_token_option:
+                  inject_into: path
+                  type: RequestPath
+                pagination_strategy:
+                  type: "CursorPagination"
+                  cursor_value: "{{ response._metadata.next }}"
+                  page_size: 10
+              requester:
+                $ref: "#/requester"
+                path: "{{ next_page_token['next_page_url'] }}"
+              record_selector:
+                $ref: "#/selector"
+            $parameters:
+              name: "lists_parent"
+              primary_key: "id"
+              extractor:
+                $ref: "#/extractor"
+                field_path: [ "{{ parameters['name'] }}" ]
     status_mapping:
       failed:
         - Error


### PR DESCRIPTION
## Initial scope...
Pass state transformations to concurrent cursor flow creation for async retriever with stream slicer flow.

Resolves https://github.com/airbytehq/airbyte-internal-issues/issues/13019

## But Also!
If we try to apply a transformation to the stream_state that already represents the cursor for the partition we can end up with things like happening [here](https://github.com/airbytehq/airbyte-python-cdk/blob/main/airbyte_cdk/sources/declarative/migrations/legacy_to_per_partition_state_migration.py#L93-L98):

From
````
{'TimePeriod': '2025-05-12T08:00:00+00:00'}
````

To:
```

{
"states": [
      {
         'cursor': '2025-05-12T08:00:00+00:00', 
         'partition': {'account_id': 'TimePeriod'}
      }
   ]
}
```

Then I'm falling False if the internal stream_state items value is not a dict, according to the docstrings:

```
        The expected state format is
        "<parent_key_id>" : {
          "<cursor_field>" : "<cursor_value>"
        }
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for state migration to ensure only correctly formatted partitioned states are processed.

- **New Features**
  - Added support for applying state migrations to streams using async retrievers in addition to simple retrievers.
  - Enhanced configuration options for partition routing by supporting hierarchical (parent-child) stream relationships.

- **Tests**
  - Expanded test coverage for state migration logic, including new scenarios for both legacy and newest state formats, and updated error message assertions for retriever compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->