### PR TITLE
tests: add test case for ab_datetime_parse with '2025-03-25T17:06:19Z'

### DIFF
--- a/unit_tests/utils/test_datetime_helpers.py
+++ b/unit_tests/utils/test_datetime_helpers.py
@@ -73,6 +73,12 @@ def test_now():
         ),  # With timezone offset
         ("2023-03-14T15:09:26Z", "2023-03-14T15:09:26+00:00", None, None),  # With Z timezone
         (
+            "2025-03-25T17:06:19Z",
+            "2025-03-25T17:06:19+00:00",
+            None,
+            None,
+        ),  # Test case for user request
+        (
             "2023-03-14T00:00:00+00:00",
             "2023-03-14T00:00:00+00:00",
             None,


### PR DESCRIPTION
# tests: add test case for ab_datetime_parse with '2025-03-25T17:06:19Z'

## Summary
Added a new test case to the existing parametrized test for `ab_datetime_parse()` to verify it can handle the datetime string '2025-03-25T17:06:19Z'. This test case was specifically requested to confirm the function's compatibility with this datetime format.

The test follows the same pattern as existing 'Z' timezone test cases, expecting the 'Z' suffix to be converted to the standard '+00:00' UTC offset format.

## Review & Testing Checklist for Human
- [ ] Verify the test passes when run locally: `poetry run pytest unit_tests/utils/test_datetime_helpers.py::test_parse -k "2025-03-25T17:06:19Z"`
- [ ] Confirm the expected output format `"2025-03-25T17:06:19+00:00"` aligns with the function's existing behavior for 'Z' timezone inputs

### Notes
This change was requested by @aaronsteers to verify `ab_datetime_parse()` can handle '2025-03-25T17:06:19Z' as input.

**Link to Devin run:** https://app.devin.ai/sessions/9e054ce9a6674ac9afcc0c22fb2f0cbe  
**Requested by:** @aaronsteers