### PR TITLE
chore: exclude auto-generated OpenAPI file and GitHub workflows from YAML formatting

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,10 @@
 # Ignore artifacts:
 build
 coverage
+
+# Ignore auto-generated files:
+airbyte_cdk/manifest_server/openapi.yaml
+
+# Ignore GitHub workflow files:
+.github/**/*.yml
+.github/**/*.yaml


### PR DESCRIPTION
# chore: exclude auto-generated OpenAPI file and GitHub workflows from YAML formatting

## Summary
This PR configures Prettier to exclude auto-generated files from YAML formatting to prevent unnecessary formatting changes in future PRs. Specifically excludes:
- `airbyte_cdk/manifest_server/openapi.yaml` (auto-generated OpenAPI spec file)
- All YAML files in `.github/` directory (workflow configurations)

The exclusions were tested and confirmed working - Prettier now reports "All matched files use Prettier code style!" indicating the excluded files are properly ignored.

## Review & Testing Checklist for Human
- [ ] **Verify exclusion patterns work correctly**: Run `npx prettier --write "**/*.{yaml,yml}" --check` to confirm excluded files are not processed
- [ ] **Test auto-generated file protection**: Verify that `airbyte_cdk/manifest_server/openapi.yaml` remains unchanged when running formatters
- [ ] **Confirm legitimate formatting still works**: Test that non-excluded YAML files can still be formatted properly by Prettier

### Notes
- The build/assemble poe tasks failed due to Dagger environment connectivity issues, so the complete end-to-end workflow testing was incomplete
- The `poetry run poe format-check` command still reported formatting issues, suggesting there may be other formatting tools involved beyond Prettier
- Requested by @aaronsteers in Devin session: https://app.devin.ai/sessions/a0d8c0f93bcd486699c37c6c651c13af

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Expanded formatting ignore rules to cover auto-generated API specification outputs.
  - Added patterns to ignore GitHub workflow files in formatting checks.
  - Changes are additive and do not modify existing behavior or content.
  - No impact on application features or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->