### PR TITLE
fix: remove unit_tests directory from coverage report and add handling of tmp files

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -9,3 +9,13 @@ omit =
 
     # omit as unimplemented
     airbyte_cdk/base_python/cdk/streams/auth/jwt.py
+
+    # omit temporary files and test files
+    /tmp/tmp*.py
+    unit_tests/*
+
+[paths]
+# Reconcile file paths
+source =
+    ./
+    /tmp/


### PR DESCRIPTION
## What

Trying to address CI failures in #556, where Pytest steps are failing on the coverage report step despite the test suites passing.

```
Run poetry run coverage report
poetry run coverage report
shell: /usr/bin/bash -e {0}
env:
pythonLocation: /opt/hostedtoolcache/Python/3.10.17/x64
PKG_CONFIG_PATH: /opt/hostedtoolcache/Python/3.10.17/x64/lib/pkgconfig
Python_ROOT_DIR: /opt/hostedtoolcache/Python/3.10.17/x64
Python2_ROOT_DIR: /opt/hostedtoolcache/Python/3.10.17/x64
Python3_ROOT_DIR: /opt/hostedtoolcache/Python/3.10.17/x64
LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.10.17/x64/lib
No source for code: '/tmp/tmpguw0ee8u.py'.
Error: Process completed with exit code 1.
```

Link to failure: https://github.com/airbytehq/airbyte-python-cdk/actions/runs/15118605619/job/42495441682?pr=556

This PR fixes CI coverage report errors by updating the `.coveragerc` configuration to properly handle temporary files and establish correct path mappings. Also excludes test files from the coverage report.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated coverage settings to exclude temporary and test files from coverage reports.
  - Adjusted source paths for improved coverage reporting accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._