### PR TITLE
feat: adds config_path to source instantiation for sdm, enabling config migrations

### DIFF
--- a/airbyte_cdk/cli/source_declarative_manifest/_run.py
+++ b/airbyte_cdk/cli/source_declarative_manifest/_run.py
@@ -95,7 +95,12 @@ def _get_local_yaml_source(args: list[str]) -> SourceLocalYaml:
     try:
         parsed_args = AirbyteEntrypoint.parse_args(args)
         config, catalog, state = _parse_inputs_into_config_catalog_state(parsed_args)
-        return SourceLocalYaml(config=config, catalog=catalog, state=state)
+        return SourceLocalYaml(
+            config=config,
+            catalog=catalog,
+            state=state,
+            config_path=parsed_args.config if hasattr(parsed_args, "config") else None,
+        )
     except Exception as error:
         print(
             orjson.dumps(
@@ -204,6 +209,7 @@ def create_declarative_source(
             catalog=catalog,
             state=state,
             source_config=cast(dict[str, Any], config["__injected_declarative_manifest"]),
+            config_path=parsed_args.config if hasattr(parsed_args, "config") else None,
         )
     except Exception as error:
         print(


### PR DESCRIPTION
## What
- Updates source-declarative-manifest to inject the config_path to the source, enabling config migrations as part of this epic: https://github.com/airbytehq/airbyte-internal-issues/issues/12530



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for specifying an optional configuration file path when running sources from local YAML files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->