### PR TITLE
fix(manifest-server): descriptor can be dict

### DIFF
--- a/airbyte_cdk/manifest_server/api_models/stream.py
+++ b/airbyte_cdk/manifest_server/api_models/stream.py
@@ -6,7 +6,7 @@ They accurately reflect the runtime types returned by the CDK, particularly
 fixing type mismatches like slice_descriptor being a string rather than an object.
 """
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from pydantic import BaseModel
 
@@ -59,7 +59,7 @@ class StreamReadSlices(BaseModel):
     """Slices of data read from a stream."""
 
     pages: List[StreamReadPages]
-    slice_descriptor: Optional[str]  # This is actually a string at runtime, not Dict[str, Any]
+    slice_descriptor: Optional[Union[Dict[str, Any], str]]  # We're seeing strings at runtime
     state: Optional[List[Dict[str, Any]]] = None
     auxiliary_requests: Optional[List[AuxiliaryRequest]] = None
 


### PR DESCRIPTION
Initially I changed this type to be a string (differing from the one declared by the TestReader response) because that's what I was observing the type to be in my tests with simple manifests. Running in prod for real users I noticed an error when returning the response because the descriptor was actually a dict (as declared)

So, instead of overriding to string, this declares the type as a union to support both responses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Broadened the accepted format for slice descriptors in the API model to allow either a dictionary or a string.
  - Updated type hints to reflect the expanded input types.
  - No changes to runtime behavior or existing flows.
  - Existing configurations continue to work without modification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->