### PR TITLE
fix: override configure method in `ManifestDeclarativeSource` to use migrated/transformed config

### DIFF
--- a/airbyte_cdk/sources/declarative/manifest_declarative_source.py
+++ b/airbyte_cdk/sources/declarative/manifest_declarative_source.py
@@ -238,6 +238,11 @@ class ManifestDeclarativeSource(DeclarativeSource):
         self._spec_component.transform_config(mutable_config)
         return mutable_config
 
+    def configure(self, config: Mapping[str, Any], temp_dir: str
+    ) -> Mapping[str, Any]:
+        config = self._config or config
+        return super().configure(config, temp_dir)
+
     def _migrate_manifest(self) -> None:
         """
         This method is used to migrate the manifest. It should be called after the manifest has been validated.


### PR DESCRIPTION
## What
- The entrypoint was passing the unmigrated/untransformed config to each operation methods (check/discover/read)
- This fix overrides the Source method `configure` in the `ManifestDeclarativeSource` ultimately returning the transformed/migrated config to the entrypoint, where the config can then be validated against the spec and passed to each operation method.