### PR TITLE
chore: update source-declarative-manifest base image to use python 3.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # A new version of source-declarative-manifest is built for every new Airbyte CDK release, and their versions are kept in sync.
 #
 
-FROM docker.io/airbyte/python-connector-base:dev-test-python-3.13@sha256:161175fd22ef4eb3e7efc56bc38496bfb7ed8ebfaeb0137c9d689fe78bbc9102
+FROM docker.io/airbyte/python-connector-base:4.1.0@sha256:1d1aa21d34e851df4e8a87b391c27724c06e2597608e7161f4d167be853bd7b6
 
 WORKDIR /airbyte/integration_code
 


### PR DESCRIPTION
## What
Build and Release a new Source Declarative Manifest Base image using Python 3.13
Resolves https://github.com/airbytehq/airbyte-internal-issues/issues/14879
Depends on https://github.com/airbytehq/airbyte/pull/68190



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated base Docker image to version 4.1.0
  * Updated Python runtime environment to version 3.13

<!-- end of auto-generated comment: release notes by coderabbit.ai -->