### PR TITLE
fix: parent state cursor fallback

### DIFF
--- a/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -3865,7 +3865,9 @@ class ModelToComponentFactory:
 
                 if not parent_state and not isinstance(parent_state, dict):
                     cursor_values = child_state.values()
-                    if cursor_values:
+                    if cursor_values and len(cursor_values) == 1:
+                        # We assume the child state is a pair `{<cursor_field>: <cursor_value>}` and we will use the
+                        # cursor value as a parent state.
                         incremental_sync_model: Union[
                             DatetimeBasedCursorModel,
                             IncrementingCountCursorModel,


### PR DESCRIPTION
## What

Addressing oncall issue https://github.com/airbytehq/oncall/issues/9163

## How

Ensuring that the state migration only happens if the child state is `{<cursor_field>: <cursor value>}`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected parent stream state inference to only occur when the child state contains a single cursor. This prevents constructing invalid parent state from multi-cursor child states, reducing edge-case errors.
  * Improves reliability of incremental syncs by avoiding unintended state assumptions, leading to more predictable behavior and fewer sync interruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->