### PR TITLE
feat(JwtAuthenticator): add passphrase support to jwt auth

### DIFF
--- a/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -1270,6 +1270,12 @@ definitions:
         title: Additional JWT Payload Properties
         description: Additional properties to be added to the JWT payload.
         additionalProperties: true
+      passphrase:
+        title: Passphrase
+        description: A passphrase/password used to encrypt the private key. Only provide a passphrase if required by the API for JWT authentication. The API will typically provide the passphrase when generating the public/private key pair.
+        type: string
+        examples:
+          - "{{ config['passphrase'] }}"
       $parameters:
         type: object
         additionalProperties: true

--- a/airbyte_cdk/sources/declarative/interpolation/macros.py
+++ b/airbyte_cdk/sources/declarative/interpolation/macros.py
@@ -6,6 +6,7 @@ import builtins
 import datetime
 import re
 import typing
+import uuid
 from typing import Optional, Union
 from urllib.parse import quote_plus
 
@@ -205,6 +206,13 @@ def camel_case_to_snake_case(value: str) -> str:
      :return: snake_case formatted string
     """
     return re.sub(r"(?<!^)(?=[A-Z])", "_", value).lower()
+
+
+def random_uuid() -> str:
+    """
+    Generates a UUID4
+    """
+    return str(uuid.uuid4())
 
 
 _macros_list = [

--- a/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
+++ b/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
@@ -448,6 +448,12 @@ class JwtAuthenticator(BaseModel):
         description="Additional properties to be added to the JWT payload.",
         title="Additional JWT Payload Properties",
     )
+    passphrase: Optional[str] = Field(
+        None,
+        description="A passphrase/password used to encrypt the private key. Only provide a passphrase if required by the API for JWT authentication. The API will typically provide the passphrase when generating the public/private key pair.",
+        examples=["{{ config['passphrase'] }}"],
+        title="Passphrase",
+    )
     parameters: Optional[Dict[str, Any]] = Field(None, alias="$parameters")
 
 

--- a/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -2705,6 +2705,7 @@ class ModelToComponentFactory:
             aud=jwt_payload.aud,
             additional_jwt_headers=model.additional_jwt_headers,
             additional_jwt_payload=model.additional_jwt_payload,
+            passphrase=model.passphrase,
         )
 
     def create_list_partition_router(


### PR DESCRIPTION
## What
- Adds support for passphrases/passwords to encrypt private keys before signing JWT tokens. These are common for RSxxx algorithms.
- Adds random UUID generator macro. This is necessary for an upcoming connector that requires a random UUID for every generated request to verify each request.


## Review Order
1. declarative_component_schema
2. model_to_component_factory
3. jwt.py
4. macros
5. tests