### PR TITLE
ci: temporarily remove source-amplitude from CDK connector tests

### DIFF
--- a/.github/workflows/connector-tests.yml
+++ b/.github/workflows/connector-tests.yml
@@ -76,8 +76,10 @@ jobs:
             cdk_extra: file-based
           - connector: destination-motherduck
             cdk_extra: sql
-          - connector: source-amplitude
-            cdk_extra: n/a
+          # source-amplitude failing for unrelated issue "date too far back"
+          # e.g. https://github.com/airbytehq/airbyte-python-cdk/actions/runs/16053716569/job/45302638848?pr=639
+          # - connector: source-amplitude
+          #   cdk_extra: n/a
           - connector: source-intercom
             cdk_extra: n/a
           - connector: source-pokeapi


### PR DESCRIPTION


> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled tests for the source-amplitude connector in the workflow due to a known unrelated issue. Added comments with details and a reference link for further context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->