### PR TITLE
fix: replace flaky setup-poetry action with install-poetry

### DIFF
--- a/.github/workflows/autofix-command.yml
+++ b/.github/workflows/autofix-command.yml
@@ -73,9 +73,9 @@ jobs:
             [1]: ${{ steps.vars.outputs.run-url }}
 
       - name: Set up Poetry
-        uses: Gr1N/setup-poetry@v9
+        uses: snok/install-poetry@v1
         with:
-          poetry-version: "2.0.1"
+          version: "2.0.1"
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/connector-tests.yml
+++ b/.github/workflows/connector-tests.yml
@@ -141,9 +141,9 @@ jobs:
 
       - name: Set up Poetry
         if: steps.no_changes.outputs.status != 'cancelled'
-        uses: Gr1N/setup-poetry@v9
+        uses: snok/install-poetry@v1
         with:
-          poetry-version: "2.0.1"
+          version: "2.0.1"
 
       - name: Get Connector Language
         if: steps.no_changes.outputs.status != 'cancelled'

--- a/.github/workflows/pdoc_preview.yml
+++ b/.github/workflows/pdoc_preview.yml
@@ -14,9 +14,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Set up Poetry
-        uses: Gr1N/setup-poetry@v9
+        uses: snok/install-poetry@v1
         with:
-          poetry-version: "2.0.1"
+          version: "2.0.1"
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/pdoc_publish.yml
+++ b/.github/workflows/pdoc_publish.yml
@@ -31,9 +31,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Set up Poetry
-        uses: Gr1N/setup-poetry@v9
+        uses: snok/install-poetry@v1
         with:
-          poetry-version: "2.0.1"
+          version: "2.0.1"
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/poetry-lock-command.yml
+++ b/.github/workflows/poetry-lock-command.yml
@@ -81,9 +81,9 @@ jobs:
             [1]: ${{ steps.vars.outputs.run-url }}
 
       - name: Set up Poetry
-        uses: Gr1N/setup-poetry@v9
+        uses: snok/install-poetry@v1
         with:
-          poetry-version: "2.0.1"
+          version: "2.0.1"
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/pytest_fast.yml
+++ b/.github/workflows/pytest_fast.yml
@@ -15,9 +15,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Poetry
-        uses: Gr1N/setup-poetry@v9
+        uses: snok/install-poetry@v1
         with:
-          poetry-version: "2.0.1"
+          version: "2.0.1"
 
       - name: Check Poetry lock file is current
         run: poetry check
@@ -42,9 +42,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Set up Poetry
-        uses: Gr1N/setup-poetry@v9
+        uses: snok/install-poetry@v1
         with:
-          poetry-version: "2.0.1"
+          version: "2.0.1"
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/pytest_matrix.yml
+++ b/.github/workflows/pytest_matrix.yml
@@ -58,10 +58,10 @@ jobs:
               - 'poetry.lock'
               - 'pyproject.toml'
       - name: Set up Poetry
-        uses: Gr1N/setup-poetry@v9
+        uses: snok/install-poetry@v1
         if: steps.changes.outputs.src == 'true'
         with:
-          poetry-version: "2.0.1"
+          version: "2.0.1"
       - name: Set up Python
         uses: actions/setup-python@v5
         if: steps.changes.outputs.src == 'true'

--- a/.github/workflows/python_dependency_analysis.yml
+++ b/.github/workflows/python_dependency_analysis.yml
@@ -26,9 +26,9 @@ jobs:
         with:
           python-version: "3.10"
       - name: Set up Poetry
-        uses: Gr1N/setup-poetry@v9
+        uses: snok/install-poetry@v1
         with:
-          poetry-version: "2.0.1"
+          version: "2.0.1"
       - name: Install dependencies
         run: poetry install --all-extras
 

--- a/.github/workflows/python_lint.yml
+++ b/.github/workflows/python_lint.yml
@@ -15,9 +15,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Set up Poetry
-        uses: Gr1N/setup-poetry@v9
+        uses: snok/install-poetry@v1
         with:
-          poetry-version: "2.0.1"
+          version: "2.0.1"
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -38,9 +38,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Set up Poetry
-        uses: Gr1N/setup-poetry@v9
+        uses: snok/install-poetry@v1
         with:
-          poetry-version: "1.8.4"
+          version: "1.8.4"
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -61,9 +61,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Set up Poetry
-        uses: Gr1N/setup-poetry@v9
+        uses: snok/install-poetry@v1
         with:
-          poetry-version: "1.8.4"
+          version: "1.8.4"
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -83,9 +83,9 @@ jobs:
       # Same as the `python_pytest.yml` file:
 
       - name: Set up Poetry
-        uses: Gr1N/setup-poetry@v9
+        uses: snok/install-poetry@v1
         with:
-          poetry-version: "2.0.1"
+          version: "2.0.1"
       - name: Set up Python
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
The old one kept randomly timing out like so:

<img width="443" height="174" alt="Screenshot 2025-08-28 at 1 04 18 AM" src="https://github.com/user-attachments/assets/7ac70950-43a8-45b6-a666-865a2751bcfb" />

https://github.com/airbytehq/airbyte-python-cdk/actions/runs/17281035642/job/49049280943

This PR replaces `setup-poetry` with `install-poetry`, which is used in our other repos and has more stars.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Updated CI workflows to use a new Poetry installer action with standardized input naming.
  - Aligned Poetry version settings across testing, linting, docs, and dependency-analysis pipelines.
  - Improves reliability and consistency of build, test, and documentation jobs.
  - No user-facing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._