### PR TITLE
feat: update `DpathValidator` to skip validation if returned value is falsy

### DIFF
--- a/airbyte_cdk/sources/declarative/validators/dpath_validator.py
+++ b/airbyte_cdk/sources/declarative/validators/dpath_validator.py
@@ -47,6 +47,8 @@ class DpathValidator(Validator):
         if "*" in path:
             try:
                 values = dpath.values(input_data, path)
+                if not values:
+                    return
                 for value in values:
                     self.strategy.validate(value)
             except KeyError as e:
@@ -54,6 +56,8 @@ class DpathValidator(Validator):
         else:
             try:
                 value = dpath.get(input_data, path)
+                if not value:
+                    return
                 self.strategy.validate(value)
             except KeyError as e:
                 raise ValueError(f"Error validating path '{self.field_path}': {e}")

--- a/unit_tests/sources/declarative/validators/test_dpath_validator.py
+++ b/unit_tests/sources/declarative/validators/test_dpath_validator.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+
 from unittest import TestCase
 
 import pytest
@@ -90,3 +92,13 @@ class TestDpathValidator(TestCase):
         assert strategy.validate_called
         assert strategy.validated_value in ["user1@example.com", "user2@example.com"]
         self.assertIn(strategy.validated_value, ["user1@example.com", "user2@example.com"])
+
+    def test_given_no_values_when_validate_then_validate_is_not_called(self):
+        strategy = MockValidationStrategy()
+        validator = DpathValidator(field_path=["users", "*", "email"], strategy=strategy)
+
+        validator.validate({"users": {}})
+        validator.validate(None)
+        validator.validate({"users": [{"name": "Octavia"}]})
+
+        assert not strategy.validate_called


### PR DESCRIPTION
## What
- `DpathValidator` does not invoke validation strategy if value at specified path is falsy

## How
```python
value = dpath.get(data, path)
if not value:
   return
...
validate()
```

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation handling to prevent unnecessary validation attempts when no matching data is found, avoiding errors on empty or missing values.

- **Tests**
  - Added tests to ensure validation is skipped when no values are present for specified paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->