### PR TITLE
docs: adjust descriptions of page token option

### DIFF
--- a/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -1838,6 +1838,7 @@ definitions:
         "$ref": "#/definitions/RequestOption"
       page_token_option:
         title: Inject Page Token Into Outgoing HTTP Request
+        description: Inject the page token into the outgoing HTTP requests by inserting it into either the request URL path or a field on the request.
         anyOf:
           - "$ref": "#/definitions/RequestOption"
           - "$ref": "#/definitions/RequestPath"
@@ -3486,7 +3487,7 @@ definitions:
           - [["content", "html"], ["content", "plain_text"]]
   RequestPath:
     title: Request Path
-    description: Specifies where in the request path a component's value should be inserted.
+    description: The URL path to be used for the HTTP request.
     type: object
     required:
       - type

--- a/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
+++ b/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
@@ -2002,7 +2002,9 @@ class DefaultPaginator(BaseModel):
         None, title="Inject Page Size Into Outgoing HTTP Request"
     )
     page_token_option: Optional[Union[RequestOption, RequestPath]] = Field(
-        None, title="Inject Page Token Into Outgoing HTTP Request"
+        None,
+        description="Inject the page token into the outgoing HTTP requests by inserting it into either the request URL path or a field on the request.",
+        title="Inject Page Token Into Outgoing HTTP Request",
     )
     parameters: Optional[Dict[str, Any]] = Field(None, alias="$parameters")
 


### PR DESCRIPTION
Currently in the Builder UI, there is no tooltip explaining what the difference between Request Option and Request Path is for page token injection.

This PR fixes this by adjusting the descriptions of these definitions. This is what the changes look like in the UI:
<img width="958" height="206" alt="Screenshot 2025-08-06 at 5 10 06 PM" src="https://github.com/user-attachments/assets/538760cd-2c61-46c6-93b5-636c3fc2fbe1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved descriptions for configuration options related to page token injection and request paths in the schema, providing clearer guidance for users configuring HTTP requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->