### PR TITLE
docs: Add dark mode background and logo visibility fixes to pdoc docs

### DIFF
--- a/docs/templates/custom.css
+++ b/docs/templates/custom.css
@@ -106,6 +106,14 @@ body {
   font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
 }
 
+/* Logo styling - swap to light logo in dark mode for better visibility */
+@media (prefers-color-scheme: dark) {
+  .logo {
+    /* Replace the dark logo with the light logo in dark mode */
+    content: url("https://docs.airbyte.com/img/logo-light.png");
+  }
+}
+
 /* Enhanced heading styles */
 h1, h2, h3, h4, h5, h6 {
   font-weight: 600;

--- a/docs/templates/theme.css
+++ b/docs/templates/theme.css
@@ -20,3 +20,27 @@
     --def: #3f3bff;
     --annotation: #007020;
 }
+
+/* Dark mode theme */
+@media (prefers-color-scheme: dark) {
+    :root {
+        --pdoc-background: #212529;
+    }
+
+    .pdoc {
+        --text: hsl(240, 10%, 90%);
+        --muted: #9d9d9d;
+        --link: #9492ff;
+        --link-hover: #c8c7ff;
+        --code: hsl(252, 25%, 18%);
+        --active: #555;
+
+        --accent: hsl(240, 14%, 14%);
+        --accent2: #555;
+
+        --nav-hover: rgba(0, 0, 0, 0.1);
+        --name: #9492ff;
+        --def: #8381ff;
+        --annotation: #00c037;
+    }
+}


### PR DESCRIPTION
# fix: Add dark mode background and logo visibility fixes to pdoc docs

## Summary
Fixes two dark mode rendering issues in the Python CDK API documentation discovered after PR #804 merged:

1. **Missing background color**: Main content area had no background in dark mode (only sidebar was styled), making text hard to read
2. **Logo visibility**: The logo used dark blue text (`logo-dark.png`) which was nearly invisible on the dark background

**Changes:**
- `theme.css`: Added `@media (prefers-color-scheme: dark)` block with `--pdoc-background: #212529` and dark mode color variables (based on pdoc's official dark-mode example)
- `custom.css`: Added logo swap using CSS `content: url()` to replace `logo-dark.png` with `logo-light.png` in dark mode

**Dark mode detection**: Automatic based on system/browser dark mode preference - no manual toggle.

## Review & Testing Checklist for Human
- [ ] **Visual testing in dark mode** (CRITICAL): Enable system dark mode on your OS/browser and verify https://airbytehq.github.io/airbyte-python-cdk/ displays with:
  - Proper dark gray background (#212529) in main content area
  - Light-colored logo text (not dark blue) that's clearly visible
- [ ] **Mobile testing**: Test on mobile device (where issue was originally reported by AJ) to ensure both background and logo render correctly
- [ ] **Light mode regression**: Toggle back to light mode and confirm it still works correctly - logo should show dark text and background should be white
- [ ] **Cross-browser check**: Test in at least Chrome/Firefox to verify CSS `content: url()` works for logo swap

### Test Plan
1. Enable dark mode on your system/browser settings
2. Navigate to https://airbytehq.github.io/airbyte-python-cdk/ (after deployment)
3. Verify dark background and light logo text
4. Toggle between light/dark mode to ensure smooth transitions
5. Test on mobile device (iOS/Android)

### Notes
- This is purely CSS changes - no functional code impact
- Logo swap uses CSS `content: url()` which works in all modern browsers but may not work in very old browsers (acceptable trade-off for docs)
- Dark mode colors are from [pdoc's official dark-mode example](https://github.com/mitmproxy/pdoc/tree/main/examples/dark-mode)
- I verified the changes work by manually injecting dark mode CSS and confirmed screenshots with AJ, but couldn't test with actual system dark mode in my testing environment
- Issue originally reported by AJ Steers (@aaronsteers) on mobile where dark mode text was unreadable
- Same fix applied to PyAirbyte in PR #834
- Requested by AJ Steers (@aaronsteers) in Devin session: https://app.devin.ai/sessions/2212dc6e64a6496fadf6f3f18f4250c1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dark mode support with system preference detection. Theme includes optimized color palette for text, links, code, navigation, and UI elements. Logo automatically adapts to display a light variant in dark contexts for improved visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->