### PR TITLE
docs: integrate the SDM readme into `pdoc` (targets #620)

### DIFF
--- a/airbyte_cdk/__init__.py
+++ b/airbyte_cdk/__init__.py
@@ -32,6 +32,17 @@ The Airbyte CDK provides a set of classes that help you work with the Airbyte pr
 - `airbyte_cdk.models.airbyte_protocol`
 - `airbyte_cdk.models.airbyte_protocol_serializers`
 
+## Using the CLI (`airbyte_cdk.cli`)
+
+The Airbyte CDK provides two command-line interfaces (CLIs) for interacting with the framework.
+
+- `airbyte-cdk`: This is the main CLI for the Airbyte CDK. It provides commands for building
+  and testing connectors, as well as other utilities. See the `airbyte_cdk.cli.airbyte_cdk` module
+  for more details.
+- `source-declarative-manifest` (`airbyte_cdk.cli.source_declarative_manifest`): This command allows
+  you to run declarative manifests directly. See the `airbyte_cdk.cli.source_declarative_manifest`
+  module for more details.
+
 ---
 
 API Reference

--- a/airbyte_cdk/__init__.py
+++ b/airbyte_cdk/__init__.py
@@ -39,9 +39,8 @@ The Airbyte CDK provides two command-line interfaces (CLIs) for interacting with
 - `airbyte-cdk`: This is the main CLI for the Airbyte CDK. It provides commands for building
   and testing connectors, as well as other utilities. See the `airbyte_cdk.cli.airbyte_cdk` module
   for more details.
-- `source-declarative-manifest` (`airbyte_cdk.cli.source_declarative_manifest`): This command allows
-  you to run declarative manifests directly. See the `airbyte_cdk.cli.source_declarative_manifest`
-  module for more details.
+- `source-declarative-manifest`: This command allows you to run declarative manifests directly.
+  See the `airbyte_cdk.cli.source_declarative_manifest` module for more details.
 
 ---
 

--- a/airbyte_cdk/cli/source_declarative_manifest/__init__.py
+++ b/airbyte_cdk/cli/source_declarative_manifest/__init__.py
@@ -1,3 +1,7 @@
+"""
+.. include:: ./README.md
+   :start-line: 2
+"""
 from airbyte_cdk.cli.source_declarative_manifest._run import run
 
 __all__ = [

--- a/airbyte_cdk/cli/source_declarative_manifest/__init__.py
+++ b/airbyte_cdk/cli/source_declarative_manifest/__init__.py
@@ -2,6 +2,7 @@
 .. include:: ./README.md
    :start-line: 2
 """
+
 from airbyte_cdk.cli.source_declarative_manifest._run import run
 
 __all__ = [

--- a/airbyte_cdk/cli/source_declarative_manifest/_run.py
+++ b/airbyte_cdk/cli/source_declarative_manifest/_run.py
@@ -299,5 +299,9 @@ def _register_components_from_file(filepath: str) -> None:
 
 
 def run() -> None:
+    """Run the `source-declarative-manifest` CLI.
+
+    Args are detected from the command line, and the appropriate command is executed.
+    """
     args: list[str] = sys.argv[1:]
     handle_command(args)


### PR DESCRIPTION
Targets:

- #620

Run `poe docs-preview` locally to test - or (alternatively) download the artifacts from the Build Docs job in CI.


On the docs home:

> <img width="807" alt="image" src="https://github.com/user-attachments/assets/cfecba59-e4e1-44ce-b0d8-c53f7bbb58bb" />

On the SDM module:

> <img width="1172" alt="image" src="https://github.com/user-attachments/assets/ce04d8d0-27a0-4b62-804a-64af1ac3819e" />
