### PR TITLE
tests: add debug option for entrypoint wrapper

### DIFF
--- a/airbyte_cdk/test/entrypoint_wrapper.py
+++ b/airbyte_cdk/test/entrypoint_wrapper.py
@@ -373,6 +373,7 @@ def read(
     expecting_exception: bool | None = None,  # Deprecated, use `expected_outcome` instead.
     *,
     expected_outcome: ExpectedOutcome | None = None,
+    debug: bool = False,
 ) -> EntrypointOutput:
     """
     config and state must be json serializable
@@ -394,6 +395,8 @@ def read(
             "--catalog",
             catalog_file,
         ]
+        if debug:
+            args.append("--debug")
         if state is not None:
             args.extend(
                 [


### PR DESCRIPTION
## What
- Adds `debug` parameter to `EntrypointWrapper.read` method, when set to true, will append the `--debug` option to the list of args passed to the read operation.

## Why
- Helpful for debugging mock server tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional debug mode for the read command, allowing users to enable additional debug output when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->