### PR TITLE
fix(declarative): Support nested $ref patterns in dynamic stream templates (do not merge)

### DIFF
--- a/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -1508,6 +1508,13 @@ definitions:
           - "$ref": "#/definitions/SimpleRetriever"
           - "$ref": "#/definitions/AsyncRetriever"
           - "$ref": "#/definitions/CustomRetriever"
+          - type: object
+            properties:
+              $ref:
+                type: string
+                pattern: "^#/definitions/"
+            required: ["$ref"]
+            additionalProperties: true
       incremental_sync:
         title: Incremental Sync
         description: Component used to fetch data incrementally based on a time field in the data.
@@ -2414,6 +2421,13 @@ definitions:
           - "$ref": "#/definitions/SimpleRetriever"
           - "$ref": "#/definitions/AsyncRetriever"
           - "$ref": "#/definitions/CustomRetriever"
+          - type: object
+            properties:
+              $ref:
+                type: string
+                pattern: "^#/definitions/"
+            required: ["$ref"]
+            additionalProperties: true
       schema_filter:
         title: Schema Filter
         description: Responsible for filtering fields to be added to json schema.
@@ -3214,6 +3228,13 @@ definitions:
         anyOf:
           - "$ref": "#/definitions/DeclarativeStream"
           - "$ref": "#/definitions/StateDelegatingStream"
+          - type: object
+            properties:
+              $ref:
+                type: string
+                pattern: "^#/definitions/"
+            required: ["$ref"]
+            additionalProperties: true
       parent_key:
         title: Parent Key
         description: The primary key of records from the parent stream that will be used during the retrieval of records for the current substream. This parent identifier field is typically a characteristic of the child records being extracted from the source API.
@@ -3654,6 +3675,13 @@ definitions:
         anyOf:
           - "$ref": "#/definitions/HttpRequester"
           - "$ref": "#/definitions/CustomRequester"
+          - type: object
+            properties:
+              $ref:
+                type: string
+                pattern: "^#/definitions/"
+            required: ["$ref"]
+            additionalProperties: true
       decoder:
         title: HTTP Response Format
         description: Component decoding the response so records can be extracted.
@@ -4202,6 +4230,13 @@ definitions:
           - "$ref": "#/definitions/SimpleRetriever"
           - "$ref": "#/definitions/AsyncRetriever"
           - "$ref": "#/definitions/CustomRetriever"
+          - type: object
+            properties:
+              $ref:
+                type: string
+                pattern: "^#/definitions/"
+            required: ["$ref"]
+            additionalProperties: true
       components_mapping:
         type: array
         items:
@@ -4336,6 +4371,13 @@ definitions:
         anyOf:
           - "$ref": "#/definitions/DeclarativeStream"
           - "$ref": "#/definitions/StateDelegatingStream"
+          - type: object
+            properties:
+              $ref:
+                type: string
+                pattern: "^#/definitions/"
+            required: ["$ref"]
+            additionalProperties: true
       components_resolver:
         title: Components Resolver
         description: Component resolve and populates stream templates with components values.


### PR DESCRIPTION
# fix(declarative): Support nested $ref patterns in dynamic stream templates

## Summary

This PR fixes a schema validation regression introduced in PR #560 (commit f52bc2e9) that prevented the Airtable connector from validating against the declarative component schema. The issue occurred when the `stream_template` field in `DynamicDeclarativeStream` was changed from a simple `$ref` to an `anyOf` structure that only accepted direct references to `DeclarativeStream` or `StateDelegatingStream`, breaking Airtable's nested reference pattern `{"$ref": "#/definitions/streams/airtable_stream"}`.

**Key Changes:**
- Added generic `$ref` object support to `stream_template` field in `DynamicDeclarativeStream`
- Added generic `$ref` object support to `requester` field in multiple SimpleRetriever schema definitions
- Added generic `$ref` object support to `stream` field in `ParentStreamConfig`
- Allows `$ref` objects with additional properties (e.g., `path`, `http_method`) as used by Airtable

The fix maintains backward compatibility while enabling more flexible reference patterns needed by dynamic stream connectors like Airtable.

## Review & Testing Checklist for Human

- [ ] **Test Airtable connector validation in Builder UI** - Verify that Airtable can now be forked in the Connector Builder without the "Validation against json schema" error
- [ ] **Run schema validation tests across other connectors** - Ensure the broader `$ref` pattern support doesn't break existing connectors that use direct references
- [ ] **Verify the pattern matching is restrictive enough** - Check that the `^#/definitions/` pattern prevents invalid external references while allowing valid nested references
- [ ] **Test dynamic stream generation** - Confirm that Airtable's dynamic stream discovery actually works end-to-end, not just schema validation

**Recommended Test Plan:**
1. Load Airtable connector in Builder UI and verify "Generate Streams" works without validation errors
2. Run a subset of existing connector tests to ensure no regressions
3. Test creating a new connector with both direct and nested `$ref` patterns

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    Airtable["source-airtable/manifest.yaml"]:::context
    Schema["declarative_component_schema.yaml"]:::major-edit
    Builder["Connector Builder UI"]:::context
    
    Airtable --> |"validates against"| Schema
    Schema --> |"enables validation in"| Builder
    
    subgraph "Schema Changes"
        StreamTemplate["stream_template field<br/>(DynamicDeclarativeStream)"]:::major-edit
        RequesterField["requester field<br/>(SimpleRetriever)"]:::major-edit
        StreamField["stream field<br/>(ParentStreamConfig)"]:::major-edit
    end
    
    Schema --> StreamTemplate
    Schema --> RequesterField  
    Schema --> StreamField
    
    subgraph Legend
        L1["Major Edit"]:::major-edit
        L3["Context/No Edit"]:::context
    end

classDef major-edit fill:#90EE90
classDef context fill:#FFFFFF
```

### Notes

- **Root Cause**: PR #560 made stream template validation more restrictive, breaking Airtable's nested `$ref` pattern `#/definitions/streams/airtable_stream`
- **Validation Scope**: The CDK's generic error masking made diagnosis difficult - the actual validation errors were much more specific than the reported "schema failed" message
- **Testing**: Validated against Airtable manifest and synthetic test cases, but broader connector testing recommended
- **Risk**: Schema changes affect all connectors, though this change is additive (allows more patterns) rather than restrictive

**Session Details:**
- Requested by: AJ Steers (@aaronsteers)  
- Session: https://app.devin.ai/sessions/f71f399dac1b42a5b3e58bfd87fa8586

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Expanded the declarative schema to accept inline reference objects alongside direct $ref usage across several fields, allowing both a direct "$ref" and an inline object containing "$ref". This broadens configuration flexibility and maintains backward compatibility. No runtime behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->