### PR TITLE
refactor: connectors can launch themselves; deprecate: `AirbyteEntrypoint` and `launch()`

### DIFF
--- a/airbyte_cdk/cli/source_declarative_manifest/_run.py
+++ b/airbyte_cdk/cli/source_declarative_manifest/_run.py
@@ -45,6 +45,7 @@ from airbyte_cdk.sources.declarative.concurrent_declarative_source import (
 )
 from airbyte_cdk.sources.declarative.yaml_declarative_source import YamlDeclarativeSource
 from airbyte_cdk.sources.source import TState
+from airbyte_cdk.utils.cli_arg_parse import parse_cli_args
 from airbyte_cdk.utils.datetime_helpers import ab_datetime_now
 
 
@@ -93,7 +94,7 @@ def handle_command(args: list[str]) -> None:
 
 def _get_local_yaml_source(args: list[str]) -> SourceLocalYaml:
     try:
-        parsed_args = AirbyteEntrypoint.parse_args(args)
+        parsed_args = parse_cli_args(args)
         config, catalog, state = _parse_inputs_into_config_catalog_state(parsed_args)
         return SourceLocalYaml(config=config, catalog=catalog, state=state)
     except Exception as error:
@@ -119,10 +120,7 @@ def _get_local_yaml_source(args: list[str]) -> SourceLocalYaml:
 
 def handle_local_manifest_command(args: list[str]) -> None:
     source = _get_local_yaml_source(args)
-    launch(
-        source=source,
-        args=args,
-    )
+    source.launch_with_cli_args(args)
 
 
 def handle_remote_manifest_command(args: list[str]) -> None:
@@ -149,10 +147,7 @@ def handle_remote_manifest_command(args: list[str]) -> None:
         print(AirbyteEntrypoint.airbyte_message_to_string(message))
     else:
         source = create_declarative_source(args)
-        launch(
-            source=source,
-            args=args,
-        )
+        source.launch_with_cli_args(args=args)
 
 
 def create_declarative_source(
@@ -169,7 +164,7 @@ def create_declarative_source(
         catalog: ConfiguredAirbyteCatalog | None
         state: list[AirbyteStateMessage]
 
-        parsed_args = AirbyteEntrypoint.parse_args(args)
+        parsed_args = parse_cli_args(args)
         config, catalog, state = _parse_inputs_into_config_catalog_state(parsed_args)
 
         if config is None:

--- a/airbyte_cdk/connector.py
+++ b/airbyte_cdk/connector.py
@@ -8,7 +8,10 @@ import logging
 import os
 import pkgutil
 from abc import ABC, abstractmethod
-from typing import Any, Generic, Mapping, MutableMapping, Optional, Protocol, TypeVar
+from email import message
+from io import StringIO
+from pathlib import Path
+from typing import Any, Generic, Mapping, Optional, Self, TypeVar
 
 import yaml
 
@@ -17,14 +20,21 @@ from airbyte_cdk.models import (
     ConnectorSpecification,
     ConnectorSpecificationSerializer,
 )
+from airbyte_cdk.models.airbyte_protocol import AirbyteMessage, Type
+from airbyte_cdk.sources.message.repository import MessageRepository, PassthroughMessageRepository
+from airbyte_cdk.test.entrypoint_wrapper import EntrypointOutput
+from airbyte_cdk.utils.cli_arg_parse import ConnectorCLIArgs, parse_cli_args
 
 
-def load_optional_package_file(package: str, filename: str) -> Optional[bytes]:
+def _load_optional_package_file(package: str, filename: str) -> Optional[bytes]:
     """Gets a resource from a package, returning None if it does not exist"""
     try:
         return pkgutil.get_data(package, filename)
     except FileNotFoundError:
         return None
+
+def _write_config(config: Mapping[str, Any], config_path: str) -> None:
+    Path(config_path).write_text(json.dumps(config))
 
 
 TConfig = TypeVar("TConfig", bound=Mapping[str, Any])
@@ -35,37 +45,19 @@ class BaseConnector(ABC, Generic[TConfig]):
     check_config_against_spec: bool = True
 
     @abstractmethod
-    def configure(self, config: Mapping[str, Any], temp_dir: str) -> TConfig:
-        """
-        Persist config in temporary directory to run the Source job
-        """
+    @classmethod
+    def to_typed_config(
+        cls,
+        config: Mapping[str, Any],
+    ) -> TConfig:
+        """Return a typed config object from a config dictionary."""
+        ...
 
-    @staticmethod
-    def read_config(config_path: str) -> MutableMapping[str, Any]:
-        config = BaseConnector._read_json_file(config_path)
-        if isinstance(config, MutableMapping):
-            return config
-        else:
-            raise ValueError(
-                f"The content of {config_path} is not an object and therefore is not a valid config. Please ensure the file represent a config."
-            )
-
-    @staticmethod
-    def _read_json_file(file_path: str) -> Any:
-        with open(file_path, "r") as file:
-            contents = file.read()
-
-        try:
-            return json.loads(contents)
-        except json.JSONDecodeError as error:
-            raise ValueError(
-                f"Could not read json file {file_path}: {error}. Please ensure that it is a valid JSON."
-            )
-
-    @staticmethod
-    def write_config(config: TConfig, config_path: str) -> None:
-        with open(config_path, "w") as fh:
-            fh.write(json.dumps(config))
+    @classmethod
+    def configure(cls, config: Mapping[str, Any], temp_dir: str) -> TConfig:
+        config_path = os.path.join(temp_dir, "config.json")
+        _write_config(config, config_path)
+        return cls.to_typed_config(config)
 
     def spec(self, logger: logging.Logger) -> ConnectorSpecification:
         """
@@ -75,8 +67,8 @@ class BaseConnector(ABC, Generic[TConfig]):
 
         package = self.__class__.__module__.split(".")[0]
 
-        yaml_spec = load_optional_package_file(package, "spec.yaml")
-        json_spec = load_optional_package_file(package, "spec.json")
+        yaml_spec = _load_optional_package_file(package, "spec.yaml")
+        json_spec = _load_optional_package_file(package, "spec.json")
 
         if yaml_spec and json_spec:
             raise RuntimeError(
@@ -104,20 +96,61 @@ class BaseConnector(ABC, Generic[TConfig]):
         to the Stripe API.
         """
 
+    @abstractmethod
+    @classmethod
+    def create_with_cli_args(
+        cls,
+        cli_args: ConnectorCLIArgs,
+    ) -> Self:
+        """Return an instance of the connector, using the provided CLI args."""
+        ...
 
-class _WriteConfigProtocol(Protocol):
-    @staticmethod
-    def write_config(config: Mapping[str, Any], config_path: str) -> None: ...
+    @classmethod
+    def launch_with_cli_args(
+        cls,
+        args: list[str],
+        *,
+        logger: logging.Logger | None = None,
+        message_repository: MessageRepository | None = None,
+        # TODO: Add support for inputs:
+        # stdin: StringIO | MessageRepository | None = None,
+    ) -> None:
+        """Launches the connector with the provided configuration."""
+        logger = logger or logging.getLogger(f"airbyte.{type(cls).__name__}")
+        message_repository = message_repository or PassthroughMessageRepository()
+        parsed_cli_args: ConnectorCLIArgs = parse_cli_args(
+            args,
+            with_read=True if getattr(cls, "read", False) else False,
+            with_write=True if getattr(cls, "write", False) else False,
+            with_discover=True if getattr(cls, "discover", False) else False,
+        )
+        logger.info(f"Launching connector with args: {parsed_cli_args}")
+        verb = parsed_cli_args.command
 
-
-class DefaultConnectorMixin:
-    # can be overridden to change an input config
-    def configure(
-        self: _WriteConfigProtocol, config: Mapping[str, Any], temp_dir: str
-    ) -> Mapping[str, Any]:
-        config_path = os.path.join(temp_dir, "config.json")
-        self.write_config(config, config_path)
-        return config
-
-
-class Connector(DefaultConnectorMixin, BaseConnector[Mapping[str, Any]], ABC): ...
+        spec: ConnectorSpecification
+        if verb == "check":
+            config = cls.to_typed_config(parsed_cli_args.get_config_dict())
+            connector = cls.create_with_cli_args(parsed_cli_args)
+            connector.check(logger, config)
+        elif verb == "spec":
+            connector = cls()
+            spec = connector.spec(logger)
+            message_repository.emit_message(
+                AirbyteMessage(
+                    type=Type.SPEC,
+                    spec=spec,
+                )
+            )
+        elif verb == "discover":
+            connector = cls()
+            spec = connector.spec(logger)
+            print(json.dumps(spec.to_dict(), indent=2))
+        elif verb == "read":
+            # Implementation for reading data goes here
+            pass
+        elif verb == "write":
+            # Implementation for writing data goes here
+            pass
+        else:
+            raise ValueError(f"Unknown command: {verb}")
+        # Implementation for launching the connector goes here

--- a/airbyte_cdk/connector_builder/main.py
+++ b/airbyte_cdk/connector_builder/main.py
@@ -27,6 +27,7 @@ from airbyte_cdk.models import (
 )
 from airbyte_cdk.sources.declarative.manifest_declarative_source import ManifestDeclarativeSource
 from airbyte_cdk.sources.source import Source
+from airbyte_cdk.utils.cli_arg_parse import parse_cli_args
 from airbyte_cdk.utils.traced_exception import AirbyteTracedException
 
 
@@ -35,7 +36,7 @@ def get_config_and_catalog_from_args(
 ) -> Tuple[str, Mapping[str, Any], Optional[ConfiguredAirbyteCatalog], Any]:
     # TODO: Add functionality for the `debug` logger.
     #  Currently, no one `debug` level log will be displayed during `read` a stream for a connector created through `connector-builder`.
-    parsed_args = AirbyteEntrypoint.parse_args(args)
+    parsed_args = parse_cli_args(args)
     config_path, catalog_path, state_path = (
         parsed_args.config,
         parsed_args.catalog,

--- a/airbyte_cdk/models/airbyte_protocol.py
+++ b/airbyte_cdk/models/airbyte_protocol.py
@@ -2,9 +2,10 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
 
-from dataclasses import InitVar, dataclass
+from dataclasses import InitVar, asdict, dataclass
 from typing import Annotated, Any, Dict, List, Mapping, Optional, Union
 
+import orjson
 from airbyte_protocol_dataclasses.models import *  # noqa: F403  # Allow '*'
 from serpyco_rs.metadata import Alias
 
@@ -86,3 +87,9 @@ class AirbyteMessage:
     state: Optional[AirbyteStateMessage] = None
     trace: Optional[AirbyteTraceMessage] = None  # type: ignore [name-defined]
     control: Optional[AirbyteControlMessage] = None  # type: ignore [name-defined]
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+    def to_string(self) -> str:
+        return orjson.dumps(self.to_dict()).decode("utf-8")

--- a/airbyte_cdk/test/entrypoint_wrapper.py
+++ b/airbyte_cdk/test/entrypoint_wrapper.py
@@ -44,6 +44,7 @@ from airbyte_cdk.models import (
     Type,
 )
 from airbyte_cdk.sources import Source
+from airbyte_cdk.utils.cli_arg_parse import ConnectorCLIArgs, parse_cli_args
 
 
 class EntrypointOutput:
@@ -166,7 +167,7 @@ def _run_command(
     parent_logger = logging.getLogger("")
     parent_logger.addHandler(stream_handler)
 
-    parsed_args = AirbyteEntrypoint.parse_args(args)
+    parsed_args: ConnectorCLIArgs = parse_cli_args(args)
 
     source_entrypoint = AirbyteEntrypoint(source)
     messages = []

--- a/airbyte_cdk/utils/cli_arg_parse.py
+++ b/airbyte_cdk/utils/cli_arg_parse.py
@@ -1,0 +1,193 @@
+# Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+"""CLI Argument Parsing Utilities."""
+
+
+import argparse
+import json
+from collections.abc import MutableMapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+def _read_json_file(
+    file_path: Path | str,
+) -> dict[str, Any]:
+    """Read a JSON file and return its contents as a dictionary.
+
+    Raises ValueError if the file cannot be read or is not valid JSON.
+    """
+    file_text = Path(file_path).read_text()
+
+    try:
+        return json.loads(file_text)
+    except json.JSONDecodeError as error:
+        raise ValueError(
+            f"Could not read json file {file_path}: {error}. Please ensure that it is a valid JSON."
+        )
+
+
+@dataclass(kw_only=True)
+class ConnectorCLIArgs:
+    command: str
+    debug: bool
+    config: str | None = None
+    state: str | None = None
+    catalog: str | None = None
+    manifest_path: str | None = None
+    components_path: str | None = None
+
+    def get_config_dict(
+        self,
+        *,
+        allow_missing: bool = False,
+    ) -> MutableMapping[str, Any]:
+        """Read the config file and return its contents as a dictionary.
+
+        If allow_missing is True, return an empty dictionary when the config file is not provided.
+        """
+        if self.config is None:
+            if not allow_missing:
+                raise ValueError("Config file path is required.")
+
+            return {}
+
+        config = _read_json_file(self.config)
+        if isinstance(config, MutableMapping):
+            return config
+        else:
+            raise ValueError(
+                f"The content of {self.config} is not an object and therefore is not a valid config. Please ensure the file represent a config."
+            )
+
+
+def parse_cli_args(
+    args: list[str],
+    *,
+    with_read: bool = True,
+    with_discover: bool = True,
+    with_write: bool = False,
+) -> ConnectorCLIArgs:
+    """Return the parsed CLI arguments for the connector.
+
+    The caller can validate the arguments and use them as needed. This function allows all possible
+    arguments to be passed in, but the caller should only use the ones that are relevant to the
+    command being executed. By default, we expect a typical "source" configuration.
+
+    Optionally, caller may specify command availability by overriding the `with` flags.
+    """
+    # set up parent parsers
+    parent_parser = argparse.ArgumentParser(add_help=False)
+    parent_parser.add_argument(
+        "--debug", action="store_true", help="enables detailed debug logs related to the sync"
+    )
+    main_parser = argparse.ArgumentParser()
+    subparsers = main_parser.add_subparsers(
+        title="commands",
+        dest="command",
+        required=True,
+    )
+
+    # spec
+    subparsers.add_parser(
+        "spec", help="outputs the json configuration specification", parents=[parent_parser]
+    )
+
+    # check
+    check_parser = subparsers.add_parser(
+        "check", help="checks the config can be used to connect", parents=[parent_parser]
+    )
+    required_check_parser = check_parser.add_argument_group("required named arguments")
+    required_check_parser.add_argument(
+        "--config", type=str, required=True, help="path to the json configuration file"
+    )
+    check_parser.add_argument(
+        "--manifest-path",
+        type=str,
+        required=False,
+        help="path to the YAML manifest file to inject into the config",
+    )
+    check_parser.add_argument(
+        "--components-path",
+        type=str,
+        required=False,
+        help="path to the custom components file, if it exists",
+    )
+
+    if with_discover:
+        discover_parser = subparsers.add_parser(
+            "discover",
+            help="outputs a catalog describing the source's schema",
+            parents=[parent_parser],
+        )
+        required_discover_parser = discover_parser.add_argument_group("required named arguments")
+        required_discover_parser.add_argument(
+            "--config", type=str, required=True, help="path to the json configuration file"
+        )
+        discover_parser.add_argument(
+            "--manifest-path",
+            type=str,
+            required=False,
+            help="path to the YAML manifest file to inject into the config",
+        )
+        discover_parser.add_argument(
+            "--components-path",
+            type=str,
+            required=False,
+            help="path to the custom components file, if it exists",
+        )
+
+    if with_read:
+        read_parser = subparsers.add_parser(
+            "read", help="reads the source and outputs messages to STDOUT", parents=[parent_parser]
+        )
+
+        read_parser.add_argument(
+            "--state", type=str, required=False, help="path to the json-encoded state file"
+        )
+        required_read_parser = read_parser.add_argument_group("required named arguments")
+        required_read_parser.add_argument(
+            "--config", type=str, required=True, help="path to the json configuration file"
+        )
+        required_read_parser.add_argument(
+            "--catalog",
+            type=str,
+            required=True,
+            help="path to the catalog used to determine which data to read",
+        )
+        read_parser.add_argument(
+            "--manifest-path",
+            type=str,
+            required=False,
+            help="path to the YAML manifest file to inject into the config",
+        )
+        read_parser.add_argument(
+            "--components-path",
+            type=str,
+            required=False,
+            help="path to the custom components file, if it exists",
+        )
+
+    if with_write:
+        # write
+        write_parser = subparsers.add_parser(
+            "write", help="Writes data to the destination", parents=[parent_parser]
+        )
+        write_required = write_parser.add_argument_group("required named arguments")
+        write_required.add_argument(
+            "--config", type=str, required=True, help="path to the JSON configuration file"
+        )
+        write_required.add_argument(
+            "--catalog", type=str, required=True, help="path to the configured catalog JSON file"
+        )
+
+    parsed_args: argparse.Namespace = main_parser.parse_args(args)
+    return ConnectorCLIArgs(
+        command=parsed_args.command,
+        debug=parsed_args.debug,
+        config=parsed_args.config,
+        state=parsed_args.state,
+        catalog=parsed_args.catalog,
+        manifest_path=parsed_args.manifest_path,
+        components_path=parsed_args.components_path,
+    )

--- a/cdk-migrations.md
+++ b/cdk-migrations.md
@@ -1,5 +1,17 @@
 # CDK Migration Guide
 
+## Upgrading to 6.XX.YY
+
+This version deprecates (but does not remove) the AirbyteEntrypoint class and related methods.
+Deprecation warnings will be emitted beginning in this version if `launch()` is called, or any
+other now-deprecated methods or classes.
+
+Beginning in this version, all connectors have a `launch_with_cli_args()` class method, which
+can be called directly from the class itself.
+
+Most connector classes will not need to modify this class method, although it can be overriden as
+needed, if any custom behavior is required.
+
 ## Upgrading to 6.34.0
 
 [Version 6.34.0](https://github.com/airbytehq/airbyte-python-cdk/releases/tag/v6.34.0) of the CDK removes support for `stream_state` in the Jinja interpolation context. This change is breaking for any low-code connectors that use `stream_state` in the interpolation context.

--- a/debug_manifest/debug_manifest.py
+++ b/debug_manifest/debug_manifest.py
@@ -19,7 +19,7 @@ def debug_manifest(source: YamlDeclarativeSource, args: list[str]) -> None:
     """
     Run the debug manifest with the given source and arguments.
     """
-    launch(source, args)
+    source.launch_with_cli_args(args)
 
 
 if __name__ == "__main__":

--- a/unit_tests/destinations/test_destination.py
+++ b/unit_tests/destinations/test_destination.py
@@ -32,6 +32,7 @@ from airbyte_cdk.models import (
     SyncMode,
     Type,
 )
+from airbyte_cdk.utils.cli_arg_parse import ConnectorCLIArgs, parse_cli_args
 
 
 @pytest.fixture(name="destination")
@@ -57,7 +58,7 @@ class TestArgParsing:
     def test_successful_parse(
         self, arg_list: List[str], expected_output: Mapping[str, Any], destination: Destination
     ):
-        parsed_args = vars(destination.parse_args(arg_list))
+        parsed_args: ConnectorCLIArgs = parse_cli_args(arg_list)
         assert parsed_args == expected_output, (
             f"Expected parsing {arg_list} to return parsed args {expected_output} but instead found {parsed_args}"
         )
@@ -80,7 +81,7 @@ class TestArgParsing:
         # We use BaseException because it encompasses SystemExit (raised by failed parsing) and other exceptions (raised by additional semantic
         # checks)
         with pytest.raises(BaseException):
-            destination.parse_args(arg_list)
+            parse_cli_args(arg_list)
 
 
 def _state(state: Dict[str, Any]) -> AirbyteStateMessage:
@@ -156,7 +157,6 @@ class TestRun:
         destination: Destination,
     ) -> None:
         mocker.patch.object(destination_module, "init_uncaught_exception_handler")
-        mocker.patch.object(destination, "parse_args")
         mocker.patch.object(destination, "run_cmd")
         destination.run(["dummy"])
         destination_module.init_uncaught_exception_handler.assert_called_once_with(

--- a/unit_tests/sources/file_based/test_scenarios.py
+++ b/unit_tests/sources/file_based/test_scenarios.py
@@ -227,10 +227,7 @@ def verify_check(
 
 
 def spec(capsys: CaptureFixture[str], scenario: TestScenario[AbstractSource]) -> Mapping[str, Any]:
-    launch(
-        scenario.source,
-        ["spec"],
-    )
+    scenario.source.launch_with_cli_args(["spec"])
     captured = capsys.readouterr()
     return json.loads(captured.out.splitlines()[0])["spec"]  # type: ignore
 
@@ -238,10 +235,11 @@ def spec(capsys: CaptureFixture[str], scenario: TestScenario[AbstractSource]) ->
 def check(
     capsys: CaptureFixture[str], tmp_path: PosixPath, scenario: TestScenario[AbstractSource]
 ) -> Dict[str, Any]:
-    launch(
-        scenario.source,
-        ["check", "--config", make_file(tmp_path / "config.json", scenario.config)],
-    )
+    scenario.source.launch_with_cli_args([
+        "check",
+        "--config",
+        make_file(tmp_path / "config.json", scenario.config),
+    ])
     captured = capsys.readouterr()
     return _find_connection_status(captured.out.splitlines())
 
@@ -257,8 +255,7 @@ def _find_connection_status(output: List[str]) -> Mapping[str, Any]:
 def discover(
     capsys: CaptureFixture[str], tmp_path: PosixPath, scenario: TestScenario[AbstractSource]
 ) -> Dict[str, Any]:
-    launch(
-        scenario.source,
+    scenario.source.launch_with_cli_args(
         ["discover", "--config", make_file(tmp_path / "config.json", scenario.config)],
     )
     output = [json.loads(line) for line in capsys.readouterr().out.splitlines()]

--- a/unit_tests/sources/test_integration_source.py
+++ b/unit_tests/sources/test_integration_source.py
@@ -77,11 +77,11 @@ def test_external_request_source(
             args = ["read", "--config", "config.json", "--catalog", "configured_catalog.json"]
             if expected_error:
                 with pytest.raises(AirbyteTracedException):
-                    launch(source, args)
+                    source.launch_with_cli_args(args)
                     messages = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
                     assert contains_error_trace_message(messages, expected_error)
             else:
-                launch(source, args)
+                source.launch_with_cli_args(args)
 
 
 @pytest.mark.parametrize(
@@ -138,11 +138,11 @@ def test_external_oauth_request_source(
         args = ["read", "--config", "config.json", "--catalog", "configured_catalog.json"]
         if expected_error:
             with pytest.raises(AirbyteTracedException):
-                launch(source, args)
+                source.launch_with_cli_args(args)
                 messages = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
                 assert contains_error_trace_message(messages, expected_error)
         else:
-            launch(source, args)
+            source.launch_with_cli_args(args)
 
 
 def contains_error_trace_message(messages: List[Mapping[str, Any]], expected_error: str) -> bool:


### PR DESCRIPTION
Request: Early Feedback.

Goal here is to detangle the tightly-coupled interdependencies:
- `AirbyteEntrypoint` class
- `launch()` method
- `Connector` and `Source` classes themselves.

