### PR TITLE
fix: zero out declarative cursor on concurrent streams

### DIFF
--- a/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -2090,6 +2090,12 @@ class ModelToComponentFactory:
             elif concurrent_cursor:
                 cursor = concurrent_cursor
 
+            # FIXME to be removed once we migrate everything to DefaultStream
+            if isinstance(retriever, SimpleRetriever):
+                # We zero it out here, but since this is a cursor reference, the state is still properly
+                # instantiated for the other components that reference it
+                retriever.cursor = None
+
             partition_generator = StreamSlicerPartitionGenerator(
                 DeclarativePartitionFactory(
                     stream_name,


### PR DESCRIPTION
## What

The v6.60.16 of the CDK brought back by accident some of the processing of the declarative cursor which is less resilient than the Concurrent CDK one. In order to fix this, we need to add [this logic](https://github.com/airbytehq/airbyte-python-cdk/blob/2b07f9338e64f98eef8a88b06ba45cb9ff7fb359/airbyte_cdk/sources/declarative/concurrent_declarative_source.py#L88) as part of the ModelToComponentFactory. 

For more information, see https://airbytehq-team.slack.com/archives/C09BWEEGWTE