### PR TITLE
fix: monkey patch SQLiteDict in order to fix sqlite3.InterfaceError

### DIFF
--- a/airbyte_cdk/sources/streams/http/http_client.py
+++ b/airbyte_cdk/sources/streams/http/http_client.py
@@ -56,7 +56,7 @@ from airbyte_cdk.utils.traced_exception import AirbyteTracedException
 BODY_REQUEST_METHODS = ("GET", "POST", "PUT", "PATCH")
 
 
-def monkey_patched_get_item(self, key):
+def monkey_patched_get_item(self, key):  # type: ignore # this interface is a copy/paste from the requests_cache lib
     """
     con.execute can lead to `sqlite3.InterfaceError: bad parameter or other API misuse`. There was a fix implemented
     [here](https://github.com/requests-cache/requests-cache/commit/5ca6b9cdcb2797dd2fed485872110ccd72aee55d#diff-f43db4a5edf931647c32dec28ea7557aae4cae8444af4b26c8ecbe88d8c925aaL330-R332)
@@ -74,7 +74,7 @@ def monkey_patched_get_item(self, key):
         return self.deserialize(key, row[0])
 
 
-requests_cache.SQLiteDict.__getitem__ = monkey_patched_get_item
+requests_cache.SQLiteDict.__getitem__ = monkey_patched_get_item  # type: ignore # see the method doc for more information
 
 
 class MessageRepresentationAirbyteTracedErrors(AirbyteTracedException):

--- a/airbyte_cdk/sources/streams/http/http_client.py
+++ b/airbyte_cdk/sources/streams/http/http_client.py
@@ -4,7 +4,6 @@
 
 import logging
 import os
-import sqlite3
 import urllib
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple, Union

--- a/unit_tests/test_requests_cache_monkeypatch_version.py
+++ b/unit_tests/test_requests_cache_monkeypatch_version.py
@@ -1,0 +1,11 @@
+import requests_cache
+
+
+def test_assert_requests_cache_version():
+    """
+    We need to be alerted once the requests_cache version is updated. The reason is that we monkey patch one of the
+    method in order to fix a bug until a new version is released.
+
+    For more information about the reasons of this test, see monkey_patched_get_item in http_client.py
+    """
+    assert requests_cache.__version__ == "1.2.1"


### PR DESCRIPTION
## What

https://airbytehq-team.slack.com/archives/C0980AJD0F7/p1756166020078259?thread_ts=1756138243.067239&cid=C0980AJD0F7

https://github.com/airbytehq/airbyte-python-cdk/actions/runs/17223546541/job/48863700904?pr=719#step:8:33688

## How

There is no version of requests_cache that got release with this fix so we monkey_patch stuff until there is a new release

I've added a test so that when the version gets updated, we can re-assess what is the next step

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Resolved intermittent cache read errors that could cause HTTP-based syncs to fail.
  - Improved reliability when accessing the local cache, reducing unexpected exceptions during runs.

- Chores
  - Applied a temporary workaround to ensure stable cache behavior without requiring user configuration changes.

- Tests
  - Added a safeguard test to detect incompatible cache library versions early.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->