### PR TITLE
chore: v7 migration script

### DIFF
--- a/bin/v7_migration.py
+++ b/bin/v7_migration.py
@@ -357,7 +357,7 @@ class Connector:
         1. If the connector uses source-declarative-manifest, updates the metadata.yaml
            to use baseImage: docker.io/airbyte/source-declarative-manifest:7.0.0@sha256:<TBD>
         2. If the connector is Python, sets the version in pyproject.toml to ^7
-        
+
         For both cases, it also increments the dockerImageTag in metadata.yaml.
 
         Returns:
@@ -412,9 +412,7 @@ class Connector:
                 metadata_content = f.read()
 
             # Update the baseImage to version 7
-            new_base_image = (
-                f"docker.io/airbyte/source-declarative-manifest:7.0.1@sha256:ff1e701c8f913cf24a0220f62c8e64cc1c3011ba0a636985f4db47fdab1391b6"
-            )
+            new_base_image = f"docker.io/airbyte/source-declarative-manifest:7.0.1@sha256:ff1e701c8f913cf24a0220f62c8e64cc1c3011ba0a636985f4db47fdab1391b6"
 
             # Replace the base image using regex to preserve formatting
             base_image_pattern = r"(baseImage:\s*)[^\n\r]+"
@@ -525,21 +523,17 @@ class Connector:
             # Update the dockerImageTag field by incrementing the version
             docker_tag_pattern = r"(dockerImageTag:\s*)([^\n\r]+)"
             docker_tag_match = re.search(docker_tag_pattern, metadata_content)
-            
+
             if docker_tag_match:
                 current_tag = docker_tag_match.group(2).strip()
                 new_tag = self._increment_version(current_tag)
-                
-                updated_content = re.sub(
-                    docker_tag_pattern, 
-                    rf"\g<1>{new_tag}", 
-                    metadata_content
-                )
-                
+
+                updated_content = re.sub(docker_tag_pattern, rf"\g<1>{new_tag}", metadata_content)
+
                 # Write back the updated metadata
                 with open(metadata_file, "w") as f:
                     f.write(updated_content)
-                
+
                 print(f"Updated dockerImageTag from {current_tag} to {new_tag} for {self.name}")
                 return True
             else:


### PR DESCRIPTION
The script will also not migrate the following even though they should be fine:
* source-bing-ads: custom partition router
* source-gong: custom cursor
* source-google-sheets: custom partition router
* source-hubspot: the weird test that we don't like
* source-jira: custom partition router
* source-instagram: custom partition router
* source-intercom: custom retriever
* source-orb (not in list official list that we maintain so I haven't investigated)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a migration tool to upgrade source connectors to CDK v7, detecting eligible declarative and Python connectors and migrating them automatically.
  - Updates connector base images or dependency versions and attempts to refresh lockfiles, with progress reporting and graceful warnings on failures.

- Chores
  - Automatically increments connector changelogs with a new patch version and date after successful migrations.

- Style
  - Improved console output and diagnostics for migration status and errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->