### PR TITLE
fix: revert connector builder limitation wrongly applied to all the streams

### DIFF
--- a/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -2085,13 +2085,7 @@ class ModelToComponentFactory:
                     retriever,
                     self._message_repository,
                 ),
-                stream_slicer=cast(
-                    StreamSlicer,
-                    StreamSlicerTestReadDecorator(
-                        wrapped_slicer=combined_slicers,
-                        maximum_number_of_slices=self._limit_slices_fetched or 5,
-                    ),
-                ),
+                stream_slicer=combined_slicers,
             )
             return DefaultStream(
                 partition_generator=partition_generator,


### PR DESCRIPTION
## What

We are applying Connector Builder stream slice limit to real syncs

Repro steps:
```
version: 6.60.7

type: DeclarativeSource

check:
  type: CheckStream
  stream_names:
    - pokemon

streams:
  - type: DeclarativeStream
    name: pokemon
    retriever:
      type: SimpleRetriever
      partition_router:
        type: ListPartitionRouter
        values:
          - bulbasaur
          - ivysaur
          - venusaur
          - charmander
          - charmeleon
          - charizard
        cursor_field: name
      requester:
        type: HttpRequester
        url: https://pokeapi.co/api/v2/pokemon/{{ stream_partition.name }}
        http_method: GET
      record_selector:
        type: RecordSelector
        extractor:
          type: DpathExtractor
          field_path:
            - abilities
    schema_loader:
      type: InlineSchemaLoader
      schema:
        type: object
        $schema: http://json-schema.org/schema#
        properties:
          any:
            type:
              - string
              - "null"
        additionalProperties: true

spec:
  type: Spec
  connection_specification:
    type: object
    $schema: http://json-schema.org/draft-07/schema#
    required: []
    properties: {}
    additionalProperties: true
```

Before the change: `{"type":"LOG","log":{"level":"INFO","message":"Read 10 records from pokemon stream"}}`
After the change: `{"type":"LOG","log":{"level":"INFO","message":"Read 12 records from pokemon stream"}}`

## How

Remove the casting of the StreamSlicer. This should be fine for Connector Builder stuff because we will only take this code path when it is not Connector Builder stuff (see [this condition](https://github.com/airbytehq/airbyte-python-cdk/pull/716/files#diff-1d9bc4ca384e5c00867da05e9db9d919aba908c59bb73aab83883b9ed20def05R2070)).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed an inadvertent slice-processing cap that could truncate data in sliced streams, ensuring all slices are processed and data is complete.

* **Performance**
  * Sliced syncs with many partitions may take longer, as all slices are now processed without a limit.

* **Stability**
  * Improves consistency of incremental and partitioned reads by aligning slice handling with expected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->