### PR TITLE
chore: Update source-declarative-manifest to use python-connector-base 4.0.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # A new version of source-declarative-manifest is built for every new Airbyte CDK release, and their versions are kept in sync.
 #
 
-FROM docker.io/airbyte/python-connector-base:4.0.0@sha256:d9894b6895923b379f3006fa251147806919c62b7d9021b5cd125bb67d7bbe22
+FROM docker.io/airbyte/python-connector-base:4.0.1-rc.1
 
 WORKDIR /airbyte/integration_code
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # A new version of source-declarative-manifest is built for every new Airbyte CDK release, and their versions are kept in sync.
 #
 
-FROM docker.io/airbyte/python-connector-base:4.0.2-rc.1@sha256:9fdb1888c4264cf6fee473649ecb593f56f58e5d0096a87ee0b231777e2e3e73
+FROM docker.io/airbyte/python-connector-base:4.0.2@sha256:9fdb1888c4264cf6fee473649ecb593f56f58e5d0096a87ee0b231777e2e3e73
 
 WORKDIR /airbyte/integration_code
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # A new version of source-declarative-manifest is built for every new Airbyte CDK release, and their versions are kept in sync.
 #
 
-FROM docker.io/airbyte/python-connector-base:4.0.1-rc.1@sha256:5d1d8216467b29cf8a65d42e9c3316cdb5e62529ec3bcb14cfa993f5221316ed
+FROM docker.io/airbyte/python-connector-base:4.0.2-rc.1@sha256:9fdb1888c4264cf6fee473649ecb593f56f58e5d0096a87ee0b231777e2e3e73
 
 WORKDIR /airbyte/integration_code
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # A new version of source-declarative-manifest is built for every new Airbyte CDK release, and their versions are kept in sync.
 #
 
-FROM docker.io/airbyte/python-connector-base:4.0.1-rc.1
+FROM docker.io/airbyte/python-connector-base:4.0.1-rc.1@sha256:5d1d8216467b29cf8a65d42e9c3316cdb5e62529ec3bcb14cfa993f5221316ed
 
 WORKDIR /airbyte/integration_code
 


### PR DESCRIPTION
See associated PR: https://github.com/airbytehq/airbyte/pull/62909

Along with the release of a new python connector base image, this creates a new base image for manifest only connectors using Python3.11.13, patching security vulnerabilities.


## Testing
To test this out I performed the following steps
1. ensure the new python connector base image release (or release candidate) was published to DockerHub (see other PR)
1. reference that new published image in the `Dockerfile` at the root of the repo
1. commits to the PR should automatically trigger a dev build of the source declarative manifest base image ([link](https://github.com/airbytehq/airbyte-python-cdk/actions/runs/16210025289/job/45768215609?pr=651)), make sure that is passing
1. create a pre-release version of the SDM docker image by following the steps [here](https://github.com/airbytehq/airbyte-python-cdk/blob/c67c554e3ebaede9adfcbb42162eb3f77d1f07a1/docs/RELEASES.md#L20)
1. finally try building manifest-only connectors locally in the airbyte repo using airbyte-ci and running test syncs. Alternatively, for a easier smoke test of the manifest onyl connector image, do `airbyte-cdk secrets fetch`, followed by `airbyte-cdk image test`

I tested this out on `source-google-sheets`, `source-greenhouse`, `source-monday`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the base image version used for building and running the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->