### PR TITLE
fix: unmark partition router as linkable

### DIFF
--- a/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -3682,7 +3682,6 @@ definitions:
       partition_router:
         title: Partition Router
         description: Used to iteratively execute requests over a set of values, such as a parent stream's records or a list of constant values.
-        linkable: true
         anyOf:
           - "$ref": "#/definitions/SubstreamPartitionRouter"
           - "$ref": "#/definitions/ListPartitionRouter"


### PR DESCRIPTION
This PR makes `partition_router` no longer linkable.

Since the Builder uses `$ref`s in partition_router to point to different streams, there were some funky edge cases happening when the CDK would normalize manifests that contained partition routers.

I don't actually think there is that much value in having partition_routers be linkable across streams anyway, because they tend to be pretty stream-specific. So the safest and easiest change is to just stop linking them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the schema metadata for the "partition_router" property in the "SimpleRetriever" component. No changes to user-facing features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->