### PR TITLE
fix: config remap fields component to provide correct config context

### DIFF
--- a/airbyte_cdk/sources/declarative/transformations/config_transformations/remap_field.py
+++ b/airbyte_cdk/sources/declarative/transformations/config_transformations/remap_field.py
@@ -59,7 +59,7 @@ class ConfigRemapField(ConfigTransformation):
 
         field_name = path_components[-1]
 
-        mapping = self._map.eval(config=self.config)
+        mapping = self._map.eval(config=self.config or config)
 
         if field_name in current and current[field_name] in mapping:
             current[field_name] = mapping[current[field_name]]


### PR DESCRIPTION
## What
- Will now attempt to use self.config and if its empty, will fallback to injected config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved reliability of field remapping by ensuring the correct configuration context is used during transformations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._