### PR TITLE
feat: Add --no-creds option to connector and image test commands

### DIFF
--- a/airbyte_cdk/cli/airbyte_cdk/_connector.py
+++ b/airbyte_cdk/cli/airbyte_cdk/_connector.py
@@ -123,11 +123,18 @@ def connector_cli_group() -> None:
     multiple=True,
     help="Additional argument(s) to pass to pytest. Can be specified multiple times.",
 )
+@click.option(
+    "--no-creds",
+    is_flag=True,
+    default=False,
+    help="Skip tests that require credentials (marked with 'requires_creds').",
+)
 def connector_test(
     connector: str | Path | None = None,
     *,
     collect_only: bool = False,
     pytest_args: list[str] | None = None,
+    no_creds: bool = False,
 ) -> None:
     """Run connector tests.
 
@@ -146,6 +153,9 @@ def connector_test(
     pytest_args = pytest_args or []
     if collect_only:
         pytest_args.append("--collect-only")
+
+    if no_creds:
+        pytest_args.extend(["-m", "not requires_creds"])
 
     run_connector_tests(
         connector_name=connector_name,

--- a/airbyte_cdk/cli/airbyte_cdk/_image.py
+++ b/airbyte_cdk/cli/airbyte_cdk/_image.py
@@ -100,10 +100,17 @@ def build(
     "--image",
     help="Image to test, instead of building a new one.",
 )
+@click.option(
+    "--no-creds",
+    is_flag=True,
+    default=False,
+    help="Skip tests that require credentials (marked with 'requires_creds').",
+)
 def image_test(  # "image test" command
     connector: str | None = None,
     *,
     image: str | None = None,
+    no_creds: bool = False,
 ) -> None:
     """Test a connector Docker image.
 
@@ -124,7 +131,7 @@ def image_test(  # "image test" command
     connector_name, connector_directory = resolve_connector_name_and_directory(connector)
 
     # Select only tests with the 'image_tests' mark
-    pytest_args = ["-m", "image_tests"]
+    pytest_args = ["-m", "image_tests and not requires_creds" if no_creds else "image_tests"]
     if not image:
         metadata_file_path: Path = connector_directory / "metadata.yaml"
         try:

--- a/airbyte_cdk/cli/airbyte_cdk/_image.py
+++ b/airbyte_cdk/cli/airbyte_cdk/_image.py
@@ -131,7 +131,11 @@ def image_test(  # "image test" command
     connector_name, connector_directory = resolve_connector_name_and_directory(connector)
 
     # Select only tests with the 'image_tests' mark
-    pytest_args = ["-m", "image_tests and not requires_creds" if no_creds else "image_tests"]
+    pytest_filter = "image_tests"
+    if no_creds:
+        pytest_filter += " and not requires_creds"
+
+    pytest_args = ["-m", pytest_filter]
     if not image:
         metadata_file_path: Path = connector_directory / "metadata.yaml"
         try:

--- a/airbyte_cdk/test/models/scenario.py
+++ b/airbyte_cdk/test/models/scenario.py
@@ -186,3 +186,8 @@ class ConnectorTestScenario(BaseModel):
             **self.model_dump(exclude={"status"}),
             status="succeed",
         )
+
+    @property
+    def requires_creds(self) -> bool:
+        """Return True if the scenario requires credentials to run."""
+        return bool(self.config_path and "secrets" in self.config_path.parts)


### PR DESCRIPTION
# feat: Add --no-creds option to connector and image test commands

## Summary

Adds a `--no-creds` CLI option to both `airbyte-cdk connector test` and `airbyte-cdk image test` commands that skips tests marked with the `requires_creds` pytest marker. This enables running tests without requiring credentials to be configured, which is useful for CI environments, forks, and local development where credentials may not be available.

**Key Changes:**
- Added `--no-creds` flag to `airbyte-cdk connector test` command
- Added `--no-creds` flag to `airbyte-cdk image test` command  
- When `--no-creds` is used, tests marked with `requires_creds` are skipped via pytest marker filtering
- For connector tests: uses `-m "not requires_creds"` filter
- For image tests: combines with existing marker using `-m "image_tests and not requires_creds"`
- Maintains full backward compatibility when flag is not used

## Review & Testing Checklist for Human

- [ ] **Test actual functionality** with a real connector that has `requires_creds` tests - verify that `--no-creds` properly skips those tests while running others
- [ ] **Verify pytest marker syntax** is correct, especially the `"image_tests and not requires_creds"` combination for image tests
- [ ] **Test CLI argument handling** works correctly with other options like `--collect-only` and `--pytest-arg`
- [ ] **Confirm backward compatibility** by running both commands without `--no-creds` to ensure existing behavior is unchanged

**Recommended Test Plan:**
1. Find a connector with tests marked `@pytest.mark.requires_creds`
2. Run `airbyte-cdk connector test <connector> --collect-only` (should show requires_creds tests)
3. Run `airbyte-cdk connector test <connector> --no-creds --collect-only` (should skip requires_creds tests)
4. Run `airbyte-cdk image test <connector> --no-creds --collect-only` (should show only image_tests that don't require creds)

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TB
    CLI1["airbyte_cdk/cli/airbyte_cdk/<br/>_connector.py"]:::major-edit
    CLI2["airbyte_cdk/cli/airbyte_cdk/<br/>_image.py"]:::major-edit
    
    SHARED["airbyte_cdk/cli/airbyte_cdk/<br/>_connector.py<br/>run_connector_tests()"]:::context
    
    PYTEST_INI["pytest.ini<br/>requires_creds marker"]:::context
    PYPROJECT["pyproject.toml<br/>existing pattern"]:::context
    
    CLI1 -->|"calls with<br/>extra_pytest_args"| SHARED
    CLI2 -->|"calls with<br/>extra_pytest_args"| SHARED
    
    CLI1 -.->|"adds -m not requires_creds<br/>when --no-creds used"| PYTEST_INI
    CLI2 -.->|"adds -m image_tests and<br/>not requires_creds"| PYTEST_INI
    
    PYPROJECT -.->|"existing pattern:<br/>pytest-fast excludes<br/>requires_creds"| PYTEST_INI

    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end

    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#F5F5F5
```

### Notes

- Implementation follows the existing pattern used in `pyproject.toml` where `pytest-fast` already excludes `requires_creds` tests
- The `requires_creds` marker is already defined in `pytest.ini` 
- Both commands leverage the shared `run_connector_tests()` function, so the implementation is consistent
- Limited local testing was possible since the commands require being run from a proper connector directory

**Link to Devin session:** https://app.devin.ai/sessions/9fc0a40482c64cbc8c865fb7f009f415  
**Requested by:** @aaronsteers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `--no-creds` command-line option to both the connector and image test commands, allowing users to easily skip tests that require credentials.
  * Test scenarios now automatically identify and mark those requiring credentials, improving test selection and execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->