### PR TITLE
fix: change log level for dpath validator to `info`

### DIFF
--- a/airbyte_cdk/__init__.py
+++ b/airbyte_cdk/__init__.py
@@ -129,6 +129,7 @@ from .sources.declarative.schema import JsonFileSchemaLoader
 from .sources.declarative.transformations.add_fields import AddedFieldDefinition, AddFields
 from .sources.declarative.transformations.transformation import RecordTransformation
 from .sources.declarative.types import FieldPointer
+from .sources.declarative.validators import DpathValidator, PredicateValidator, ValidateAdheresToSchema, ValidationStrategy, Validator
 from .sources.declarative.yaml_declarative_source import YamlDeclarativeSource
 from .sources.message import InMemoryMessageRepository, MessageRepository
 from .sources.source import TState
@@ -339,6 +340,12 @@ __all__ = [
     "Record",
     "Source",
     "StreamSlice",
+    # Validators
+    "Validator",
+    "DpathValidator",
+    "PredicateValidator",
+    "ValidationStrategy",
+    "ValidateAdheresToSchema",
 ]
 
 __version__: str

--- a/airbyte_cdk/sources/declarative/validators/dpath_validator.py
+++ b/airbyte_cdk/sources/declarative/validators/dpath_validator.py
@@ -53,7 +53,7 @@ class DpathValidator(Validator):
                 for value in values:
                     self.strategy.validate(value)
             except KeyError as e:
-                logger.warning(f"Error validating path. Key not found: {e}")
+                logger.info(f"Error validating path. Key not found: {e}")
                 return
 
         else:
@@ -61,5 +61,5 @@ class DpathValidator(Validator):
                 value = dpath.get(input_data, path)
                 self.strategy.validate(value)
             except KeyError as e:
-                logger.warning(f"Error validating path. Key not found: {e}")
+                logger.info(f"Error validating path. Key not found: {e}")
                 return

--- a/airbyte_cdk/sources/declarative/validators/dpath_validator.py
+++ b/airbyte_cdk/sources/declarative/validators/dpath_validator.py
@@ -53,7 +53,7 @@ class DpathValidator(Validator):
                 for value in values:
                     self.strategy.validate(value)
             except KeyError as e:
-                logger.info(f"Error validating path. Key not found: {e}")
+                logger.info(f"Validation skipped. Key not found: {e}")
                 return
 
         else:
@@ -61,5 +61,5 @@ class DpathValidator(Validator):
                 value = dpath.get(input_data, path)
                 self.strategy.validate(value)
             except KeyError as e:
-                logger.info(f"Error validating path. Key not found: {e}")
+                logger.info(f"Validation skipped. Key not found: {e}")
                 return


### PR DESCRIPTION
## What
- Updates log leve to `info` and changes wording so that users do not think there was a failure