### PR TITLE
PoC pagination reset

### DIFF
--- a/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -2057,6 +2057,7 @@ class ModelToComponentFactory:
             client_side_incremental_sync={"cursor": concurrent_cursor}
             if self._is_client_side_filtering_enabled(model)
             else None,
+            cursor=concurrent_cursor,
             transformations=transformations,
             file_uploader=file_uploader,
             incremental_sync=model.incremental_sync,
@@ -2279,6 +2280,7 @@ class ModelToComponentFactory:
         config: Config,
         *,
         url_base: str,
+        cursor: Cursor,
         extractor_model: Optional[Union[CustomRecordExtractorModel, DpathExtractorModel]] = None,
         decoder: Optional[Decoder] = None,
         cursor_used_for_stop_condition: Optional[Cursor] = None,
@@ -2316,6 +2318,7 @@ class ModelToComponentFactory:
             page_token_option=page_token_option,
             pagination_strategy=pagination_strategy,
             url_base=url_base,
+            cursor=cursor,
             config=config,
             parameters=model.parameters or {},
         )
@@ -3149,6 +3152,7 @@ class ModelToComponentFactory:
         config: Config,
         *,
         name: str,
+        cursor: Cursor,
         primary_key: Optional[Union[str, List[str], List[List[str]]]],
         request_options_provider: Optional[RequestOptionsProvider] = None,
         stop_condition_cursor: Optional[Cursor] = None,
@@ -3271,6 +3275,7 @@ class ModelToComponentFactory:
                 extractor_model=model.record_selector.extractor,
                 decoder=decoder,
                 cursor_used_for_stop_condition=stop_condition_cursor or None,
+                cursor=cursor,
             )
             if model.paginator
             else NoPagination(parameters={})

--- a/airbyte_cdk/sources/declarative/requesters/error_handlers/default_error_handler.py
+++ b/airbyte_cdk/sources/declarative/requesters/error_handlers/default_error_handler.py
@@ -13,7 +13,7 @@ from airbyte_cdk.sources.declarative.requesters.error_handlers.default_http_resp
 from airbyte_cdk.sources.declarative.requesters.error_handlers.http_response_filter import (
     HttpResponseFilter,
 )
-from airbyte_cdk.sources.streams.http.error_handlers import BackoffStrategy, ErrorHandler
+from airbyte_cdk.sources.streams.http.error_handlers import BackoffStrategy, ErrorHandler, ResponseAction
 from airbyte_cdk.sources.streams.http.error_handlers.response_models import (
     SUCCESS_RESOLUTION,
     ErrorResolution,
@@ -106,6 +106,16 @@ class DefaultErrorHandler(ErrorHandler):
         if not self.response_filters:
             self.response_filters = [HttpResponseFilter(config=self.config, parameters={})]
 
+        self.response_filters = [
+            # FIXME I have not wired up the RESET_PAGINATION in the model but assume I did and I configured this in the manifest.yaml...
+            HttpResponseFilter(
+                action=ResponseAction.RESET_PAGINATION,
+                http_codes={400},
+                error_message_contains="You cannot access tickets beyond the 300th page",
+                config=self.config,
+                parameters={}
+            )
+        ] + self.response_filters
         self._last_request_to_attempt_count: MutableMapping[requests.PreparedRequest, int] = {}
 
     def interpret_response(

--- a/airbyte_cdk/sources/declarative/requesters/paginators/no_pagination.py
+++ b/airbyte_cdk/sources/declarative/requesters/paginators/no_pagination.py
@@ -74,3 +74,6 @@ class NoPagination(Paginator):
         last_page_token_value: Optional[Any],
     ) -> Optional[Mapping[str, Any]]:
         return {}
+
+    def generate_stream_slice_on_reset(self, stream_slice: StreamSlice) -> Optional[StreamSlice]:
+        return stream_slice

--- a/airbyte_cdk/sources/declarative/requesters/paginators/paginator.py
+++ b/airbyte_cdk/sources/declarative/requesters/paginators/paginator.py
@@ -63,3 +63,7 @@ class Paginator(ABC, RequestOptionsProvider):
         :return: path to hit to fetch the next request. Returning None means the path is not defined by the next_page_token
         """
         pass
+
+    @abstractmethod
+    def generate_stream_slice_on_reset(self, stream_slice: StreamSlice) -> Optional[StreamSlice]:
+        pass

--- a/airbyte_cdk/sources/streams/http/error_handlers/response_models.py
+++ b/airbyte_cdk/sources/streams/http/error_handlers/response_models.py
@@ -17,6 +17,7 @@ class ResponseAction(Enum):
     FAIL = "FAIL"
     IGNORE = "IGNORE"
     RATE_LIMITED = "RATE_LIMITED"
+    RESET_PAGINATION = "RESET_PAGINATION"
 
 
 @dataclass

--- a/airbyte_cdk/sources/streams/http/http_client.py
+++ b/airbyte_cdk/sources/streams/http/http_client.py
@@ -79,6 +79,10 @@ def monkey_patched_get_item(self, key):  # type: ignore # this interface is a co
 requests_cache.SQLiteDict.__getitem__ = monkey_patched_get_item  # type: ignore # see the method doc for more information
 
 
+class PaginationResetRequiredException(Exception):
+    pass
+
+
 class MessageRepresentationAirbyteTracedErrors(AirbyteTracedException):
     """
     Before the migration to the HttpClient in low-code, the exception raised was
@@ -427,6 +431,9 @@ class HttpClient:
     ) -> None:
         if error_resolution.response_action not in self._ACTIONS_TO_RETRY_ON:
             self._evict_key(request)
+
+        if error_resolution.response_action == ResponseAction.RESET_PAGINATION:
+            raise PaginationResetRequiredException()
 
         # Emit stream status RUNNING with the reason RATE_LIMITED to log that the rate limit has been reached
         if error_resolution.response_action == ResponseAction.RATE_LIMITED:


### PR DESCRIPTION
## What

https://docs.google.com/document/d/14Rk-eziI78h4bMYyvZLmuWY2Fd4SwAglRElR3XR2NiU/edit?tab=t.0

## How

Add a ResponseAction to trigger an exception that needs to be handled by those doing pagination (in this case, it is the SimpleRetriever). When this is done, call the cursor to try to regenerate the stream slice. 

TODO:
* ConcurrentPerPartition which should be straightforward as it just need to get the underlying cursor, call `reduce_slice_range` on it and build the StreamSlice accordingly
* Add the `ResponseAction` type to the model
* Clean the model_to_component_factory stuff as this is horrible right now with the number of cursors being passed
* Tests

Running the following manifest for stream `tickets` from source-freshdesk without the custom components:
```
version: 6.36.2

type: DeclarativeSource

check:
  type: CheckStream
  stream_names:
    - tickets

definitions:
  streams:
    tickets:
      type: DeclarativeStream
      name: tickets
      primary_key:
        - id
      retriever:
        type: SimpleRetriever
        requester:
          $ref: "#/definitions/base_requester"
          type: HttpRequester
          path: tickets
          http_method: GET
          request_parameters:
            include: description,requester,stats
            order_by: updated_at
            order_type: asc
          error_handler:
            type: CompositeErrorHandler
            error_handlers:
              - type: DefaultErrorHandler
                response_filters:
                  - type: HttpResponseFilter
                    action: FAIL
                    http_codes:
                      - 401
                    error_message: >-
                      The endpoint to access stream tickets returned 401: Unauthorized. This is most likely due to wrong credentials.
              - type: DefaultErrorHandler
                backoff_strategies:
                  - type: WaitTimeFromHeader
                    header: Retry-After
        record_selector:
          type: RecordSelector
          extractor:
            type: DpathExtractor
            field_path: []
        paginator:
          type: DefaultPaginator
          page_size_option:
            type: RequestOption
            field_name: per_page
            inject_into: request_parameter
          page_token_option:
            type: RequestOption
            field_name: page
            inject_into: request_parameter
          pagination_strategy:
            type: PageIncrement
            page_size: 100
            start_from_page: 300
      incremental_sync:
        type: DatetimeBasedCursor
        cursor_field: updated_at
        start_datetime:
          type: MinMaxDatetime
          datetime: >-
            {{ config.get('start_date') or day_delta(-3650,
            '%Y-%m-%dT%H:%M:%SZ') }}
        datetime_format: "%Y-%m-%dT%H:%M:%SZ"
        start_time_option:
          type: RequestOption
          field_name: updated_since
          inject_into: request_parameter
        cursor_datetime_formats:
          - "%Y-%m-%dT%H:%M:%SZ"
      schema_loader:
        type: InlineSchemaLoader
        schema:
          $ref: "#/schemas/tickets"
  base_requester:
    type: HttpRequester
    url_base: https://{{ config['domain'] }}/api/v2/
    authenticator:
      type: BasicHttpAuthenticator
      username: "{{ config.get('api_key')}}"

streams:
  - $ref: "#/definitions/streams/tickets"

spec:
  type: Spec
  connection_specification:
    type: object
    $schema: http://json-schema.org/draft-07/schema#
    required:
      - api_key
      - domain
    properties:
      api_key:
        type: string
        description: >-
          Freshdesk API Key. See the <a
          href="https://docs.airbyte.com/integrations/sources/freshdesk">docs</a>
          for more information on how to obtain this key.
        order: 0
        title: API Key
        airbyte_secret: true
      domain:
        type: string
        description: Freshdesk domain
        order: 1
        title: Domain
        pattern: ^[a-zA-Z0-9._-]*\.freshdesk\.com$
        examples:
          - myaccount.freshdesk.com
      requests_per_minute:
        type: integer
        description: >-
          The number of requests per minute that this source allowed to use.
          There is a rate limit of 50 requests per minute per app per account.
        order: 2
        title: Requests per minute
      rate_limit_plan:
        type: object
        description: Rate Limit Plan for API Budget
        title: Rate Limit Plan
        oneOf:
          - type: object
            title: Free Plan
            properties:
              plan_type:
                type: string
                title: Plan
                const: free
              general_rate_limit:
                type: integer
                title: General Rate
                description: General Maximum Rate in Limit/minute for other endpoints in Free Plan
                const: 50
              tickets_rate_limit:
                type: integer
                title: Tickets Rate
                description: Maximum Rate in Limit/minute for tickets list endpoint in Free Plan
                const: 50
              contacts_rate_limit:
                type: integer
                title: Contacts Rate
                description: Maximum Rate in Limit/minute for contacts list endpoint in Free Plan
                const: 50
          - type: object
            title: Growth Plan
            properties:
              plan_type:
                type: string
                title: Plan
                const: growth
              general_rate_limit:
                type: integer
                title: General Rate
                description: General Maximum Rate in Limit/minute for other endpoints in Growth Plan
                const: 200
              tickets_rate_limit:
                type: integer
                title: Tickets Rate
                description: Maximum Rate in Limit/minute for tickets list endpoint in Growth Plan
                const: 20
              contacts_rate_limit:
                type: integer
                title: Contacts Rate
                description: Maximum Rate in Limit/minute for contacts list endpoint in Growth Plan
                const: 20
          - type: object
            title: Pro Plan
            properties:
              plan_type:
                type: string
                title: Plan
                const: pro
              general_rate_limit:
                type: integer
                title: General Rate
                description: General Maximum Rate in Limit/minute for other endpoints in Pro Plan
                const: 400
              tickets_rate_limit:
                type: integer
                title: Tickets Rate
                description: Maximum Rate in Limit/minute for tickets list endpoint in Pro Plan
                const: 100
              contacts_rate_limit:
                type: integer
                title: Contacts Rate
                description: Maximum Rate in Limit/minute for contacts list endpoint in Pro Plan
                const: 100
          - type: object
            title: Enterprise Plan
            properties:
              plan_type:
                type: string
                title: Plan
                const: enterprise
              general_rate_limit:
                type: integer
                title: General Rate
                description: General Maximum Rate in Limit/minute for other endpoints in Enterprise Plan
                const: 700
              tickets_rate_limit:
                type: integer
                title: Tickets Rate
                description: Maximum Rate in Limit/minute for tickets list endpoint in Enterprise Plan
                const: 200
              contacts_rate_limit:
                type: integer
                title: Contacts Rate
                description: Maximum Rate in Limit/minute for contacts list endpoint in Enterprise Plan
                const: 200
          - type: object
            title: Custom Plan
            properties:
              plan_type:
                type: string
                title: Plan
                const: custom
              general_rate_limit:
                type: integer
                title: General Rate
                description: General Maximum Rate in Limit/minute for other endpoints in Custom Plan
              tickets_rate_limit:
                type: integer
                title: Tickets Rate
                description: Maximum Rate in Limit/minute for tickets list endpoint in Custom Plan
              contacts_rate_limit:
                type: integer
                title: Contacts Rate
                description: Maximum Rate in Limit/minute for contacts list endpoint in Custom Plan
      start_date:
        type: string
        description: >-
          UTC date and time. Any data created after this date will be
          replicated. If this parameter is not set, all data will be replicated.
        order: 3
        title: Start Date
        format: date-time
        pattern: ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$
        examples:
          - "2020-12-01T00:00:00Z"
      lookback_window_in_days:
        type: integer
        description: Number of days for lookback window for the stream Satisfaction Ratings
        order: 4
        title: Lookback Window
        default: 14
    additionalProperties: true

schemas:
  tickets:
    type: object
    $schema: http://json-schema.org/draft-07/schema#
    properties:
      type:
        type:
          - string
          - "null"
      description:
        type:
          - string
          - "null"
      cc_emails:
        type:
          - array
          - "null"
      fwd_emails:
        type:
          - array
          - "null"
      reply_cc_emails:
        type:
          - array
          - "null"
      ticket_cc_emails:
        type:
          - array
          - "null"
      fr_escalated:
        type:
          - "null"
          - boolean
      spam:
        type:
          - "null"
          - boolean
      email_config_id:
        type:
          - integer
          - "null"
      group_id:
        type:
          - integer
          - "null"
      priority:
        type:
          - integer
          - "null"
      requester_id:
        type:
          - integer
          - "null"
      responder_id:
        type:
          - integer
          - "null"
      source:
        type:
          - integer
          - "null"
      company_id:
        type:
          - integer
          - "null"
      status:
        type:
          - integer
          - "null"
      subject:
        type:
          - string
          - "null"
      association_type:
        type:
          - integer
          - "null"
      to_emails:
        type:
          - array
          - "null"
        items:
          type:
            - string
            - "null"
      product_id:
        type:
          - integer
          - "null"
      id:
        type:
          - integer
          - "null"
      due_by:
        type:
          - string
          - "null"
      fr_due_by:
        type:
          - string
          - "null"
      is_escalated:
        type:
          - boolean
          - "null"
      custom_fields:
        type:
          - object
          - "null"
      created_at:
        type:
          - string
          - "null"
      updated_at:
        type:
          - string
          - "null"
      associated_tickets_count:
        type:
          - integer
          - "null"
      tags:
        type:
          - array
          - "null"
      nr_due_by:
        type:
          - string
          - "null"
      nr_escalated:
        type:
          - boolean
          - "null"
      description_text:
        type:
          - string
          - "null"
      requester:
        type:
          - object
          - "null"
      stats:
        type:
          - object
          - "null"
    additionalProperties: true

api_budget:
  type: HTTPAPIBudget
  policies:
    - type: FixedWindowCallRatePolicy
      period: "PT1M"
      # due to lack for support for interpolated string for the call_limit field, this has been
      # hardcoded to 50 which is the default rate for free plan
      # in the near term use "{{ config.get('requests_per_minute')}}"
      # long term is to utilize the `rate_limit_plan` field in config and specifying for each endpoint
      call_limit: 50 
      matchers:
        - method: GET
          url_base: "https://{{ config['domain'] }}/api/v2/"
  ratelimit_reset_header: Retry-After
  ratelimit_remaining_header: X-RateLimit-Remaining
  status_codes_for_ratelimit_hit: [429]
```