### PR TITLE
fix: state migration

### DIFF
--- a/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -2114,9 +2114,7 @@ class ModelToComponentFactory:
     ) -> Optional[StreamSlicer]:
         state_transformations = (
             [
-                self._create_component_from_model(
-                    state_migration, config, declarative_stream=model
-                )
+                self._create_component_from_model(state_migration, config, declarative_stream=model)
                 for state_migration in model.state_migrations
             ]
             if model.state_migrations
@@ -2190,9 +2188,7 @@ class ModelToComponentFactory:
 
         if model.state_migrations:
             state_transformations = [
-                self._create_component_from_model(
-                    state_migration, config, declarative_stream=model
-                )
+                self._create_component_from_model(state_migration, config, declarative_stream=model)
                 for state_migration in model.state_migrations
             ]
         else:


### PR DESCRIPTION
## What 

[This PR](https://github.com/airbytehq/airbyte-python-cdk/pull/679) broke connector with state migration because we build the concurrent cursor here now. We can see the impact [here](https://github.com/airbytehq/airbyte/pull/64197)

## How

Building state migration components from model because calling the methods

## User Impact
Connectors with state migration and increment datetime cursors or incremental counting cursors won't be broken anymore

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of state transformations for incremental and concurrent cursors to enhance code clarity. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->