### PR TITLE
fix: properly set token_expiry_is_time_of_expiration and mask access token when logging

### DIFF
--- a/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -2801,6 +2801,7 @@ class ModelToComponentFactory:
                 ).eval(config),
                 scopes=model.scopes,
                 token_expiry_date_format=model.token_expiry_date_format,
+                token_expiry_is_time_of_expiration=bool(model.token_expiry_date_format),
                 message_repository=self._message_repository,
                 refresh_token_error_status_codes=model.refresh_token_updater.refresh_token_error_status_codes,
                 refresh_token_error_key=model.refresh_token_updater.refresh_token_error_key,

--- a/airbyte_cdk/sources/streams/http/requests_native_auth/abstract_oauth.py
+++ b/airbyte_cdk/sources/streams/http/requests_native_auth/abstract_oauth.py
@@ -225,10 +225,14 @@ class AbstractOauth2Authenticator(AuthBase):
 
             response_json = response.json()
 
-            # extract the access token and add to secrets to avoid logging the raw value
-            access_key = self._extract_access_token(response_json)
-            if access_key:
-                add_to_secrets(access_key)
+            try:
+                # extract the access token and add to secrets to avoid logging the raw value
+                access_key = self._extract_access_token(response_json)
+                if access_key:
+                    add_to_secrets(access_key)
+            except ResponseKeysMaxRecurtionReached as e:
+                # could not find the access token in the response, so do nothing
+                pass
             
             self._log_response(response)
 

--- a/airbyte_cdk/sources/streams/http/requests_native_auth/abstract_oauth.py
+++ b/airbyte_cdk/sources/streams/http/requests_native_auth/abstract_oauth.py
@@ -218,6 +218,8 @@ class AbstractOauth2Authenticator(AuthBase):
                 headers=self.build_refresh_request_headers(),
             )
 
+            response_json = None
+            json_exception = None
             try:
                 response_json = response.json()
             except Exception as e:
@@ -231,7 +233,7 @@ class AbstractOauth2Authenticator(AuthBase):
                     if access_key:
                         add_to_secrets(access_key)
             except ResponseKeysMaxRecurtionReached as e:
-                ## could not find the access token in the response, so do nothing
+                # could not find the access token in the response, so do nothing
                 pass
 
             # log the response even if the request failed for troubleshooting purposes
@@ -240,7 +242,7 @@ class AbstractOauth2Authenticator(AuthBase):
 
             if json_exception:
                 raise json_exception
-            
+
             return response_json
         except requests.exceptions.RequestException as e:
             if e.response is not None:

--- a/airbyte_cdk/sources/streams/http/requests_native_auth/abstract_oauth.py
+++ b/airbyte_cdk/sources/streams/http/requests_native_auth/abstract_oauth.py
@@ -217,10 +217,15 @@ class AbstractOauth2Authenticator(AuthBase):
                 data=self.build_refresh_request_body(),
                 headers=self.build_refresh_request_headers(),
             )
+            response_json = response.json()
+            # extract the access token and add to secrets to avoid logging the raw value
+            access_key = self._extract_access_token(response_json)
+            if access_key:
+                add_to_secrets(access_key)
             # log the response even if the request failed for troubleshooting purposes
             self._log_response(response)
             response.raise_for_status()
-            return response.json()
+            return response_json
         except requests.exceptions.RequestException as e:
             if e.response is not None:
                 if e.response.status_code == 429 or e.response.status_code >= 500:

--- a/airbyte_cdk/sources/streams/http/requests_native_auth/abstract_oauth.py
+++ b/airbyte_cdk/sources/streams/http/requests_native_auth/abstract_oauth.py
@@ -233,7 +233,7 @@ class AbstractOauth2Authenticator(AuthBase):
             except ResponseKeysMaxRecurtionReached as e:
                 # could not find the access token in the response, so do nothing
                 pass
-            
+
             self._log_response(response)
 
             return response_json


### PR DESCRIPTION
## What

When testing out some Builder changes relating to OAuth, I noticed two issues with the implementation of OAuth in the CDK:
1. When I didn't set a token expiry date in my config, I was receiving this error: `Invalid expires_in value: 2025-08-01T21:34:33Z. Expected number of seconds when no format specified.`
2. The access token was not being masked with `****` in the OAuth response shown in the Builder - I could see the raw value

## How

I traced the first issue down to the fact that `token_expiry_is_time_of_expiration` is not being set when constructing `DeclarativeSingleUseRefreshTokenOauth2Authenticator` [here](https://github.com/airbytehq/airbyte-python-cdk/blob/a562875fafc8b0c6bb658dd2be20f7475cc5dd0b/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py#L2758C20-L2758C71).

This caused this [if statement](https://github.com/airbytehq/airbyte-python-cdk/blob/4e6b9f230bd129f8271cd2b2eb820064902d5b0c/airbyte_cdk/sources/streams/http/requests_native_auth/abstract_oauth.py#L277) to always return False, causing the error to be thrown.

To fix this, I simply set the `token_expiry_is_time_of_expiration` the same way it is being set when constructing `DeclarativeOauth2Authenticator` [below](https://github.com/airbytehq/airbyte-python-cdk/blob/a562875fafc8b0c6bb658dd2be20f7475cc5dd0b/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py#L2827)

---

The second issue I traced down to the fact that the OAuth response was being logged before anything had a chance to add the access token to the secrets list. The fix was to extract the access token and add it to the secrets mask list before logging the response

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of OAuth token expiry by correctly setting the token expiry parameter during authentication.
  * Enhanced security by masking access tokens in logs immediately after retrieval from the token refresh endpoint.
  * Improved error handling by checking response status before processing OAuth token requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->