### PR TITLE
fix(low-code cdk): Add literal type for ConfigNormalizationRules components

### DIFF
--- a/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -3835,7 +3835,12 @@ definitions:
         title: Config Normalization Rules
         type: object
         additionalProperties: false
+        required:
+          - type
         properties:
+          type:
+            type: string
+            enum: [ConfigNormalizationRules]
           config_migrations:
             title: Config Migrations
             description: The discrete migrations that will be applied on the incoming config. Each migration will be applied in the order they are defined.

--- a/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
+++ b/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
@@ -2160,6 +2160,7 @@ class ConfigNormalizationRules(BaseModel):
     class Config:
         extra = Extra.forbid
 
+    type: Literal["ConfigNormalizationRules"]
     config_migrations: Optional[List[ConfigMigration]] = Field(
         [],
         description="The discrete migrations that will be applied on the incoming config. Each migration will be applied in the order they are defined.",

--- a/unit_tests/sources/declarative/test_manifest_declarative_source.py
+++ b/unit_tests/sources/declarative/test_manifest_declarative_source.py
@@ -2488,6 +2488,7 @@ def test_given_unmigrated_config_when_migrating_then_config_is_migrated(migratio
             "documentation_url": "https://example.org",
             "connection_specification": {},
             "config_normalization_rules": {
+                "type": "ConfigNormalizationRules",
                 "config_migrations": [
                     {
                         "type": "ConfigMigration",
@@ -2558,6 +2559,7 @@ def test_given_already_migrated_config_no_control_message_is_emitted(migration_m
             "documentation_url": "https://example.org",
             "connection_specification": {},
             "config_normalization_rules": {
+                "type": "ConfigNormalizationRules",
                 "config_migrations": [
                     {
                         "type": "ConfigMigration",
@@ -2628,6 +2630,7 @@ def test_given_transformations_config_is_transformed():
             "documentation_url": "https://example.org",
             "connection_specification": {},
             "config_normalization_rules": {
+                "type": "ConfigNormalizationRules",
                 "transformations": [
                     {
                         "type": "ConfigAddFields",
@@ -2703,6 +2706,7 @@ def test_given_valid_config_streams_validates_config_and_does_not_raise():
             "connection_specification": {},
             "parameters": {},
             "config_normalization_rules": {
+                "type": "ConfigNormalizationRules",
                 "validations": [
                     {
                         "type": "DpathValidator",
@@ -2767,6 +2771,7 @@ def test_given_invalid_config_streams_validates_config_and_raises():
             "connection_specification": {},
             "parameters": {},
             "config_normalization_rules": {
+                "type": "ConfigNormalizationRules",
                 "validations": [
                     {
                         "type": "DpathValidator",


### PR DESCRIPTION
While implementing config validations for a connector, I noticed that we weren't requiring a `type` on the `ConfigNormalizationRules` component. For consistency we should do so.

The one annoying part is that this would technically constitute a breaking change because `type` will now be required on all instances of the type and no existing connectors contain it. Rather than institute a trivial breaking change, I propose that we prepare PRs for the few uses we have of this component that add the type. Merge this as a minor version, then update the base images for those connectors.

This should be relatively low risk since it will fail quite loudly and the changes themselves are quite trivial

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The configuration now requires a "type" field for config normalization rules, ensuring clearer identification and validation.
* **Tests**
  * Updated test manifests to include the required "type" field for config normalization rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->