### PR TITLE
fix: dpath_validator should not raise when key does not exist

### DIFF
--- a/airbyte_cdk/sources/declarative/validators/dpath_validator.py
+++ b/airbyte_cdk/sources/declarative/validators/dpath_validator.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2025 Airbyte, Inc., all rights reserved.
 #
 
+import logging
 from dataclasses import dataclass
 from typing import Any, List
 
@@ -10,6 +11,9 @@ import dpath.util
 from airbyte_cdk.sources.declarative.interpolation.interpolated_string import InterpolatedString
 from airbyte_cdk.sources.declarative.validators.validation_strategy import ValidationStrategy
 from airbyte_cdk.sources.declarative.validators.validator import Validator
+
+logger = logging.getLogger("airbyte")
+
 
 @dataclass
 class DpathValidator(Validator):
@@ -49,10 +53,13 @@ class DpathValidator(Validator):
                 for value in values:
                     self.strategy.validate(value)
             except KeyError as e:
+                logger.warning(f"Error validating path. Key not found: {e}")
                 return
+
         else:
             try:
                 value = dpath.get(input_data, path)
                 self.strategy.validate(value)
             except KeyError as e:
+                logger.warning(f"Error validating path. Key not found: {e}")
                 return

--- a/airbyte_cdk/sources/declarative/validators/dpath_validator.py
+++ b/airbyte_cdk/sources/declarative/validators/dpath_validator.py
@@ -3,14 +3,13 @@
 #
 
 from dataclasses import dataclass
-from typing import Any, List, Union
+from typing import Any, List
 
 import dpath.util
 
 from airbyte_cdk.sources.declarative.interpolation.interpolated_string import InterpolatedString
 from airbyte_cdk.sources.declarative.validators.validation_strategy import ValidationStrategy
 from airbyte_cdk.sources.declarative.validators.validator import Validator
-
 
 @dataclass
 class DpathValidator(Validator):
@@ -47,17 +46,13 @@ class DpathValidator(Validator):
         if "*" in path:
             try:
                 values = dpath.values(input_data, path)
-                if not values:
-                    return
                 for value in values:
                     self.strategy.validate(value)
             except KeyError as e:
-                raise ValueError(f"Error validating path '{self.field_path}': {e}")
+                return
         else:
             try:
                 value = dpath.get(input_data, path)
-                if not value:
-                    return
                 self.strategy.validate(value)
             except KeyError as e:
-                raise ValueError(f"Error validating path '{self.field_path}': {e}")
+                return

--- a/unit_tests/sources/declarative/validators/test_dpath_validator.py
+++ b/unit_tests/sources/declarative/validators/test_dpath_validator.py
@@ -34,17 +34,18 @@ class TestDpathValidator(TestCase):
         assert strategy.validate_called
         assert strategy.validated_value
 
-    def test_given_invalid_path_when_validate_then_raise_key_error(self):
+
+class TestDpathValidator(TestCase):
+    def test_given_valid_top_level_path_and_input_validate_is_successful(self):
         strategy = MockValidationStrategy()
-        validator = DpathValidator(field_path=["user", "profile", "phone"], strategy=strategy)
+        validator = DpathValidator(field_path=["user"], strategy=strategy)
 
-        test_data = {"user": {"profile": {"email": "test@example.com"}}}
+        test_data = {"user": {"profile": {"email": "test@example.com", "name": "Test User"}}}
 
-        with pytest.raises(ValueError) as context:
-            validator.validate(test_data)
+        validator.validate(test_data)
 
-        assert "Error validating path" in str(context.value)
-        assert not strategy.validate_called
+        assert strategy.validate_called
+        assert strategy.validated_value
 
     def test_given_strategy_fails_when_validate_then_raise_value_error(self):
         error_message = "Invalid email format"
@@ -53,7 +54,7 @@ class TestDpathValidator(TestCase):
 
         test_data = {"user": {"email": "invalid-email"}}
 
-        with pytest.raises(ValueError) as context:
+        with pytest.raises(ValueError):
             validator.validate(test_data)
 
         assert strategy.validate_called
@@ -63,15 +64,6 @@ class TestDpathValidator(TestCase):
         strategy = MockValidationStrategy()
         validator = DpathValidator(field_path=[], strategy=strategy)
         test_data = {"key": "value"}
-
-        with pytest.raises(ValueError):
-            validator.validate(test_data)
-
-    def test_given_empty_input_data_when_validate_then_validate_raises_exception(self):
-        strategy = MockValidationStrategy()
-        validator = DpathValidator(field_path=["data", "field"], strategy=strategy)
-
-        test_data = {}
 
         with pytest.raises(ValueError):
             validator.validate(test_data)


### PR DESCRIPTION
## What
- Fixes bug in `DpathValidator` where KeyErrors were not properly skipped.