### PR TITLE
feat: add suggestions for datetime based cursor fields

### DIFF
--- a/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -987,6 +987,18 @@ definitions:
           - "%Y-%m-%d %H:%M:%S.%f+00:00"
           - "%s"
           - "%ms"
+        suggestions:
+          - "%Y-%m-%d"
+          - "%Y-%m-%d %H:%M:%S"
+          - "%Y-%m-%dT%H:%M:%S"
+          - "%Y-%m-%dT%H:%M:%SZ"
+          - "%Y-%m-%dT%H:%M:%S%z"
+          - "%Y-%m-%dT%H:%M:%S.%fZ"
+          - "%Y-%m-%dT%H:%M:%S.%f%z"
+          - "%Y-%m-%d %H:%M:%S.%f+00:00"
+          - "%s"
+          - "%ms"
+          - "%s_as_float"
       start_datetime:
         title: Start Datetime
         description: The datetime that determines the earliest record that should be synced.
@@ -1061,6 +1073,18 @@ definitions:
           - "%s"
           - "%ms"
           - "%s_as_float"
+        suggestions:
+          - "%Y-%m-%d"
+          - "%Y-%m-%d %H:%M:%S"
+          - "%Y-%m-%dT%H:%M:%S"
+          - "%Y-%m-%dT%H:%M:%SZ"
+          - "%Y-%m-%dT%H:%M:%S%z"
+          - "%Y-%m-%dT%H:%M:%S.%fZ"
+          - "%Y-%m-%dT%H:%M:%S.%f%z"
+          - "%Y-%m-%d %H:%M:%S.%f+00:00"
+          - "%s"
+          - "%ms"
+          - "%s_as_float"
       cursor_granularity:
         title: Cursor Granularity
         description: |
@@ -1075,6 +1099,13 @@ definitions:
         type: string
         examples:
           - "PT1S"
+        suggestions:
+          - "PT0.000001S"
+          - "PT0.001S"
+          - "PT1S"
+          - "PT1M"
+          - "PT1H"
+          - "P1D"
       is_data_feed:
         title: Data Feed API
         description: A data feed API is an API that does not allow filtering and paginates the content from the most recent to the least recent. Given this, the CDK needs to know when to stop paginating and this field will generate a stop condition for pagination.
@@ -1133,6 +1164,12 @@ definitions:
         examples:
           - "P1W"
           - "{{ config['step_increment'] }}"
+        suggestions:
+          - "PT1H"
+          - "P1D"
+          - "P1W"
+          - "P1M"
+          - "P1Y"
       $parameters:
         type: object
         additionalProperties: true
@@ -2804,6 +2841,18 @@ definitions:
           - "%Y-%m-%dT%H:%M:%S.%f%z"
           - "%Y-%m-%d"
           - "%s"
+        suggestions:
+          - "%Y-%m-%d"
+          - "%Y-%m-%d %H:%M:%S"
+          - "%Y-%m-%dT%H:%M:%S"
+          - "%Y-%m-%dT%H:%M:%SZ"
+          - "%Y-%m-%dT%H:%M:%S%z"
+          - "%Y-%m-%dT%H:%M:%S.%fZ"
+          - "%Y-%m-%dT%H:%M:%S.%f%z"
+          - "%Y-%m-%d %H:%M:%S.%f+00:00"
+          - "%s"
+          - "%ms"
+          - "%s_as_float"
       max_datetime:
         title: Max Datetime
         description: Ceiling applied on the datetime value. Must be formatted with the datetime_format field.


### PR DESCRIPTION
Once https://github.com/airbytehq/airbyte-platform-internal/pull/17519 is merged, the Connector Builder will automatically render a list of values when `suggestions` is set on a `string` or `array<string>` field.

This PR adds common values to the `suggestions` properties of various DatetimeBasedCursor fields, as these tend to be confusing for users to configure and having suggestions makes this easier.