### PR TITLE
fix: update deprecated jsonschema import to use protocols module

### DIFF
--- a/airbyte_cdk/sources/utils/transform.py
+++ b/airbyte_cdk/sources/utils/transform.py
@@ -8,6 +8,7 @@ from enum import Flag, auto
 from typing import TYPE_CHECKING, Any, Callable, Dict, Generator, Mapping, Optional, cast
 
 from jsonschema import Draft7Validator, ValidationError, validators
+from jsonschema.protocols import Validator
 from referencing import Registry, Resource
 from referencing._core import Resolver
 from referencing.exceptions import Unresolvable
@@ -16,12 +17,6 @@ from referencing.jsonschema import DRAFT7
 from airbyte_cdk.sources.utils.schema_helpers import expand_refs
 
 from .schema_helpers import get_ref_resolver_registry
-
-try:
-    from jsonschema.validators import Validator
-except:
-    from jsonschema import Validator
-
 
 MAX_NESTING_DEPTH = 3
 json_to_python_simple = {


### PR DESCRIPTION
# fix: update deprecated jsonschema import to use protocols module

## Summary
Replaces the deprecated `from jsonschema import Validator` import with `from jsonschema.protocols import Validator` to resolve the DeprecationWarning in `airbyte_cdk/sources/utils/transform.py`. This addresses the warning message:

```
DeprecationWarning: Importing Validator directly from the jsonschema package is deprecated and will become an ImportError. Import it from jsonschema.protocols instead.
```

The change removes a try/except import fallback block and uses the new recommended import path directly.

## Review & Testing Checklist for Human

- [ ] Verify the deprecation warning is no longer present when running PyAirbyte or CDK code
- [ ] Run a broader test suite to ensure no import errors are introduced in dependent code
- [ ] Check that connectors using the CDK still function correctly with this change

### Notes
- All linting, formatting, and type checking passes locally
- One test failed during fast test run but appeared unrelated to this import change (pagination record ordering)
- This affects a core utility module that may be widely used across connectors
- Requested by @aaronsteers via session: https://app.devin.ai/sessions/3551a22ca21e4b9593b24aa450d53734

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal type annotations to use a single, consistent source, reducing ambiguity and improving maintainability. No changes to runtime behavior or user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->