### PR TITLE
fix: fast tests conditionally skip streams

### DIFF
--- a/airbyte_cdk/test/entrypoint_wrapper.py
+++ b/airbyte_cdk/test/entrypoint_wrapper.py
@@ -51,7 +51,6 @@ from airbyte_cdk.sources import Source
 from airbyte_cdk.test.models.scenario import ExpectedOutcome
 
 
-@dataclass
 class AirbyteEntrypointException(Exception):
     """Exception raised for errors in the AirbyteEntrypoint execution.
 

--- a/airbyte_cdk/test/models/scenario.py
+++ b/airbyte_cdk/test/models/scenario.py
@@ -44,12 +44,17 @@ class ConnectorTestScenario(BaseModel):
         skip_test: bool
         bypass_reason: str
 
+    class AcceptanceTestEmptyStreams(BaseModel):
+        name: str
+        bypass_reason: str | None = None
+
     config_path: Path | None = None
     config_dict: dict[str, Any] | None = None
 
     _id: str | None = None  # Used to override the default ID generation
 
     configured_catalog_path: Path | None = None
+    empty_streams: list[AcceptanceTestEmptyStreams] | list[str] | None = None
     timeout_seconds: int | None = None
     expect_records: AcceptanceTestExpectRecords | None = None
     file_types: AcceptanceTestFileTypes | None = None

--- a/airbyte_cdk/test/models/scenario.py
+++ b/airbyte_cdk/test/models/scenario.py
@@ -44,7 +44,7 @@ class ConnectorTestScenario(BaseModel):
         skip_test: bool
         bypass_reason: str
 
-    class AcceptanceTestEmptyStreams(BaseModel):
+    class AcceptanceTestEmptyStream(BaseModel):
         name: str
         bypass_reason: str | None = None
 
@@ -54,7 +54,7 @@ class ConnectorTestScenario(BaseModel):
     _id: str | None = None  # Used to override the default ID generation
 
     configured_catalog_path: Path | None = None
-    empty_streams: list[AcceptanceTestEmptyStreams] | list[str] | None = None
+    empty_streams: list[AcceptanceTestEmptyStream] | None = None
     timeout_seconds: int | None = None
     expect_records: AcceptanceTestExpectRecords | None = None
     file_types: AcceptanceTestFileTypes | None = None

--- a/airbyte_cdk/test/models/scenario.py
+++ b/airbyte_cdk/test/models/scenario.py
@@ -48,6 +48,10 @@ class ConnectorTestScenario(BaseModel):
         name: str
         bypass_reason: str | None = None
 
+        # bypass reason does not affect equality
+        def __hash__(self) -> int:
+            return hash(self.name)
+
     config_path: Path | None = None
     config_dict: dict[str, Any] | None = None
 

--- a/airbyte_cdk/test/standard_tests/connector_base.py
+++ b/airbyte_cdk/test/standard_tests/connector_base.py
@@ -10,20 +10,12 @@ from typing import TYPE_CHECKING, cast
 
 from boltons.typeutils import classproperty
 
-from airbyte_cdk.models import (
-    AirbyteMessage,
-    Type,
-)
 from airbyte_cdk.test import entrypoint_wrapper
 from airbyte_cdk.test.models import (
     ConnectorTestScenario,
 )
 from airbyte_cdk.test.standard_tests._job_runner import IConnector, run_test_job
 from airbyte_cdk.test.standard_tests.docker_base import DockerConnectorTestSuite
-from airbyte_cdk.utils.connector_paths import (
-    ACCEPTANCE_TEST_CONFIG,
-    find_connector_root,
-)
 
 if TYPE_CHECKING:
     from collections.abc import Callable

--- a/airbyte_cdk/test/standard_tests/docker_base.py
+++ b/airbyte_cdk/test/standard_tests/docker_base.py
@@ -346,7 +346,7 @@ class DockerConnectorTestSuite:
 
             if scenario.empty_streams:
                 # If there are empty streams, we remove them from the list of streams to read.
-                streams_list = list(set(streams_list) - set(scenario.empty_streams))
+                streams_list = list(set(streams_list) - set(stream.name for stream in scenario.empty_streams))
 
             configured_catalog: ConfiguredAirbyteCatalog = ConfiguredAirbyteCatalog(
                 streams=[

--- a/airbyte_cdk/test/standard_tests/docker_base.py
+++ b/airbyte_cdk/test/standard_tests/docker_base.py
@@ -66,13 +66,15 @@ class DockerConnectorTestSuite:
     @classproperty
     def acceptance_test_config(cls) -> dict[str, object]:
         """Get the contents of acceptance test config file.
-        
+
         Also perform some basic validation that the file has the expected structure.
         """
         acceptance_test_config_path = cls.get_connector_root_dir() / ACCEPTANCE_TEST_CONFIG
         if not acceptance_test_config_path.exists():
-            raise FileNotFoundError(f"Acceptance test config file not found at: {str(acceptance_test_config_path)}")
-        
+            raise FileNotFoundError(
+                f"Acceptance test config file not found at: {str(acceptance_test_config_path)}"
+            )
+
         tests_config = yaml.safe_load(acceptance_test_config_path.read_text())
 
         if "acceptance_tests" not in tests_config:
@@ -130,7 +132,9 @@ class DockerConnectorTestSuite:
                 if scenario.config_path == existing_scenario.config_path:
                     # If a scenario with the same config_path already exists, we merge the empty streams.
                     # scenarios are immutable, so we create a new one.
-                    all_empty_streams = (existing_scenario.empty_streams or []) + (scenario.empty_streams or [])
+                    all_empty_streams = (existing_scenario.empty_streams or []) + (
+                        scenario.empty_streams or []
+                    )
                     new_scenario = existing_scenario.model_copy(
                         update={"empty_streams": all_empty_streams}
                     )
@@ -346,7 +350,9 @@ class DockerConnectorTestSuite:
 
             if scenario.empty_streams:
                 # If there are empty streams, we remove them from the list of streams to read.
-                streams_list = list(set(streams_list) - set(stream.name for stream in scenario.empty_streams))
+                streams_list = list(
+                    set(streams_list) - set(stream.name for stream in scenario.empty_streams)
+                )
 
             configured_catalog: ConfiguredAirbyteCatalog = ConfiguredAirbyteCatalog(
                 streams=[

--- a/airbyte_cdk/test/standard_tests/docker_base.py
+++ b/airbyte_cdk/test/standard_tests/docker_base.py
@@ -10,7 +10,6 @@ import tempfile
 import warnings
 from dataclasses import asdict
 from pathlib import Path
-from subprocess import CompletedProcess, SubprocessError
 from typing import Literal, cast
 
 import orjson
@@ -35,7 +34,6 @@ from airbyte_cdk.utils.connector_paths import (
 from airbyte_cdk.utils.docker import (
     build_connector_image,
     run_docker_airbyte_command,
-    run_docker_command,
 )
 
 
@@ -85,7 +83,7 @@ class DockerConnectorTestSuite:
         """
         categories = ["connection", "spec"]
         try:
-            acceptance_test_config_path = cls.acceptance_test_config_path
+            cls.acceptance_test_config_path
         except FileNotFoundError as e:
             # Destinations sometimes do not have an acceptance tests file.
             warnings.warn(

--- a/airbyte_cdk/test/standard_tests/docker_base.py
+++ b/airbyte_cdk/test/standard_tests/docker_base.py
@@ -10,7 +10,7 @@ import tempfile
 import warnings
 from dataclasses import asdict
 from pathlib import Path
-from typing import Literal, cast
+from typing import Any, Literal, cast
 
 import orjson
 import pytest
@@ -64,7 +64,7 @@ class DockerConnectorTestSuite:
         return cast(str, cls.connector_name).startswith("destination-")
 
     @classproperty
-    def acceptance_test_config(cls) -> dict[str, object]:
+    def acceptance_test_config(cls) -> Any:
         """Get the contents of acceptance test config file.
 
         Also perform some basic validation that the file has the expected structure.

--- a/airbyte_cdk/test/standard_tests/docker_base.py
+++ b/airbyte_cdk/test/standard_tests/docker_base.py
@@ -354,6 +354,11 @@ class DockerConnectorTestSuite:
                     set(streams_list) - set(stream.name for stream in scenario.empty_streams)
                 )
 
+            if scenario.empty_streams:
+                # Filter out streams marked as empty in the scenario.
+                empty_stream_names = [stream.name for stream in scenario.empty_streams]
+                streams_list = [s for s in streams_list if s.name not in empty_stream_names]
+
             configured_catalog: ConfiguredAirbyteCatalog = ConfiguredAirbyteCatalog(
                 streams=[
                     ConfiguredAirbyteStream(

--- a/airbyte_cdk/test/standard_tests/source_base.py
+++ b/airbyte_cdk/test/standard_tests/source_base.py
@@ -121,9 +121,11 @@ class SourceTestSuiteBase(ConnectorTestSuiteBase):
             # Failed as expected; we're done.
             return
         streams = discover_result.catalog.catalog.streams  # type: ignore [reportOptionalMemberAccess, union-attr]
-        if scenario.empty_streams is not None:
-            # If the scenario has an "empty_streams" key, filter out those streams.
-            streams = [stream for stream in streams if stream.name not in scenario.empty_streams]
+
+        if scenario.empty_streams:
+            # Don't read from any streams marked as empty in the scenario.
+            streams = list(set(streams) - set(stream.name for stream in scenario.empty_streams))
+
         configured_catalog = ConfiguredAirbyteCatalog(
             streams=[
                 ConfiguredAirbyteStream(

--- a/airbyte_cdk/test/standard_tests/source_base.py
+++ b/airbyte_cdk/test/standard_tests/source_base.py
@@ -123,9 +123,10 @@ class SourceTestSuiteBase(ConnectorTestSuiteBase):
         streams = discover_result.catalog.catalog.streams  # type: ignore [reportOptionalMemberAccess, union-attr]
 
         if scenario.empty_streams:
-            # Don't read from any streams marked as empty in the scenario.
-            streams = list(set(streams) - set(stream.name for stream in scenario.empty_streams))
-
+            # Filter out streams marked as empty in the scenario.
+            empty_stream_names = [stream.name for stream in scenario.empty_streams]
+            streams = [s for s in streams if s.name not in empty_stream_names]
+    
         configured_catalog = ConfiguredAirbyteCatalog(
             streams=[
                 ConfiguredAirbyteStream(

--- a/airbyte_cdk/test/standard_tests/source_base.py
+++ b/airbyte_cdk/test/standard_tests/source_base.py
@@ -126,7 +126,7 @@ class SourceTestSuiteBase(ConnectorTestSuiteBase):
             # Filter out streams marked as empty in the scenario.
             empty_stream_names = [stream.name for stream in scenario.empty_streams]
             streams = [s for s in streams if s.name not in empty_stream_names]
-    
+
         configured_catalog = ConfiguredAirbyteCatalog(
             streams=[
                 ConfiguredAirbyteStream(

--- a/airbyte_cdk/test/standard_tests/source_base.py
+++ b/airbyte_cdk/test/standard_tests/source_base.py
@@ -120,7 +120,10 @@ class SourceTestSuiteBase(ConnectorTestSuiteBase):
         if scenario.expected_outcome.expect_exception() and discover_result.errors:
             # Failed as expected; we're done.
             return
-
+        streams = discover_result.catalog.catalog.streams  # type: ignore [reportOptionalMemberAccess, union-attr]
+        if scenario.empty_streams is not None:
+            # If the scenario has an "empty_streams" key, filter out those streams.
+            streams = [stream for stream in streams if stream.name not in scenario.empty_streams]
         configured_catalog = ConfiguredAirbyteCatalog(
             streams=[
                 ConfiguredAirbyteStream(
@@ -128,7 +131,7 @@ class SourceTestSuiteBase(ConnectorTestSuiteBase):
                     sync_mode=SyncMode.full_refresh,
                     destination_sync_mode=DestinationSyncMode.append_dedup,
                 )
-                for stream in discover_result.catalog.catalog.streams  # type: ignore [reportOptionalMemberAccess, union-attr]
+                for stream in streams
             ]
         )
         result = run_test_job(

--- a/airbyte_cdk/utils/connector_paths.py
+++ b/airbyte_cdk/utils/connector_paths.py
@@ -86,8 +86,6 @@ def resolve_airbyte_repo_root(
 
 def resolve_connector_name_and_directory(
     connector_ref: str | Path | None = None,
-    *,
-    connector_directory: Path | None = None,
 ) -> tuple[str, Path]:
     """Resolve the connector name and directory.
 
@@ -104,6 +102,7 @@ def resolve_connector_name_and_directory(
         FileNotFoundError: If the connector directory does not exist or cannot be found.
     """
     connector_name: str | None = None
+    connector_directory: Path | None = None
 
     # Resolve connector_ref to connector_name or connector_directory (if provided)
     if connector_ref:


### PR DESCRIPTION
## What

fixes: https://github.com/airbytehq/airbyte-internal-issues/issues/13521

This PR attempts to make FAST tests respect the `empty_streams` key in acceptance-test-config.yml files by choosing not to sync data from those streams. Historically the `empty_streams` key was used not only to denote streams that don't have any data to sync but also streams that will fail syncs for a variety of reasons. Running tests against these streams has been leading to false positive failures. This PR attempts to replicate the behavior of CATs with a bit less sophistication, fitting with the goals of the FAST test suite. 

This implementation somewhat messy due to how the test suite currently parses these files - extracting only a subset of test scenarios to run all operations (spec, check, read) against.

I see this as a temporary fix until we are able to redesign how we want to configure FASTs and deprecate these files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for specifying empty streams with optional bypass reasons in connector test scenarios. Scenarios can now identify streams expected to be empty and exclude them from read tests.

* **Bug Fixes**
  * Improved test behavior to correctly filter out empty streams during connector acceptance tests.

* **Refactor**
  * Enhanced merging of duplicate test scenarios to preserve all empty stream information.
  * Updated function signatures and internal logic for better configuration handling and code clarity.
  * Removed `@dataclass` decorator from a custom exception class for simplicity.

* **Chores**
  * Removed unused imports for cleaner codebase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->