### PR TITLE
feat(connector-builder): stop setting the staging_file_url and file_size_bytes fields for the case of a Builder test read.

### DIFF
--- a/airbyte_cdk/sources/declarative/retrievers/file_uploader/connector_builder_file_uploader.py
+++ b/airbyte_cdk/sources/declarative/retrievers/file_uploader/connector_builder_file_uploader.py
@@ -21,6 +21,4 @@ class ConnectorBuilderFileUploader(FileUploader):
 
     def upload(self, record: Record) -> None:
         self.file_uploader.upload(record=record)
-        for file_reference_key, file_reference_value in record.file_reference.__dict__.items():
-            if not file_reference_key.startswith("_"):
-                record.data[file_reference_key] = file_reference_value  # type: ignore
+        record.data["source_file_relative_path"] = record.file_reference.source_file_relative_path  # type: ignore

--- a/unit_tests/sources/declarative/file/test_file_stream.py
+++ b/unit_tests/sources/declarative/file/test_file_stream.py
@@ -253,12 +253,10 @@ class FileStreamTest(TestCase):
 
                 # Assert file reference fields are copied to record data
                 record_data = output.records[0].record.data
-                assert record_data["staging_file_url"] == file_reference.staging_file_url
                 assert (
                     record_data["source_file_relative_path"]
                     == file_reference.source_file_relative_path
                 )
-                assert record_data["file_size_bytes"] == file_reference.file_size_bytes
 
     def test_discover_article_attachments(self) -> None:
         output = discover(self._config())


### PR DESCRIPTION
Stop setting the staging_file_url and file_size_bytes fields for the case of a Builder test read.

[File Upload UX improvements](https://airbytehq-team.slack.com/archives/C08GNBT7AV7/p1749838324442659?thread_ts=1749837328.926989&cid=C08GNBT7AV7)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted file upload behavior to include only the "source_file_relative_path" in uploaded data, rather than multiple file reference attributes.

* **Tests**
  * Updated tests to reflect the change by removing checks for "staging_file_url" and "file_size_bytes" in the uploaded data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->