### PR TITLE
feat(dynamic-streams): Add StateDelegatingStream to DynamicDeclarativeStream

### DIFF
--- a/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -4085,7 +4085,9 @@ definitions:
       stream_template:
         title: Stream Template
         description: Reference to the stream template.
-        "$ref": "#/definitions/DeclarativeStream"
+        anyOf:
+          - "$ref": "#/definitions/DeclarativeStream"
+          - "$ref": "#/definitions/StateDelegatingStream"
       components_resolver:
         title: Components Resolver
         description: Component resolve and populates stream templates with components values.

--- a/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
+++ b/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
@@ -2738,7 +2738,7 @@ class DynamicDeclarativeStream(BaseModel):
     name: Optional[str] = Field(
         "", description="The dynamic stream name.", example=["Tables"], title="Name"
     )
-    stream_template: DeclarativeStream = Field(
+    stream_template: Union[DeclarativeStream, StateDelegatingStream] = Field(
         ..., description="Reference to the stream template.", title="Stream Template"
     )
     components_resolver: Union[HttpComponentsResolver, ConfigComponentsResolver] = Field(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded support for stream templates in dynamic declarative streams, allowing both standard and state-delegating stream types for greater flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->