### PR TITLE
fix: make incremental_sync not linkable

### DIFF
--- a/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -2038,6 +2038,7 @@ definitions:
         deprecation_message: "Use `url` field instead."
         title: API Base URL
         description: Deprecated, use the `url` instead. Base URL of the API source. Do not put sensitive information (e.g. API tokens) into this field - Use the Authenticator component for this.
+        linkable: true
         type: string
         interpolation_context:
           - config

--- a/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -1511,7 +1511,6 @@ definitions:
       incremental_sync:
         title: Incremental Sync
         description: Component used to fetch data incrementally based on a time field in the data.
-        linkable: true
         anyOf:
           - "$ref": "#/definitions/DatetimeBasedCursor"
           - "$ref": "#/definitions/IncrementingCountCursor"
@@ -2039,7 +2038,6 @@ definitions:
         deprecation_message: "Use `url` field instead."
         title: API Base URL
         description: Deprecated, use the `url` instead. Base URL of the API source. Do not put sensitive information (e.g. API tokens) into this field - Use the Authenticator component for this.
-        linkable: true
         type: string
         interpolation_context:
           - config


### PR DESCRIPTION
It seems incremental_sync is not playing nicely with the linkable behavior - both are causing issues for some users when the Builder resolves their connectors.

More investigation will be needed to determine root cause of the issues but for now I'd like to remove `linkable: true` from these fields to unblock the users ASAP.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

* **Refactor**
  * Updated schema definitions by removing certain attributes from specific properties. No changes to functionality or visible features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->