### PR TITLE
chore: update Manifest Server to use Python 3.13

### DIFF
--- a/airbyte_cdk/manifest_server/Dockerfile
+++ b/airbyte_cdk/manifest_server/Dockerfile
@@ -5,7 +5,7 @@
 # Example:
 # docker build -f airbyte_cdk/manifest_server/Dockerfile -t airbyte/manifest-server .
 
-FROM python:3.12-slim-bookworm
+FROM python:3.13.9-slim-bookworm@sha256:4c9fe962f6ce46ecf3633a7e9d0a9fb7f5622121ee00d628eff206da024147c9
 
 # Install git (needed for dynamic versioning) and poetry
 RUN apt-get update && \


### PR DESCRIPTION
After several PRs to remove problematic CDK dependencies, update the Manifest Server to use Python 3.13

resolves: https://github.com/airbytehq/airbyte-internal-issues/issues/14878

**Testing**
- I published a pre-release manifest-server image and referenced it [here](https://github.com/airbytehq/airbyte-platform-internal/blob/master/oss/charts/v2/airbyte/values.yaml#L2690-L2691) on my local `airbyte-platform-internal` repo. Then I built the platform with `make dev.up.oss` and verified I could use the Connector Builder.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded container runtime environment to Python 3.13.9 for improved stability and performance.
  * Added explicit image digest to ensure reproducible and verifiable deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->