### PR TITLE
fix: noproxy that breaks regression tests

### DIFF
--- a/airbyte_cdk/sources/streams/http/http_client.py
+++ b/airbyte_cdk/sources/streams/http/http_client.py
@@ -562,7 +562,7 @@ class HttpClient:
 
         env_settings = self._session.merge_environment_settings(
             url=request.url,
-            proxies=request_kwargs.get("proxies"),
+            proxies=request_kwargs.get("proxies", {}),
             stream=request_kwargs.get("stream"),
             verify=request_kwargs.get("verify"),
             cert=request_kwargs.get("cert"),

--- a/unit_tests/sources/streams/http/test_http_client.py
+++ b/unit_tests/sources/streams/http/test_http_client.py
@@ -756,9 +756,7 @@ def test_given_noproxy_for_another_url_when_send_request_then_do_not_break(reque
         json={"test": "a response"},
     )
 
-    x = http_client.send_request(
-        "GET", "https://google.com/", request_kwargs={}
-    )
+    x = http_client.send_request("GET", "https://google.com/", request_kwargs={})
 
     assert x
 

--- a/unit_tests/sources/streams/http/test_http_client.py
+++ b/unit_tests/sources/streams/http/test_http_client.py
@@ -747,6 +747,22 @@ def test_given_different_headers_then_response_is_not_cached(requests_mock):
     assert second_response.json()["test"] == "second response"
 
 
+def test_given_noproxy_for_another_url_when_send_request_then_do_not_break(requests_mock):
+    http_client = HttpClient(name="test", logger=MagicMock(), use_cache=True)
+    os.environ["no_proxy"] = "another.com"
+    requests_mock.register_uri(
+        "GET",
+        "https://google.com/",
+        json={"test": "a response"},
+    )
+
+    x = http_client.send_request(
+        "GET", "https://google.com/", request_kwargs={}
+    )
+
+    assert x
+
+
 @patch.dict("os.environ", {"REQUESTS_CA_BUNDLE": "/path/to/ca-bundle.crt"})
 def test_send_request_respects_environment_variables():
     """Test that send_request respects REQUESTS_CA_BUNDLE environment variable."""


### PR DESCRIPTION
## What

Following [this change](https://github.com/airbytehq/airbyte-python-cdk/pull/755), regression tests (or anything run having `noproxy` as a env and querying another domain than what is defined in `noproxy` will cause a NoneType exception

## How

Pass a dict if proxies is not defined

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - Default proxy settings now reliably use an explicit empty proxy value when none are provided, avoiding unexpected failures.
  - HTTPS certificate verification now honors the environment/system CA bundle configuration.

- Tests
  - Added tests for proxy bypass scenarios.
  - Added tests ensuring custom CA bundle settings are respected.

- Other
  - No changes to public interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->