### PR TITLE
chore: reorder inject_into in RequestOption and fix title and description in refresh token updater

### DIFF
--- a/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -1339,8 +1339,8 @@ definitions:
         examples:
           - "%Y-%m-%d %H:%M:%S.%f+00:00"
       refresh_token_updater:
-        title: Token Updater
-        description: When the token updater is defined, new refresh tokens, access tokens and the access token expiry date are written back from the authentication response to the config object. This is important if the refresh token can only used once.
+        title: Refresh Token Updater
+        description: When the refresh token updater is defined, new refresh tokens, access tokens and the access token expiry date are written back from the authentication response to the config object. This is important if the refresh token can only used once.
         properties:
           refresh_token_name:
             title: Refresh Token Property Name
@@ -1355,7 +1355,7 @@ definitions:
             type: array
             items:
               type: string
-            default: ["credentials", "access_token"]
+            default: ["access_token"]
             examples:
               - ["credentials", "access_token"]
               - ["access_token"]
@@ -1365,7 +1365,7 @@ definitions:
             type: array
             items:
               type: string
-            default: ["credentials", "refresh_token"]
+            default: ["refresh_token"]
             examples:
               - ["credentials", "refresh_token"]
               - ["refresh_token"]
@@ -1375,7 +1375,7 @@ definitions:
             type: array
             items:
               type: string
-            default: ["credentials", "token_expiry_date"]
+            default: ["token_expiry_date"]
             examples:
               - ["credentials", "token_expiry_date"]
           refresh_token_error_status_codes:

--- a/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -3424,6 +3424,19 @@ definitions:
       type:
         type: string
         enum: [RequestOption]
+      inject_into:
+        title: Inject Into
+        description: Configures where the descriptor should be set on the HTTP requests. Note that request parameters that are already encoded in the URL path will not be duplicated.
+        enum:
+          - request_parameter
+          - header
+          - body_data
+          - body_json
+        examples:
+          - request_parameter
+          - header
+          - body_data
+          - body_json
       field_name:
         title: Field Name
         description: Configures which key should be used in the location that the descriptor is being injected into. We hope to eventually deprecate this field in favor of `field_path` for all request_options, but must currently maintain it for backwards compatibility in the Builder.
@@ -3444,19 +3457,6 @@ definitions:
         interpolation_context:
           - config
           - parameters
-      inject_into:
-        title: Inject Into
-        description: Configures where the descriptor should be set on the HTTP requests. Note that request parameters that are already encoded in the URL path will not be duplicated.
-        enum:
-          - request_parameter
-          - header
-          - body_data
-          - body_json
-        examples:
-          - request_parameter
-          - header
-          - body_data
-          - body_json
   Schemas:
     title: Schemas
     description: The stream schemas representing the shape of the data emitted by the stream.

--- a/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -1355,7 +1355,7 @@ definitions:
             type: array
             items:
               type: string
-            default: ["access_token"]
+            default: ["credentials", "access_token"]
             examples:
               - ["credentials", "access_token"]
               - ["access_token"]
@@ -1365,7 +1365,7 @@ definitions:
             type: array
             items:
               type: string
-            default: ["refresh_token"]
+            default: ["credentials", "refresh_token"]
             examples:
               - ["credentials", "refresh_token"]
               - ["refresh_token"]
@@ -1375,7 +1375,7 @@ definitions:
             type: array
             items:
               type: string
-            default: ["token_expiry_date"]
+            default: ["credentials", "token_expiry_date"]
             examples:
               - ["credentials", "token_expiry_date"]
           refresh_token_error_status_codes:

--- a/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
+++ b/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
@@ -1307,6 +1307,12 @@ class InjectInto(Enum):
 
 class RequestOption(BaseModel):
     type: Literal["RequestOption"]
+    inject_into: InjectInto = Field(
+        ...,
+        description="Configures where the descriptor should be set on the HTTP requests. Note that request parameters that are already encoded in the URL path will not be duplicated.",
+        examples=["request_parameter", "header", "body_data", "body_json"],
+        title="Inject Into",
+    )
     field_name: Optional[str] = Field(
         None,
         description="Configures which key should be used in the location that the descriptor is being injected into. We hope to eventually deprecate this field in favor of `field_path` for all request_options, but must currently maintain it for backwards compatibility in the Builder.",
@@ -1318,12 +1324,6 @@ class RequestOption(BaseModel):
         description="Configures a path to be used for nested structures in JSON body requests (e.g. GraphQL queries)",
         examples=[["data", "viewer", "id"]],
         title="Field Path",
-    )
-    inject_into: InjectInto = Field(
-        ...,
-        description="Configures where the descriptor should be set on the HTTP requests. Note that request parameters that are already encoded in the URL path will not be duplicated.",
-        examples=["request_parameter", "header", "body_data", "body_json"],
-        title="Inject Into",
     )
 
 

--- a/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
+++ b/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
@@ -477,19 +477,19 @@ class RefreshTokenUpdater(BaseModel):
         title="Refresh Token Property Name",
     )
     access_token_config_path: Optional[List[str]] = Field(
-        ["credentials", "access_token"],
+        ["access_token"],
         description="Config path to the access token. Make sure the field actually exists in the config.",
         examples=[["credentials", "access_token"], ["access_token"]],
         title="Config Path To Access Token",
     )
     refresh_token_config_path: Optional[List[str]] = Field(
-        ["credentials", "refresh_token"],
+        ["refresh_token"],
         description="Config path to the access token. Make sure the field actually exists in the config.",
         examples=[["credentials", "refresh_token"], ["refresh_token"]],
         title="Config Path To Refresh Token",
     )
     token_expiry_date_config_path: Optional[List[str]] = Field(
-        ["credentials", "token_expiry_date"],
+        ["token_expiry_date"],
         description="Config path to the expiry date. Make sure actually exists in the config.",
         examples=[["credentials", "token_expiry_date"]],
         title="Config Path To Expiry Date",
@@ -637,8 +637,8 @@ class OAuthAuthenticator(BaseModel):
     )
     refresh_token_updater: Optional[RefreshTokenUpdater] = Field(
         None,
-        description="When the token updater is defined, new refresh tokens, access tokens and the access token expiry date are written back from the authentication response to the config object. This is important if the refresh token can only used once.",
-        title="Token Updater",
+        description="When the refresh token updater is defined, new refresh tokens, access tokens and the access token expiry date are written back from the authentication response to the config object. This is important if the refresh token can only used once.",
+        title="Refresh Token Updater",
     )
     profile_assertion: Optional[JwtAuthenticator] = Field(
         None,

--- a/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
+++ b/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
@@ -477,19 +477,19 @@ class RefreshTokenUpdater(BaseModel):
         title="Refresh Token Property Name",
     )
     access_token_config_path: Optional[List[str]] = Field(
-        ["access_token"],
+        ["credentials", "access_token"],
         description="Config path to the access token. Make sure the field actually exists in the config.",
         examples=[["credentials", "access_token"], ["access_token"]],
         title="Config Path To Access Token",
     )
     refresh_token_config_path: Optional[List[str]] = Field(
-        ["refresh_token"],
+        ["credentials", "refresh_token"],
         description="Config path to the access token. Make sure the field actually exists in the config.",
         examples=[["credentials", "refresh_token"], ["refresh_token"]],
         title="Config Path To Refresh Token",
     )
     token_expiry_date_config_path: Optional[List[str]] = Field(
-        ["token_expiry_date"],
+        ["credentials", "token_expiry_date"],
         description="Config path to the expiry date. Make sure actually exists in the config.",
         examples=[["credentials", "token_expiry_date"]],
         title="Config Path To Expiry Date",


### PR DESCRIPTION
Inject Into should be above field name/path, as this makes more conceptual sense in the UI.

I also changed some of the titles, descriptions, and default values in refresh_token_updater to better match what the user should expect in the UI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated terminology and descriptions related to token refresh functionality for clarity.
  * Reorganized request option settings for improved schema consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->