### PR TITLE
poc: ErrorHandler.interpret_response can return None

### DIFF
--- a/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -2277,9 +2277,6 @@ class ModelToComponentFactory:
                 response_filters.append(
                     self._create_component_from_model(model=response_filter_model, config=config)
                 )
-        response_filters.append(
-            HttpResponseFilter(config=config, parameters=model.parameters or {})
-        )
 
         return DefaultErrorHandler(
             backoff_strategies=backoff_strategies,

--- a/airbyte_cdk/sources/declarative/requesters/error_handlers/composite_error_handler.py
+++ b/airbyte_cdk/sources/declarative/requesters/error_handlers/composite_error_handler.py
@@ -58,24 +58,12 @@ class CompositeErrorHandler(ErrorHandler):
 
     def interpret_response(
         self, response_or_exception: Optional[Union[requests.Response, Exception]]
-    ) -> ErrorResolution:
-        matched_error_resolution = None
+    ) -> Optional[ErrorResolution]:
         for error_handler in self.error_handlers:
             matched_error_resolution = error_handler.interpret_response(response_or_exception)
 
-            if not isinstance(matched_error_resolution, ErrorResolution):
-                continue
-
-            if matched_error_resolution.response_action in [
-                ResponseAction.SUCCESS,
-                ResponseAction.RETRY,
-                ResponseAction.IGNORE,
-                ResponseAction.RESET_PAGINATION,
-            ]:
+            if isinstance(matched_error_resolution, ErrorResolution):
                 return matched_error_resolution
-
-        if matched_error_resolution:
-            return matched_error_resolution
 
         return create_fallback_error_resolution(response_or_exception)
 

--- a/airbyte_cdk/sources/declarative/requesters/error_handlers/default_error_handler.py
+++ b/airbyte_cdk/sources/declarative/requesters/error_handlers/default_error_handler.py
@@ -122,8 +122,8 @@ class DefaultErrorHandler(ErrorHandler):
             if response_or_exception.ok:
                 return SUCCESS_RESOLUTION
 
-        default_reponse_filter = DefaultHttpResponseFilter(parameters={}, config=self.config)
-        default_response_filter_resolution = default_reponse_filter.matches(response_or_exception)
+        default_response_filter = DefaultHttpResponseFilter(parameters={}, config=self.config)
+        default_response_filter_resolution = default_response_filter.matches(response_or_exception)
 
         return (
             default_response_filter_resolution

--- a/airbyte_cdk/sources/streams/http/error_handlers/error_handler.py
+++ b/airbyte_cdk/sources/streams/http/error_handlers/error_handler.py
@@ -32,7 +32,7 @@ class ErrorHandler(ABC):
     @abstractmethod
     def interpret_response(
         self, response: Optional[Union[requests.Response, Exception]]
-    ) -> ErrorResolution:
+    ) -> Optional[ErrorResolution]:
         """
         Interpret the response or exception and return the corresponding response action, failure type, and error message.
 

--- a/airbyte_cdk/sources/streams/http/error_handlers/http_status_error_handler.py
+++ b/airbyte_cdk/sources/streams/http/error_handlers/http_status_error_handler.py
@@ -47,7 +47,7 @@ class HttpStatusErrorHandler(ErrorHandler):
 
     def interpret_response(
         self, response_or_exception: Optional[Union[requests.Response, Exception]] = None
-    ) -> ErrorResolution:
+    ) -> Optional[ErrorResolution]:
         """
         Interpret the response and return the corresponding response action, failure type, and error message.
 

--- a/airbyte_cdk/sources/streams/http/error_handlers/response_models.py
+++ b/airbyte_cdk/sources/streams/http/error_handlers/response_models.py
@@ -45,20 +45,8 @@ def _format_response_error_message(response: requests.Response) -> str:
 
 def create_fallback_error_resolution(
     response_or_exception: Optional[Union[requests.Response, Exception]],
-) -> ErrorResolution:
-    if response_or_exception is None:
-        # We do not expect this case to happen but if it does, it would be good to understand the cause and improve the error message
-        error_message = "Error handler did not receive a valid response or exception. This is unexpected please contact Airbyte Support"
-    elif isinstance(response_or_exception, Exception):
-        error_message = _format_exception_error_message(response_or_exception)
-    else:
-        error_message = _format_response_error_message(response_or_exception)
-
-    return ErrorResolution(
-        response_action=ResponseAction.RETRY,
-        failure_type=FailureType.system_error,
-        error_message=error_message,
-    )
+) -> None:
+    return None
 
 
 SUCCESS_RESOLUTION = ErrorResolution(

--- a/airbyte_cdk/sources/streams/http/http.py
+++ b/airbyte_cdk/sources/streams/http/http.py
@@ -628,7 +628,7 @@ class HttpStreamAdapterHttpStatusErrorHandler(HttpStatusErrorHandler):
 
     def interpret_response(
         self, response_or_exception: Optional[Union[requests.Response, Exception]] = None
-    ) -> ErrorResolution:
+    ) -> Optional[ErrorResolution]:
         if isinstance(response_or_exception, Exception):
             return super().interpret_response(response_or_exception)
         elif isinstance(response_or_exception, requests.Response):

--- a/airbyte_cdk/sources/streams/http/http_client.py
+++ b/airbyte_cdk/sources/streams/http/http_client.py
@@ -342,7 +342,7 @@ class HttpClient:
         except requests.RequestException as e:
             exc = e
 
-        error_resolution: ErrorResolution = self._error_handler.interpret_response(
+        error_resolution: Optional[ErrorResolution] = self._error_handler.interpret_response(
             response if response is not None else exc
         )
 
@@ -380,7 +380,7 @@ class HttpClient:
             response=response,
             exc=exc,
             request=request,
-            error_resolution=error_resolution,
+            error_resolution=error_resolution if error_resolution else ErrorResolution(ResponseAction.SUCCESS),
             exit_on_rate_limit=exit_on_rate_limit,
         )
 

--- a/unit_tests/sources/streams/http/error_handlers/test_response_models.py
+++ b/unit_tests/sources/streams/http/error_handlers/test_response_models.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 Airbyte, Inc., all rights reserved.
 
 from unittest import TestCase
+from unittest.mock import Mock
 
 import requests
 import requests_mock
@@ -27,56 +28,8 @@ class DefaultErrorResolutionTest(TestCase):
     def test_given_none_when_create_fallback_error_resolution_then_return_error_resolution(
         self,
     ) -> None:
-        error_resolution = create_fallback_error_resolution(None)
-
-        assert error_resolution.failure_type == FailureType.system_error
-        assert error_resolution.response_action == ResponseAction.RETRY
-        assert (
-            error_resolution.error_message
-            == "Error handler did not receive a valid response or exception. This is unexpected please contact Airbyte Support"
-        )
-
-    def test_given_exception_when_create_fallback_error_resolution_then_return_error_resolution(
-        self,
-    ) -> None:
-        exception = ValueError("This is an exception")
-
-        error_resolution = create_fallback_error_resolution(exception)
-
-        assert error_resolution.failure_type == FailureType.system_error
-        assert error_resolution.response_action == ResponseAction.RETRY
-        assert error_resolution.error_message
-        assert "ValueError" in error_resolution.error_message
-        assert str(exception) in error_resolution.error_message
-
-    def test_given_response_can_raise_for_status_when_create_fallback_error_resolution_then_error_resolution(
-        self,
-    ) -> None:
-        response = self._create_response(512)
-
-        error_resolution = create_fallback_error_resolution(response)
-
-        assert error_resolution.failure_type == FailureType.system_error
-        assert error_resolution.response_action == ResponseAction.RETRY
-        assert (
-            error_resolution.error_message
-            and "512 Server Error: None for url: https://a-url.com/"
-            in error_resolution.error_message
-        )
-
-    def test_given_response_is_ok_when_create_fallback_error_resolution_then_error_resolution(
-        self,
-    ) -> None:
-        response = self._create_response(205)
-
-        error_resolution = create_fallback_error_resolution(response)
-
-        assert error_resolution.failure_type == FailureType.system_error
-        assert error_resolution.response_action == ResponseAction.RETRY
-        assert (
-            error_resolution.error_message
-            and str(response.status_code) in error_resolution.error_message
-        )
+        any_response_or_exception = Mock()
+        assert create_fallback_error_resolution(any_response_or_exception) is None
 
     def _create_response(self, status_code: int) -> requests.Response:
         with requests_mock.Mocker() as http_mocker:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a spelling inconsistency in variable names related to response filters.

* **Refactor**
  * Modified error handling so that default HttpResponseFilters are not automatically added; only explicitly provided filters are used.
  * Updated various error handler methods to allow for absent (None) error resolutions instead of constructing default messages.
  * Streamlined how HTTP error resolutions are handled, ensuring a clear distinction between success and error outcomes.

* **Tests**
  * Simplified test cases to reflect updated error resolution handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->