### PR TITLE
feat(cdk): add option to make empty cells None when parsing csv with CsvParser

### DIFF
--- a/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -3630,6 +3630,9 @@ definitions:
       delimiter:
         type: string
         default: ","
+      set_empty_cell_to_none:
+        type: boolean
+        default: false
   AsyncJobStatusMap:
     description: Matches the api job status to Async Job Status.
     type: object

--- a/airbyte_cdk/sources/declarative/decoders/composite_raw_decoder.py
+++ b/airbyte_cdk/sources/declarative/decoders/composite_raw_decoder.py
@@ -103,6 +103,7 @@ class CsvParser(Parser):
     # TODO: migrate implementation to re-use file-base classes
     encoding: Optional[str] = "utf-8"
     delimiter: Optional[str] = ","
+    set_empty_cell_to_none: Optional[bool] = False
 
     def _get_delimiter(self) -> Optional[str]:
         """
@@ -121,6 +122,8 @@ class CsvParser(Parser):
         text_data = TextIOWrapper(data, encoding=self.encoding)  # type: ignore
         reader = csv.DictReader(text_data, delimiter=self._get_delimiter() or ",")
         for row in reader:
+            if self.set_empty_cell_to_none:
+                row = {k: (None if v == "" else v) for k, v in row.items()}
             yield row
 
 

--- a/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
+++ b/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
@@ -1383,6 +1383,7 @@ class CsvDecoder(BaseModel):
     type: Literal["CsvDecoder"]
     encoding: Optional[str] = "utf-8"
     delimiter: Optional[str] = ","
+    set_empty_cell_to_none: Optional[bool] = False
 
 
 class AsyncJobStatusMap(BaseModel):

--- a/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -2646,7 +2646,11 @@ class ModelToComponentFactory:
         elif isinstance(model, JsonlDecoderModel):
             return JsonLineParser()
         elif isinstance(model, CsvDecoderModel):
-            return CsvParser(encoding=model.encoding, delimiter=model.delimiter)
+            return CsvParser(
+                encoding=model.encoding,
+                delimiter=model.delimiter,
+                set_empty_cell_to_none=model.set_empty_cell_to_none,
+            )
         elif isinstance(model, GzipDecoderModel):
             return GzipParser(
                 inner_parser=ModelToComponentFactory._get_parser(model.decoder, config)

--- a/unit_tests/sources/declarative/decoders/test_composite_decoder.py
+++ b/unit_tests/sources/declarative/decoders/test_composite_decoder.py
@@ -51,12 +51,14 @@ def generate_csv(
         {"id": "2", "name": "Alice", "age": "34"},
         {"id": "3", "name": "Bob", "age": "25"},
     ]
+    fieldnames = ["id", "name", "age"]
     if add_empty_strings:
         for row in data:
             row["gender"] = ""
+        fieldnames.append("gender")
 
     output = StringIO()
-    writer = csv.DictWriter(output, fieldnames=["id", "name", "age"], delimiter=delimiter)
+    writer = csv.DictWriter(output, fieldnames=fieldnames, delimiter=delimiter)
     writer.writeheader()
     for row in data:
         writer.writerow(row)
@@ -282,7 +284,7 @@ def test_composite_raw_decoder_parse_empty_strings(requests_mock, set_empty_cell
         {"id": "3", "name": "Bob", "age": "25"},
     ]
     for expected_record in expected_data:
-        expected_recordp["gender"] = None if set_empty_cell_to_none else ""
+        expected_record["gender"] = None if set_empty_cell_to_none else ""
 
     parsed_records = list(composite_raw_decoder.decode(response))
     assert parsed_records == expected_data

--- a/unit_tests/sources/declarative/decoders/test_composite_decoder.py
+++ b/unit_tests/sources/declarative/decoders/test_composite_decoder.py
@@ -41,13 +41,19 @@ def compress_with_gzip(data: str, encoding: str = "utf-8"):
 
 
 def generate_csv(
-    encoding: str = "utf-8", delimiter: str = ",", should_compress: bool = False
+    encoding: str = "utf-8",
+    delimiter: str = ",",
+    should_compress: bool = False,
+    add_empty_strings: bool = False,
 ) -> bytes:
     data = [
         {"id": "1", "name": "John", "age": "28"},
         {"id": "2", "name": "Alice", "age": "34"},
         {"id": "3", "name": "Bob", "age": "25"},
     ]
+    if add_empty_strings:
+        for row in data:
+            row["gender"] = ""
 
     output = StringIO()
     writer = csv.DictWriter(output, fieldnames=["id", "name", "age"], delimiter=delimiter)
@@ -253,6 +259,30 @@ def test_composite_raw_decoder_csv_parser_values(requests_mock, encoding: str, d
         {"id": "2", "name": "Alice", "age": "34"},
         {"id": "3", "name": "Bob", "age": "25"},
     ]
+
+    parsed_records = list(composite_raw_decoder.decode(response))
+    assert parsed_records == expected_data
+
+
+@pytest.mark.parametrize("set_empty_cell_to_none", [True, False])
+def test_composite_raw_decoder_parse_empty_strings(requests_mock, set_empty_cell_to_none: bool):
+    requests_mock.register_uri(
+        "GET",
+        "https://airbyte.io/",
+        content=generate_csv(should_compress=False, add_empty_strings=True),
+    )
+    response = requests.get("https://airbyte.io/", stream=True)
+
+    parser = CsvParser(set_empty_cell_to_none=set_empty_cell_to_none)
+    composite_raw_decoder = CompositeRawDecoder(parser=parser)
+
+    expected_data = [
+        {"id": "1", "name": "John", "age": "28"},
+        {"id": "2", "name": "Alice", "age": "34"},
+        {"id": "3", "name": "Bob", "age": "25"},
+    ]
+    for expected_record in expected_data:
+        expected_recordp["gender"] = None if set_empty_cell_to_none else ""
 
     parsed_records = list(composite_raw_decoder.decode(response))
     assert parsed_records == expected_data


### PR DESCRIPTION
Option to default values to None is an empty cell, when migrating to manifest and validating records, it is just easier to work with

```
{"type":"RECORD","record":{"stream":"labels","data":{"Type":"Label","Status":"Active","Id":"some_id","Modified Time":"04/27/2023 17:16:34.610","Description":"my label new label","Label":"integration-test-label","Color":"#F89CAF"},"emitted_at":1748901881365}}

```

Rather:

```
{"type":"RECORD","record":{"stream":"labels","data":{"Type":"Label","Status":"Active","Id":"some_id","Parent Id":"","Campaign Id":"","Sub Type":"","Campaign":"","Ad Group":"","Asset Group":"","Website":"","Sync Time":"","Client Id":"","Modified Time":"04/27/2023 17:16:34.610","MSCLKID Auto Tagging Enabled":"","Include View Through Conversions":"","Profile Expansion Enabled":"","Features":"","Tracking Template":"","Final Url Suffix":"","Custom Parameter":"","Final Url":"","Mobile Final Url":"","Ad Click Parallel Tracking":"","Verified Tracking Setting":"","Verified Tracking Settings":"","Third Party Measurement Settings":"","Auto Apply Recommendations":"","Allow Image Auto Retrieve":"","Business Attributes":"","Blocked Segment Ids":"","Time Zone":"","Budget Id":"","Budget Name":"","Budget":"","Budget Type":"","Bid Strategy Id":"","Bid Strategy Name":"","Bid Strategy Type":"","Bid Strategy MaxCpc":"","Bid Strategy TargetCpa":"","Bid Strategy TargetRoas":"","Bid Strategy TargetAdPosition":"","Bid Strategy TargetImpressionShare":"","Bid Strategy MaxCpm":"","Inherited Bid Strategy Type":"","KeywordVariantMatchEnabled":"","Campaign Type":"","Campaign Sub Type":"","Priority":"","LocalInventoryAdsEnabled":"","Campaign Goal":"","Is Lead Gen Campaign":"","ShoppableAdsEnabled":"","RSA Auto Generated Assets Enabled":"","Predictive Targeting Enabled":"","Automated Call To Action Opt Out":"","Call To Action Opt Out":"","Destination Channel":"","Is Multi Channel Campaign":"","Is Broad Match Only Campaign":"","Is Deal Campaign":"","Use Campaign Level Dates":"","Should Serve On MSAN":"","Campaign Objective Type":"","Vanity Pharma Display URL Mode":"","Vanity Pharma Website Description":"","Enabled External Channel Sync":"","Start Date":"","End Date":"","Network Distribution":"","Ad Rotation":"","Cpc Bid":"","Cpm Bid":"","Cpv Bid":"","Mcpa Bid":"","Language":"","Target Setting":"","Privacy Status":"","Bid Option":"","Bid Boost Value":"","Ad Group Type":"","Hotel Ad Group Type":"","Percent Cpc Bid":"","Commission Rate":"","Placement":"","Canvas":"","Lead Gen SOV":"","Use Optimized Targeting":"","Use Predictive Targeting":"","Boost Publisher IDs":"","Boost Account IDs":"","Boost AdUnit IDs":"","Boost Trigger IDs":"","Frequency Cap Settings":"","First Party Bundles":"","Title":"","Text":"","Display Url":"","Domain":"","Destination Url":"","Business Name":"","Phone Number":"","Promotion":"","Editorial Status":"","Editorial Location":"","Editorial Term":"","Editorial Reason Code":"","Editorial Appeal Status":"","Editorial Entity Id":"","Device Preference":"","Ad Format Preference":"","Title Part 1":"","Title Part 2":"","Title Part 3":"","Text Part 2":"","Path 1":"","Path 2":"","Source Ad Id":"","Keyword":"","Match Type":"","Bid":"","Param1":"","Param2":"","Param3":"","Target":"","Physical Intent":"","Bid Adjustment":"","Radius Target Id":"","Name":"","OS Names":"","Radius":"","Unit":"","Business Id":"","From Hour":"","From Minute":"","To Hour":"","To Minute":"","Min Target Value":"","Max Target Value":"","Version":"","Ad Schedule":"","Use Searcher Time Zone":"","Sitelink Extension Order":"","Sitelink Extension Link Text":"","Sitelink Extension Destination Url":"","Sitelink Extension Description1":"","Sitelink Extension Description2":"","Geo Code Status":"","Map Icon":"","Business Icon":"","Address Line 1":"","Address Line 2":"","Postal Code":"","City":"","State Or Province Code":"","Province Name":"","Latitude":"","Longitude":"","StoreCode":"","SundayHours":"","MondayHours":"","TuesdayHours":"","WednesdayHours":"","ThursdayHours":"","FridayHours":"","SaturdayHours":"","SpecialHours":"","LogoPhotoURL":"","GoogleIdentifier":"","Country Code":"","Call Only":"","Call Tracking Enabled":"","Toll Free":"","Alternative Text":"","Media Ids":"","Display Text":"","Layouts":"","Publisher Countries":"","Store Id":"","Product Operator 1":"","Product Operator 2":"","Product Operator 3":"","Product Operator 4":"","Product Operator 5":"","Product Operator 6":"","Product Operator 7":"","Product Operator 8":"","Product Condition 1":"","Product Value 1":"","Product Condition 2":"","Product Value 2":"","Product Condition 3":"","Product Value 3":"","Product Condition 4":"","Product Value 4":"","Product Condition 5":"","Product Value 5":"","Product Condition 6":"","Product Value 6":"","Product Condition 7":"","Product Value 7":"","Action Text":"","Callout Text":"","Feed Id":"","Feed Type Id":"","Flyer Name":"","Media Urls":"","Action Name":"","Action Description":"","Corporate Image":"","Media Url":"","Form Headline":"","Form Business Name":"","Form Description":"","Form Policy Url":"","Form Questions":"","Confirmation Message":"","Confirmation Description":"","Confirmation Action":"","Confirmation Url":"","Lead Delivery":"","Lead Emails":"","Lead Webhook Url":"","Lead Webhook Key":"","Price Extension Type":"","Header 1":"","Header 2":"","Header 3":"","Header 4":"","Header 5":"","Header 6":"","Header 7":"","Header 8":"","Price Description 1":"","Price Description 2":"","Price Description 3":"","Price Description 4":"","Price Description 5":"","Price Description 6":"","Price Description 7":"","Price Description 8":"","Final Url 1":"","Final Url 2":"","Final Url 3":"","Final Url 4":"","Final Url 5":"","Final Url 6":"","Final Url 7":"","Final Url 8":"","Final Mobile Url 1":"","Final Mobile Url 2":"","Final Mobile Url 3":"","Final Mobile Url 4":"","Final Mobile Url 5":"","Final Mobile Url 6":"","Final Mobile Url 7":"","Final Mobile Url 8":"","Price 1":"","Price 2":"","Price 3":"","Price 4":"","Price 5":"","Price 6":"","Price 7":"","Price 8":"","Currency Code 1":"","Currency Code 2":"","Currency Code 3":"","Currency Code 4":"","Currency Code 5":"","Currency Code 6":"","Currency Code 7":"","Currency Code 8":"","Price Unit 1":"","Price Unit 2":"","Price Unit 3":"","Price Unit 4":"","Price Unit 5":"","Price Unit 6":"","Price Unit 7":"","Price Unit 8":"","Price Qualifier 1":"","Price Qualifier 2":"","Price Qualifier 3":"","Price Qualifier 4":"","Price Qualifier 5":"","Price Qualifier 6":"","Price Qualifier 7":"","Price Qualifier 8":"","Promotion Target":"","Discount Modifier":"","Percent Off":"","Money Amount Off":"","Promotion Code":"","Orders Over Amount":"","Occasion":"","Promotion Start":"","Promotion End":"","Currency Code":"","Is Exact":"","Video Id":"","Thumbnail Id":"","Video Status":"","Video Url":"","Business Logo":"","Domain Name":"","Structured Snippet Header":"","Structured Snippet Values":"","AdExtension Header Type":"","Texts":"","FeedLabel":"","Spend":"","Impressions":"","Clicks":"","CTR":"","Avg CPC":"","Avg CPM":"","Avg position":"","Conversions":"","CPA":"","Quality Score":"","Keyword Relevance":"","Landing Page Relevance":"","Landing Page User Experience":"","App Platform":"","App Id":"","Tracking Enabled":"","App Status":"","Error":"","Error Number":"","Field Path":"","Error Detail":"","Is Excluded":"","Parent Criterion Id":"","Audience":"","Audience Id":"","Scope":"","Membership Duration":"","UET Tag Id":"","Description":"my label new label","Remarketing Rule":"","Audience Search Size":"","Audience Network Size":"","Product Audience Type":"","Supported Campaign Types":"","Source Id":"","Domain Language":"","Source":"","Dynamic Description Enabled":"","Dynamic Ad Target Condition 1":"","Dynamic Ad Target Condition 2":"","Dynamic Ad Target Condition 3":"","Dynamic Ad Target Condition Operator 1":"","Dynamic Ad Target Condition Operator 2":"","Dynamic Ad Target Condition Operator 3":"","Dynamic Ad Target Value 1":"","Dynamic Ad Target Value 2":"","Dynamic Ad Target Value 3":"","Label":"integration-test-label","Color":"#F89CAF","Microsoft Click Id":"","Conversion Name":"","Conversion Value":"","Conversion Time":"","Conversion Currency Code":"","Adjustment Value":"","Adjustment Time":"","Adjustment Currency Code":"","Adjustment Type":"","External Attribution Credit":"","External Attribution Model":"","Hashed Phone Number":"","Hashed Email Address":"","Transaction Id":"","Maximum Bid":"","Bid Multiplier Source":"","Call To Action":"","Call To Action Language":"","Call To Action Text":"","Headline":"","Long Headline":"","Landscape Image Media Id":"","Square Image Media Id":"","Landscape Logo Media Id":"","Square Logo Media Id":"","Images":"","Impression Tracking Urls":"","Videos":"","Ad Sub Type":"","Ad Strength":"","Ad Strength Action Items":"","Headlines":"","Long Headlines":"","Descriptions":"","Search Theme":"","HotSpots":"","Boost Anchors":"","Asset AI Enhancement Optout":"","Profile":"","Profile Id":"","Traffic Split Percent":"","Base Campaign Id":"","Experiment Campaign Id":"","Experiment Id":"","Experiment Type":"","Asset Group Target Condition 1":"","Asset Group Target Condition 2":"","Asset Group Target Condition 3":"","Asset Group Target Condition Operator 1":"","Asset Group Target Condition Operator 2":"","Asset Group Target Condition Operator 3":"","Asset Group Target Value 1":"","Asset Group Target Value 2":"","Asset Group Target Value 3":"","Category Id":"","Target Option Id":"","Feed Name":"","Custom Attributes":"","Page Feed Ids":"","Target Campaign Id":"","Target Ad Group Id":"","Schedule":"","Disclaimer Ads Enabled":"","Disclaimer Title":"","Disclaimer Name":"","Disclaimer Layout":"","Disclaimer Popup Text":"","Disclaimer Line Text":"","Ad Schedule Use Searcher Time Zone":"","Action Type":"","Combination Rule":"","Url":"","Height":"","Width":"","Aspect Ratio":"","Source Url":"","Thumbnail Url":"","Duration In Milliseconds":"","Video Bit Rate":"","Video File Size":"","Video Format":"","Cashback Percent":"","Cashback Monthly Budget":"","Cashback Scope":"","Personalized Offers Enabled":"","Personalized Coupons Enabled":"","Is Promotions For Brands":"","App Store":"","Multi Media Ad Bid Adjustment":"","Bid Strategy TargetCostPerSale":"","Bid Strategy PercentMaxCpc":"","Bid Strategy CommissionRate":"","Bid Strategy ManualCpi":"","Bid Strategy ManualCpc":"","Goal Id":"","AdCustomizer DataType":"","AdCustomizer AttributeValue":"","Smart Listing":"","Url Expansion Opt Out":"","Use MaxClicks":"","Auto Generated Text Assets Opt Out":"","Auto Generated Image Assets Opt Out":"","Cost Per Sale Opt Out":"","Condition 1":"","Condition 2":"","Condition 3":"","Value 1":"","Value 2":"","Value 3":"","Condition Operator 1":"","Condition Operator 2":"","Condition Operator 3":"","Is BSR Enabled":"","BSR Ad Distribution":"","Audience Group Id":"","Audience Group Name":"","Audiences":"","Age Ranges":"","Gender Types":"","Negative Audiences":"","Company Name":"","Job Function":"","Industry":"","Percent Bid":"","Hotel Attribute":"","Hotel Attribute Value":"","Parent Listing Group Id":"","Brand Id":"","Brand Name":"","Brand Url":"","Editorial Status Date":"","Attribution Model Type":"","Conversion Window In Minutes":"","Count Type":"","Exclude From Bidding":"","Goal Category":"","Is Enhanced Conversions Enabled":"","Revenue Type":"","Revenue Value":"","Tracking Status":"","View Through Conversion Window In Minutes":"","Minimum Duration In Second":"","Action Expression":"","Action Operator":"","Category Expression":"","Category Operator":"","Label Expression":"","Label Operator":"","Event Value":"","Event Value Operator":"","Is Externally Attributed":"","Minimum Pages Viewed":"","URL Expression":"","URL Operator":"","Seasonality Adjustment":"","Data Exclusion":"","Device Type":"","Campaign Associations":"","Impression Campaign Id":"","Impression Ad Group Id":"","Entity Type":"","Additional Conversion Value":"","New Customer Acquisition Goal Id":"","New Customer Acquisition Bid Only Mode":"","Conversion Value Rule Value":"","Conversion Value Rule Operator":"","Included Locations":"","Excluded Locations":"","Included Location Intent":"","Excluded Location Intent":"","Square Logos":"","Landscape Logos":"","Palettes":"","Fonts":"","Site List Item Url":"","Brand Color":"","Brand Logo":""},"emitted_at":1748907915040}}

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an option to treat empty cells in CSV files as null values during data import. Users can now configure whether empty strings in CSV data are interpreted as empty strings or as nulls.
- **Tests**
  - Introduced new tests to verify correct handling of empty cells in CSV data based on the new configuration option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->