### PR TITLE
feat(property-chunking): Allow the definition of query_properties on the HttpRequester component

### DIFF
--- a/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -2043,9 +2043,15 @@ definitions:
           - "$ref": "#/definitions/NoAuth"
           - "$ref": "#/definitions/LegacySessionTokenAuthenticator"
       fetch_properties_from_endpoint:
+        deprecated: true
+        deprecation_message: "Use `query_properties` field instead."
         title: Fetch Properties from Endpoint
         description: Allows for retrieving a dynamic set of properties from an API endpoint which can be injected into outbound request using the stream_partition.extra_fields.
         "$ref": "#/definitions/PropertiesFromEndpoint"
+      query_properties:
+        title: Query Properties
+        description: For APIs that require explicit specification of the properties to query for, this component will take a static or dynamic set of properties (which can be optionally split into chunks) and allow them to be injected into an outbound request by accessing stream_partition.extra_fields.
+        "$ref": "#/definitions/QueryProperties"
       request_parameters:
         title: Query Parameters
         description: Specifies the query parameters that should be set on an outgoing HTTP request given the inputs.

--- a/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
+++ b/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
@@ -2543,8 +2543,15 @@ class HttpRequester(BaseModelWithDeprecations):
     )
     fetch_properties_from_endpoint: Optional[PropertiesFromEndpoint] = Field(
         None,
+        deprecated=True,
+        deprecation_message="Use `query_properties` field instead.",
         description="Allows for retrieving a dynamic set of properties from an API endpoint which can be injected into outbound request using the stream_partition.extra_fields.",
         title="Fetch Properties from Endpoint",
+    )
+    query_properties: Optional[QueryProperties] = Field(
+        None,
+        description="For APIs that require explicit specification of the properties to query for, this component will take a static or dynamic set of properties (which can be optionally split into chunks) and allow them to be injected into an outbound request by accessing stream_partition.extra_fields.",
+        title="Query Properties",
     )
     request_parameters: Optional[Union[Dict[str, Union[str, QueryProperties]], str]] = Field(
         None,

--- a/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -3220,6 +3220,7 @@ class ModelToComponentFactory:
             hasattr(model.requester, "fetch_properties_from_endpoint")
             and model.requester.fetch_properties_from_endpoint
         ):
+            # todo: Deprecate this condition once dependent connectors migrate to query_properties
             query_properties_definition = QueryPropertiesModel(
                 type="QueryProperties",
                 property_list=model.requester.fetch_properties_from_endpoint,
@@ -3229,6 +3230,11 @@ class ModelToComponentFactory:
 
             query_properties = self.create_query_properties(
                 model=query_properties_definition,
+                config=config,
+            )
+        elif hasattr(model.requester, "query_properties") and model.requester.query_properties:
+            query_properties = self.create_query_properties(
+                model=model.requester.query_properties,
                 config=config,
             )
 

--- a/unit_tests/sources/declarative/parsers/test_model_to_component_factory.py
+++ b/unit_tests/sources/declarative/parsers/test_model_to_component_factory.py
@@ -4404,21 +4404,23 @@ def test_simple_retriever_with_requester_properties_from_endpoint():
       url_base: "https://api.hubapi.com"
       http_method: "GET"
       path: "adAnalytics"
-      fetch_properties_from_endpoint:
-        type: PropertiesFromEndpoint
-        property_field_path: [ "name" ]
-        retriever:
-          type: SimpleRetriever
-          requester:
-            type: HttpRequester
-            url_base: https://api.hubapi.com
-            path: "/properties/v2/dynamics/properties"
-            http_method: GET
-          record_selector:
-            type: RecordSelector
-            extractor:
-              type: DpathExtractor
-              field_path: []
+      query_properties:
+        type: QueryProperties
+        property_list:
+          type: PropertiesFromEndpoint
+          property_field_path: [ "name" ]
+          retriever:
+            type: SimpleRetriever
+            requester:
+              type: HttpRequester
+              url_base: https://api.hubapi.com
+              path: "/properties/v2/dynamics/properties"
+              http_method: GET
+            record_selector:
+              type: RecordSelector
+              extractor:
+                type: DpathExtractor
+                field_path: []
     dynamic_properties_stream:
       type: DeclarativeStream
       incremental_sync:


### PR DESCRIPTION
## What

While migrating the last `source-instagram` stream `UserInsights` to low-code, I found a gap in the CDK functionality in how we chunk properties to make multiple requests and merge the records back together.

The current implementation only allows us to put all query properties under a single field in the `request_properties`. However, for Instagram, we need to load certain query properties into one parameter field and other properties to another. For example:

```
METRICS_BY_PERIOD = {
        "day": [
            "follower_count",
            "reach",
        ],
        "week": ["reach"],
        "days_28": ["reach"],
        "lifetime": ["online_followers"],
    }

We want to create 4 chunks where query params are:
?period=day&metric=follower_count,reach
?period=week&metric=reach
?period=days_28&metric=reach
?period=lifetime&metric=online_followers
```

And we still want to be able to merge the record back together for all the chunks based on a target merge key.

## How

In reality how we do this quite easy, but relied mostly on an oversight in how I had previously designed the `fetch_properties_from_endpoint` improvement from a few months ago. I had originally envisioned that we would not really need to do property chunking here and if it was needed, it would be handled from the definition in `request_properties`. However, we're now seeing a case where we want to load parameters into different fields.

By allowing for the `QueryProperties` which supports property chunking to be defined the HttpRequester, we can perform chunking and choose where they go.

I've marked `fetch_properties_from_endpoint` as deprecated and would ideally want to do an under the table deprecation of the old field. Only `source-hubspot` uses this and we can swap this out. Once we do, we can silently deprecate.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new property for HTTP requesters to explicitly specify query properties for APIs that require them.

* **Deprecation**
  * Marked the existing property for fetching properties from endpoints as deprecated, with guidance to use the new query properties feature.

* **Bug Fixes**
  * Updated tests to use the new query properties structure, ensuring compatibility and correctness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->