### PR TITLE
fix: class AirbyteOutputException initialization

### DIFF
--- a/airbyte_cdk/test/entrypoint_wrapper.py
+++ b/airbyte_cdk/test/entrypoint_wrapper.py
@@ -65,6 +65,8 @@ class AirbyteEntrypointException(Exception):
             raise output.as_exception()
     """
 
+    message: str = ""
+
 
 class EntrypointOutput:
     """A class to encapsulate the output of an Airbyte connector's execution.

--- a/airbyte_cdk/test/entrypoint_wrapper.py
+++ b/airbyte_cdk/test/entrypoint_wrapper.py
@@ -68,9 +68,8 @@ class AirbyteEntrypointException(Exception):
     message: str = ""
 
     def __post_init__(self) -> None:
-        # Propagate the message to Exception so that `str(self)` and `.args`
-        # behave like a regular exception.
         super().__init__(self.message)
+
 
 class EntrypointOutput:
     """A class to encapsulate the output of an Airbyte connector's execution.

--- a/airbyte_cdk/test/entrypoint_wrapper.py
+++ b/airbyte_cdk/test/entrypoint_wrapper.py
@@ -67,6 +67,10 @@ class AirbyteEntrypointException(Exception):
 
     message: str = ""
 
+    def __post_init__(self) -> None:
+        # Propagate the message to Exception so that `str(self)` and `.args`
+        # behave like a regular exception.
+        super().__init__(self.message)
 
 class EntrypointOutput:
     """A class to encapsulate the output of an Airbyte connector's execution.


### PR DESCRIPTION
## What
- Adds `message` attribute to `AirbyteOutputException`

Previously was receiving this error during FAST tests:
`TypeError: AirbyteEntrypointException.__init__() takes 1 positional argument but 2 were given`

This fix enables injecting a string as the error message for the exception.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved error handling by adding a message attribute to exceptions for clearer error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._