### PR TITLE
tests: Add parametrized validation test for manifest-only connectors

### DIFF
--- a/unit_tests/sources/declarative/test_manifest_registry_validation.py
+++ b/unit_tests/sources/declarative/test_manifest_registry_validation.py
@@ -1,0 +1,226 @@
+"""
+Unit tests for validating manifest.yaml files from the connector registry against the CDK schema.
+
+This test suite fetches all manifest-only connectors from the Airbyte connector registry,
+downloads their manifest.yaml files from public endpoints, and validates them against
+the current declarative component schema defined in the CDK.
+"""
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+from unittest.mock import patch
+
+import pytest
+import requests
+import yaml
+
+from airbyte_cdk.sources.declarative.validators.validate_adheres_to_schema import (
+    ValidateAdheresToSchema,
+)
+
+
+logger = logging.getLogger(__name__)
+
+EXCLUDED_CONNECTORS = [
+]
+
+CONNECTOR_REGISTRY_URL = "https://connectors.airbyte.com/files/registries/v0/oss_registry.json"
+MANIFEST_URL_TEMPLATE = "https://connectors.airbyte.com/files/metadata/airbyte/{connector_name}/latest/manifest.yaml"
+
+VALIDATION_SUCCESSES = []
+VALIDATION_FAILURES = []
+DOWNLOAD_FAILURES = []
+
+
+def load_declarative_component_schema() -> Dict[str, Any]:
+    """Load the declarative component schema from the CDK."""
+    schema_path = (
+        Path(__file__).resolve().parent.parent.parent.parent
+        / "airbyte_cdk/sources/declarative/declarative_component_schema.yaml"
+    )
+    with open(schema_path, "r") as file:
+        return yaml.safe_load(file)
+
+
+def get_manifest_only_connectors() -> List[Tuple[str, str]]:
+    """
+    Fetch manifest-only connectors from the registry.
+    
+    Returns:
+        List of tuples (connector_name, cdk_version) where cdk_version will be 
+        determined from the manifest.yaml file itself.
+    """
+    try:
+        response = requests.get(CONNECTOR_REGISTRY_URL, timeout=30)
+        response.raise_for_status()
+        registry = response.json()
+        
+        manifest_connectors = []
+        for source in registry.get("sources", []):
+            if source.get("language") == "manifest-only":
+                connector_name = source.get("dockerRepository", "").replace("airbyte/", "")
+                if connector_name:
+                    manifest_connectors.append((connector_name, None))
+        
+        return manifest_connectors
+    except Exception as e:
+        pytest.fail(f"Failed to fetch connector registry: {e}")
+
+
+def download_manifest(connector_name: str) -> Tuple[str, str]:
+    """
+    Download manifest.yaml for a connector.
+    
+    Returns:
+        Tuple of (manifest_content, cdk_version) where cdk_version is extracted
+        from the manifest's version field.
+    """
+    url = MANIFEST_URL_TEMPLATE.format(connector_name=connector_name)
+    try:
+        response = requests.get(url, timeout=30)
+        response.raise_for_status()
+        manifest_content = response.text
+        
+        manifest_dict = yaml.safe_load(manifest_content)
+        cdk_version = manifest_dict.get("version", "unknown")
+        
+        return manifest_content, cdk_version
+    except Exception as e:
+        DOWNLOAD_FAILURES.append((connector_name, str(e)))
+        raise
+
+
+def get_manifest_only_connector_names() -> List[str]:
+    """
+    Get all manifest-only connector names from the registry.
+    
+    Returns:
+        List of connector names (e.g., "source-hubspot")
+    """
+    connectors = get_manifest_only_connectors()
+    return [connector_name for connector_name, _ in connectors]
+
+
+@pytest.mark.parametrize("connector_name", get_manifest_only_connector_names())
+def test_manifest_validates_against_schema(connector_name: str):
+    """
+    Test that manifest.yaml files from the registry validate against the CDK schema.
+    
+    Args:
+        connector_name: Name of the connector (e.g., "source-hubspot")
+    """
+    # Download manifest first to get CDK version
+    try:
+        manifest_content, cdk_version = download_manifest(connector_name)
+    except Exception as e:
+        pytest.fail(f"Failed to download manifest for {connector_name}: {e}")
+    
+    if (connector_name, cdk_version) in EXCLUDED_CONNECTORS:
+        pytest.skip(
+            f"Skipping {connector_name} - connector declares it is compatible with "
+            f"CDK version {cdk_version} but is known to fail validation"
+        )
+    
+    try:
+        manifest_dict = yaml.safe_load(manifest_content)
+    except yaml.YAMLError as e:
+        error_msg = f"Invalid YAML in manifest for {connector_name}: {e}"
+        VALIDATION_FAILURES.append((connector_name, cdk_version, error_msg))
+        pytest.fail(error_msg)
+    
+    schema = load_declarative_component_schema()
+    validator = ValidateAdheresToSchema(schema=schema)
+    
+    try:
+        validator.validate(manifest_dict)
+        VALIDATION_SUCCESSES.append((connector_name, cdk_version))
+        logger.info(f"✓ {connector_name} (CDK {cdk_version}) - validation passed")
+    except ValueError as e:
+        error_msg = (
+            f"Manifest validation failed for {connector_name} "
+            f"(connector declares it is compatible with CDK version {cdk_version}): {e}"
+        )
+        VALIDATION_FAILURES.append((connector_name, cdk_version, str(e)))
+        logger.error(f"✗ {connector_name} (CDK {cdk_version}) - validation failed: {e}")
+        pytest.fail(error_msg)
+
+
+def test_schema_loads_successfully():
+    """Test that the declarative component schema loads without errors."""
+    schema = load_declarative_component_schema()
+    assert isinstance(schema, dict)
+    assert "type" in schema
+    assert schema["type"] == "object"
+
+
+def test_connector_registry_accessible():
+    """Test that the connector registry is accessible."""
+    response = requests.get(CONNECTOR_REGISTRY_URL, timeout=30)
+    assert response.status_code == 200
+    registry = response.json()
+    assert "sources" in registry
+    assert isinstance(registry["sources"], list)
+
+
+def test_manifest_only_connectors_found():
+    """Test that we can find manifest-only connectors in the registry."""
+    connectors = get_manifest_only_connectors()
+    assert len(connectors) > 0, "No manifest-only connectors found in registry"
+    
+    for connector_name, _ in connectors:
+        assert isinstance(connector_name, str)
+        assert len(connector_name) > 0
+        assert connector_name.startswith("source-") or connector_name.startswith("destination-")
+
+
+def test_sample_manifest_download():
+    """Test that we can download a sample manifest file."""
+    connectors = get_manifest_only_connectors()
+    if not connectors:
+        pytest.skip("No manifest-only connectors available for testing")
+    
+    connector_name, _ = connectors[0]
+    try:
+        manifest_content, cdk_version = download_manifest(connector_name)
+    except Exception as e:
+        pytest.skip(f"Could not download sample manifest from {connector_name}: {e}")
+    
+    assert isinstance(manifest_content, str)
+    assert len(manifest_content) > 0
+    assert isinstance(cdk_version, str)
+    assert len(cdk_version) > 0
+    
+    manifest_dict = yaml.safe_load(manifest_content)
+    assert isinstance(manifest_dict, dict)
+    assert "version" in manifest_dict
+    assert manifest_dict["version"] == cdk_version
+
+
+def log_test_results():
+    """Log comprehensive test results for analysis."""
+    print("\n" + "="*80)
+    print("MANIFEST VALIDATION TEST RESULTS SUMMARY")
+    print("="*80)
+    
+    print(f"\n✓ SUCCESSFUL VALIDATIONS ({len(VALIDATION_SUCCESSES)}):")
+    for connector_name, cdk_version in VALIDATION_SUCCESSES:
+        print(f"  - {connector_name} (CDK {cdk_version})")
+    
+    print(f"\n✗ VALIDATION FAILURES ({len(VALIDATION_FAILURES)}):")
+    for connector_name, cdk_version, error in VALIDATION_FAILURES:
+        print(f"  - {connector_name} (CDK {cdk_version}): {error}")
+    
+    print(f"\n⚠ DOWNLOAD FAILURES ({len(DOWNLOAD_FAILURES)}):")
+    for connector_name, error in DOWNLOAD_FAILURES:
+        print(f"  - {connector_name}: {error}")
+    
+    print("\n" + "="*80)
+    print(f"TOTAL: {len(VALIDATION_SUCCESSES)} passed, {len(VALIDATION_FAILURES)} failed, {len(DOWNLOAD_FAILURES)} download errors")
+    print("="*80)
+
+
+def pytest_sessionfinish(session, exitstatus):
+    """Called after whole test run finished, right before returning the exit status to the system."""
+    log_test_results()


### PR DESCRIPTION
# tests: Add parametrized validation test for manifest-only connectors

## Summary

This PR implements a new parametrized unit test that validates all manifest.yaml files from manifest-only connectors in the Airbyte registry against the current CDK declarative component schema. The test dynamically discovers connectors from the live registry API, downloads their manifest files from public endpoints, and validates them with comprehensive logging.

Key features:
- **Dynamic connector discovery**: Fetches manifest-only connectors from `https://connectors.airbyte.com/files/registries/v0/oss_registry.json`
- **Schema validation**: Uses existing `ValidateAdheresToSchema` class with the CDK's declarative component schema
- **CDK version-based exclusions**: Uses `(connector_name, cdk_version)` tuples where CDK version comes from manifest.yaml `version` field
- **Comprehensive logging**: Tracks validation successes, failures, and download errors for analysis
- **Auto-updating exclusions**: When a manifest's CDK version is updated, it automatically gets re-tested (exclusion no longer applies)

Initial testing revealed validation failures across ~475 connectors with various CDK versions, providing valuable insights into schema compatibility issues.

## Review & Testing Checklist for Human

- [ ] **Verify test performance in CI** - The test processes 475 connectors with network calls; ensure it completes within reasonable time limits
- [ ] **Review validation failure patterns** - Examine the logged failures to determine if they indicate legitimate schema issues or bugs in the validation approach
- [ ] **Test exclusion list mechanism** - Verify that adding entries to `EXCLUDED_CONNECTORS` properly skips tests and provides clear skip messages
- [ ] **Check error handling** - Test behavior when connectors.airbyte.com is unavailable or manifests are malformed
- [ ] **Run test locally** - Execute `poetry run pytest unit_tests/sources/declarative/test_manifest_registry_validation.py -v` to see the comprehensive logging output

**Recommended test plan**: Run the full test suite once to capture the complete validation log, then add a few failing connectors to the exclusion list and verify they get skipped with proper CDK version messaging.

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    Registry["connectors.airbyte.com<br/>Registry API"]
    ManifestFiles["connectors.airbyte.com<br/>Manifest Files"]
    TestFile["test_manifest_registry_validation.py"]:::major-edit
    Schema["declarative_component_schema.yaml"]:::context
    Validator["ValidateAdheresToSchema"]:::context
    
    TestFile -->|"fetches manifest-only connectors"| Registry
    TestFile -->|"downloads manifest.yaml files"| ManifestFiles
    TestFile -->|"loads schema"| Schema
    TestFile -->|"validates using"| Validator
    
    subgraph Legend
        L1["Major Edit"]:::major-edit
        L2["Minor Edit"]:::minor-edit  
        L3["Context/No Edit"]:::context
    end

    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB  
    classDef context fill:#FFFFFF
```

### Notes

- **Performance consideration**: The test currently processes all 475 manifest-only connectors. Consider adding a configuration option to limit the number for faster CI runs if needed.
- **Schema evolution**: The widespread validation failures suggest potential schema compatibility issues that may need investigation by the CDK team.
- **Network dependency**: Test relies on external APIs which could cause flakiness. Consider adding retry logic or circuit breakers if this becomes problematic.

**Session info**: Requested by AJ Steers (@aaronsteers) in Devin session: https://app.devin.ai/sessions/6cc10201932a4a13b9612410a9bb6994