### PR TITLE
feat: pass transformations to retriever instance

### DIFF
--- a/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -1707,7 +1707,7 @@ class ModelToComponentFactory:
 
             if self._is_component(model_value):
                 model_args[model_field] = self._create_nested_component(
-                    model, model_field, model_value, config
+                    model, model_field, model_value, config, **kwargs,
                 )
             elif isinstance(model_value, list):
                 vals = []
@@ -1809,7 +1809,7 @@ class ModelToComponentFactory:
             return []
 
     def _create_nested_component(
-        self, model: Any, model_field: str, model_value: Any, config: Config
+        self, model: Any, model_field: str, model_value: Any, config: Config, **kwargs
     ) -> Any:
         type_name = model_value.get("type", None)
         if not type_name:
@@ -1834,8 +1834,14 @@ class ModelToComponentFactory:
                     for kwarg in constructor_kwargs
                     if kwarg in model_parameters
                 }
+                matching_kwargs = {
+                    kwarg: kwargs[kwarg]
+                    for kwarg in constructor_kwargs
+                    if kwarg in kwargs
+                }
+
                 return self._create_component_from_model(
-                    model=parsed_model, config=config, **matching_parameters
+                    model=parsed_model, config=config, **(matching_parameters | matching_kwargs)
                 )
             except TypeError as error:
                 missing_parameters = self._extract_missing_parameters(error)

--- a/unit_tests/sources/declarative/parsers/testing_components.py
+++ b/unit_tests/sources/declarative/parsers/testing_components.py
@@ -13,6 +13,7 @@ from airbyte_cdk.sources.declarative.requesters.paginators import (
     DefaultPaginator,
     PaginationStrategy,
 )
+from airbyte_cdk.sources.declarative.retrievers import SimpleRetriever
 
 
 @dataclass
@@ -43,3 +44,8 @@ class TestingCustomSubstreamPartitionRouter(SubstreamPartitionRouter):
 
     custom_field: str
     custom_pagination_strategy: PaginationStrategy
+
+
+@dataclass
+class TestingCustomRetriever(SimpleRetriever):
+    pass


### PR DESCRIPTION
## What

Currently if we wants transformations to be passed to the record selector when there is a custom retriever, we need to do [this](https://github.com/airbytehq/airbyte/blob/6d42d30fb64970608e212ba24bf0471dbf2078d7/airbyte-integrations/connectors/source-google-ads/source_google_ads/components.py#L431). 

## How

The ModelToComponentFactory will match function arguments not only on model parameters but also on kwargs being passed. If there is a collision, model parameters will be prioritize to keep backward compatibility