### PR TITLE
fix(low-code): handle `ScannerError` in `ConfigComponentsResolver`

### DIFF
--- a/airbyte_cdk/sources/declarative/resolvers/config_components_resolver.py
+++ b/airbyte_cdk/sources/declarative/resolvers/config_components_resolver.py
@@ -11,6 +11,7 @@ import dpath
 import yaml
 from typing_extensions import deprecated
 from yaml.parser import ParserError
+from yaml.scanner import ScannerError
 
 from airbyte_cdk.sources.declarative.interpolation import InterpolatedString
 from airbyte_cdk.sources.declarative.resolvers.components_resolver import (
@@ -185,4 +186,8 @@ class ConfigComponentsResolver(ComponentsResolver):
                 return yaml.safe_load(value)
             except ParserError:  # "{{ record[0] in ['cohortActiveUsers'] }}"   # not valid YAML
                 return value
+            except ScannerError as e:  # "%Y-%m-%d'   # not valid yaml
+                if "expected alphabetic or numeric character, but found '%'" in str(e):
+                    return value
+                raise e
         return value

--- a/unit_tests/sources/declarative/resolvers/test_config_components_resolver.py
+++ b/unit_tests/sources/declarative/resolvers/test_config_components_resolver.py
@@ -145,6 +145,17 @@ _MANIFEST_WITH_STREAM_CONFIGS_LIST["dynamic_streams"][0]["components_resolver"][
     STREAM_CONFIG
 ]
 
+# Manifest with component definition with value that is fails when trying
+# to parse yaml in _parse_yaml_if_possible but generally contains valid string
+_MANIFEST_WITH_SCANNER_ERROR = deepcopy(_MANIFEST)
+_MANIFEST_WITH_SCANNER_ERROR["dynamic_streams"][0]["components_resolver"]["components_mapping"].append(
+    {
+        "type": "ComponentMappingDefinition",
+        "create_or_update": True,
+        "field_path": ["retriever", "requester", "$parameters", "cursor_format"],
+        "value": "{{ '%Y-%m-%d' if components_values['name'] == 'default_item' else '%Y-%m-%dT%H:%M:%S' }}",
+    }
+)
 
 @pytest.mark.parametrize(
     "manifest, config, expected_exception, expected_stream_names",
@@ -157,6 +168,7 @@ _MANIFEST_WITH_STREAM_CONFIGS_LIST["dynamic_streams"][0]["components_resolver"][
             None,
         ),
         (_MANIFEST_WITH_STREAM_CONFIGS_LIST, _CONFIG, None, ["item_1", "item_2", "default_item"]),
+        (_MANIFEST_WITH_SCANNER_ERROR, _CONFIG, None, ["item_1", "item_2", "default_item"]),
     ],
 )
 def test_dynamic_streams_read_with_config_components_resolver(


### PR DESCRIPTION
For [bing-ads custom reports](https://github.com/airbytehq/airbyte-internal-issues/issues/12995) we need to define cursor format based on report aggregation provided in the config by users.
Manifest will look like this:
```
 - type: ComponentMappingDefinition
   create_or_update: true
   field_path: [ "incremental_sync", "datetime_format" ]
   value: "{{ '%Y-%m-%dT%H:%M:%S+00:00' if components_values['report_aggregation'] == 'Hourly' else '%Y-%m-%d' }}"
```
When format string is being parsed in the `_parse_yaml_if_possible` Scanner error is raised. 
Added check for the error message for datetime format case to pass this value to stream template.