### PR TITLE
feat(substream-partition-router): flag to ignore parent slice

### DIFF
--- a/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -3881,6 +3881,11 @@ definitions:
         type: array
         items:
           "$ref": "#/definitions/ParentStreamConfig"
+      include_parent_slice:
+        title: Include Parent Slice
+        description: If False, the parent stream slice will not be included in the child stream slice.
+        type: boolean
+        default: true
       $parameters:
         type: object
         additionalProperties: true

--- a/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
+++ b/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
@@ -2867,6 +2867,10 @@ class SubstreamPartitionRouter(BaseModel):
         description="Specifies which parent streams are being iterated over and how parent records should be used to partition the child stream data set.",
         title="Parent Stream Configs",
     )
+    include_parent_slice: Optional[bool] = Field(True,
+                                                 description="If False, the parent stream slice will not be included in the child stream slice.",
+                                                 title="Include Parent Slice",
+                                                 )
     parameters: Optional[Dict[str, Any]] = Field(None, alias="$parameters")
 
 

--- a/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
+++ b/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
@@ -2867,10 +2867,11 @@ class SubstreamPartitionRouter(BaseModel):
         description="Specifies which parent streams are being iterated over and how parent records should be used to partition the child stream data set.",
         title="Parent Stream Configs",
     )
-    include_parent_slice: Optional[bool] = Field(True,
-                                                 description="If False, the parent stream slice will not be included in the child stream slice.",
-                                                 title="Include Parent Slice",
-                                                 )
+    include_parent_slice: Optional[bool] = Field(
+        True,
+        description="If False, the parent stream slice will not be included in the child stream slice.",
+        title="Include Parent Slice",
+    )
     parameters: Optional[Dict[str, Any]] = Field(None, alias="$parameters")
 
 

--- a/airbyte_cdk/sources/declarative/partition_routers/substream_partition_router.py
+++ b/airbyte_cdk/sources/declarative/partition_routers/substream_partition_router.py
@@ -89,6 +89,7 @@ class SubstreamPartitionRouter(PartitionRouter):
     parent_stream_configs: List[ParentStreamConfig]
     config: Config
     parameters: InitVar[Mapping[str, Any]]
+    include_parent_slice: Optional[bool] = True
 
     def __post_init__(self, parameters: Mapping[str, Any]) -> None:
         if not self.parent_stream_configs:
@@ -221,11 +222,15 @@ class SubstreamPartitionRouter(PartitionRouter):
                             **extracted_extra_fields,
                         }
 
-                    yield StreamSlice(
-                        partition={
+                    slice_partition = {
                             partition_field: partition_value,
-                            "parent_slice": parent_partition or {},
-                        },
+                        }
+
+                    if self.include_parent_slice:
+                        slice_partition["parent_slice"] = parent_partition or {}
+
+                    yield StreamSlice(
+                        partition=slice_partition,
                         cursor_slice={},
                         extra_fields=extracted_extra_fields,
                     )

--- a/airbyte_cdk/sources/declarative/partition_routers/substream_partition_router.py
+++ b/airbyte_cdk/sources/declarative/partition_routers/substream_partition_router.py
@@ -223,8 +223,8 @@ class SubstreamPartitionRouter(PartitionRouter):
                         }
 
                     slice_partition = {
-                            partition_field: partition_value,
-                        }
+                        partition_field: partition_value,
+                    }
 
                     if self.include_parent_slice:
                         slice_partition["parent_slice"] = parent_partition or {}


### PR DESCRIPTION
Legacy bing-ads state doesn't keep track of the parent slice but[ SustreamPartitionRouter adds it](https://github.com/airbytehq/airbyte-python-cdk/blob/4b73b463e8994bfd482fc5aef005d9079ab4545a/airbyte_cdk/sources/declarative/partition_routers/substream_partition_router.py#L227) by default, so, even when the [LegacyToPerPartitionStateMigration formats correctly](https://github.com/airbytehq/airbyte-python-cdk/blob/main/airbyte_cdk/sources/declarative/migrations/legacy_to_per_partition_state_migration.py#L97-L102) the new state, the ConcurrentPerPartitionCursor wont be able to find the partition key [here](https://github.com/airbytehq/airbyte-python-cdk/blob/main/airbyte_cdk/sources/declarative/incremental/concurrent_partition_cursor.py#L278-L279) because of this difference.

I have a workaround with a custom [LegacyToPerPartitionStateMigrationWithParentSlice](https://github.com/airbytehq/airbyte/pull/59750/commits/414b6b64cc236c239388deec52221003f8c03549), but honestly it seems fair easier to just ignore the parent slice if we don't need it.

Samples of Legacy state:
![image](https://github.com/user-attachments/assets/63061f44-0efe-4071-939e-701179507f25)
![image](https://github.com/user-attachments/assets/ab21344c-3923-4a98-8223-b0a1daab6997)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an option to control whether parent stream slice information is included in child stream slices for substream partitioning.

- **Tests**
  - Introduced new test cases to verify correct behavior when parent slice information is excluded from child stream slices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->