### PR TITLE
fix: properly join url and path when calculating full url

### DIFF
--- a/airbyte_cdk/sources/declarative/requesters/http_requester.py
+++ b/airbyte_cdk/sources/declarative/requesters/http_requester.py
@@ -168,7 +168,13 @@ class HttpRequester(Requester):
             next_page_token=next_page_token,
         )
 
-        full_url = self._join_url(url_base, path) if url_base else url + path if path else url
+        full_url = (
+            self._join_url(url_base, path)
+            if url_base
+            else self._join_url(url, path)
+            if path
+            else url
+        )
 
         return full_url
 


### PR DESCRIPTION
## What
A user raised a bug with the current logic for handling `Request Path` cursor page token injection: https://airbyte1416.zendesk.com/agent/tickets/13510

Basically, if the "next page token" contains a full URL which contains a different domain than the `url` field of the stream's HttpRequester, we currently just naively concatenate the two together, which usually results in a failure.

Here is an example from the zendesk ticket above:
- Currently, their API Endpoint URL for that stream is `https://globalus251.dayforcehcm.com/api/parachute/v1/Reports/job_posting`
- But the Cursor Pagination returns a "next page" URL that looks like this: `https://globalus251.dayforcehcm.com:443/api/parachute/v1/Reports/job_posting?25c92c37-2ba7-468c-89f9-834f6c050ddc=2024-01-01T00%3a00%3a00.000000&cursor=UhsMQmz0rZtvj7oCJ1e7DLe2O7v5nb5Gco1YD9NCTtU%253D`
- Notice that that next page URL has `:443` after the `.com`, but the API Endpoint URL doesn't
- This results in the second page request being sent to `https://globalus251.dayforcehcm.com/api/parachute/v1/Reports/job_postinghttps://globalus251.dayforcehcm.com:443/api/parachute/v1/Reports/job_posting?25c92c37-2ba7-468c-89f9-834f6c050ddc=2024-01-01T00%3A00%3A00.000000&cursor=UdaBrnaiXuKw%252BFyD6FzERZba7d%252FPA0HuIoON3QbfZwI%253D&pageSize=5` (which is just the concatenation of the API Endpoint URL and the next page token)

## How
To fix this, I simply modify the logic to call `_join_url()` on the `url` and `path` instead of naively concatenating them together.

This fixes the issue, because `_join_url()` will prefer the `path` if it contains its own full http scheme and domain, which is what we want in this case.

This also has a side-benefit of correctly handling the case where the `url` does not have a trailing `/` and the `path` does not have a leading `/` - the old implementation would not insert a `/` between these, whereas the new implementation does.

## Testing
I have added unit tests to validate this fix, and you can reproduce the situation with this manifest: https://gist.github.com/lmossman/404b656c3e5726ddebc026eae118b7f8 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL joining logic to ensure consistent and reliable construction of request URLs in all scenarios.

* **Tests**
  * Added new tests to verify correct URL formation when using different combinations of base URLs and paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->