### PR TITLE
fix: add interpolation_context to auth fields

### DIFF
--- a/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -1229,7 +1229,7 @@ definitions:
         interpolation_context:
           - config
         examples:
-          - "{{ config['client_id }}"
+          - "{{ config['client_id'] }}"
           - "{{ config['credentials']['client_id }}"
       client_secret_name:
         title: Client Secret Property Name

--- a/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -1095,6 +1095,8 @@ definitions:
         title: Secret Key
         type: string
         description: Secret used to sign the JSON web token.
+        interpolation_context:
+          - config
         examples:
           - "{{ config['secret_key'] }}"
       base64_encode_secret_key:
@@ -1224,6 +1226,8 @@ definitions:
         title: Client ID
         description: The OAuth client ID. Fill it in the user inputs.
         type: string
+        interpolation_context:
+          - config
         examples:
           - "{{ config['client_id }}"
           - "{{ config['credentials']['client_id }}"
@@ -1238,6 +1242,8 @@ definitions:
         title: Client Secret
         description: The OAuth client secret. Fill it in the user inputs.
         type: string
+        interpolation_context:
+          - config
         examples:
           - "{{ config['client_secret }}"
           - "{{ config['credentials']['client_secret }}"
@@ -1252,6 +1258,8 @@ definitions:
         title: Refresh Token
         description: Credential artifact used to get a new access token.
         type: string
+        interpolation_context:
+          - config
         examples:
           - "{{ config['refresh_token'] }}"
           - "{{ config['credentials]['refresh_token'] }}"
@@ -1272,6 +1280,8 @@ definitions:
         title: Access Token Value
         description: The value of the access_token to bypass the token refreshing using `refresh_token`.
         type: string
+        interpolation_context:
+          - config
         examples:
           - secret_access_token_value
       expires_in_name:

--- a/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -1245,7 +1245,7 @@ definitions:
         interpolation_context:
           - config
         examples:
-          - "{{ config['client_secret }}"
+          - "{{ config['client_secret'] }}"
           - "{{ config['credentials']['client_secret }}"
       refresh_token_name:
         title: Refresh Token Property Name

--- a/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
+++ b/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
@@ -523,7 +523,10 @@ class OAuthAuthenticator(BaseModel):
     client_id: Optional[str] = Field(
         None,
         description="The OAuth client ID. Fill it in the user inputs.",
-        examples=["{{ config['client_id }}", "{{ config['credentials']['client_id }}"],
+        examples=[
+            "{{ config['client_id'] }}",
+            "{{ config['credentials']['client_id }}",
+        ],
         title="Client ID",
     )
     client_secret_name: Optional[str] = Field(
@@ -536,7 +539,7 @@ class OAuthAuthenticator(BaseModel):
         None,
         description="The OAuth client secret. Fill it in the user inputs.",
         examples=[
-            "{{ config['client_secret }}",
+            "{{ config['client_secret'] }}",
             "{{ config['credentials']['client_secret }}",
         ],
         title="Client Secret",


### PR DESCRIPTION
`interpolation_context` was missing from multiple auth fields that commonly need to access the `config` interpolation variable.

This is a problem for the Builder UI, as `interpolation_context` is how the Builder UI knows whether it should render the JinjaInput component for a field, which offers suggestions and formatting for jinja expressions.

This PR fixes the issue by adding this property to the fields that were missing it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that several authentication fields now explicitly support dynamic value interpolation using connector configuration. This applies to secret key fields in JWT authentication and client credentials in OAuth authentication.
  * Corrected example syntax for OAuth client ID and client secret fields to improve clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->