### PR TITLE
fix(tests): resolve issue with 'exception' status raising failure of FAST container tests

### DIFF
--- a/.github/workflows/connector-tests.yml
+++ b/.github/workflows/connector-tests.yml
@@ -74,6 +74,8 @@ jobs:
             cdk_extra: n/a
           - connector: source-google-drive
             cdk_extra: file-based
+          - connector: source-google-ads
+            cdk_extra: n/a
           - connector: destination-motherduck
             cdk_extra: sql
           - connector: source-amplitude

--- a/.github/workflows/connector-tests.yml
+++ b/.github/workflows/connector-tests.yml
@@ -74,8 +74,6 @@ jobs:
             cdk_extra: n/a
           - connector: source-google-drive
             cdk_extra: file-based
-          - connector: source-google-ads
-            cdk_extra: n/a
           - connector: destination-motherduck
             cdk_extra: sql
           - connector: source-amplitude

--- a/airbyte_cdk/test/models/outcome.py
+++ b/airbyte_cdk/test/models/outcome.py
@@ -32,9 +32,12 @@ class ExpectedOutcome(Enum):
             return {
                 "succeed": ExpectedOutcome.EXPECT_SUCCESS,
                 "failed": ExpectedOutcome.EXPECT_EXCEPTION,
+                "exception": ExpectedOutcome.EXPECT_EXCEPTION,  # same as 'failed'
             }[status]
         except KeyError as ex:
-            raise ValueError(f"Invalid status '{status}'. Expected 'succeed' or 'failed'.") from ex
+            raise ValueError(
+                f"Invalid status '{status}'. Expected 'succeed', 'failed', or 'exception'.",
+            ) from ex
 
     @classmethod
     def from_expecting_exception_bool(cls, expecting_exception: bool | None) -> ExpectedOutcome:


### PR DESCRIPTION
Resolves `Invalid status 'exception'. Expected 'succeed' or 'failed'.`:

- https://github.com/airbytehq/airbyte/actions/runs/15827652192/job/44612020939?pr=61674

in

- https://github.com/airbytehq/airbyte/pull/61674

Thanks to @tolik0 for raising.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added the Google Ads connector to the automated test suite to ensure it is tested during continuous integration.

- **Bug Fixes**
  - Improved outcome status recognition in test models by accepting "exception" as a valid status equivalent to "failed".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._