### PR TITLE
fix: connector builder cdk bump workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -374,7 +374,7 @@ jobs:
           set -euo pipefail
           VALUES_FILE="oss/charts/v2/airbyte/values.yaml"
           # Get the current manifest-server tag from the values.yaml file
-          PREVIOUS_VERSION=$(grep -A4 "^manifestServer:" "$VALUES_FILE" | grep "tag:" | awk '{print $2}')
+          PREVIOUS_VERSION=$(grep -A15 "^manifestServer:" "$VALUES_FILE" | grep -A4 "image:" | grep "tag:" | awk '{print $2}')
           echo "Previous version: ${PREVIOUS_VERSION}"
           echo "New version: ${VERSION}"
           # Update the manifest-server tag in the Helm values file (preserves formatting)


### PR DESCRIPTION
Since @pedroslopez changed how we build and deploy connector builder using the `airbyte/manifest-server` image, the process of updating the CDK version used by Builder in OSS and Cloud has become much simpler and this workflow that creates a PR automatically to update Builder to the latest CDK version needed to be altered.

I tested this out by manually running this workflow (generating a pre-release CDK version).

Here's the PR that was created: https://github.com/airbytehq/airbyte-platform-internal/pull/18058/files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI job dependencies and simplified the publish workflow orchestration.
  * Removed an external Python setup step from the job to streamline execution.
  * Replaced a retry-based multi-step updater with a single in-repo substitution that updates the manifest server image and API build references and persists the new version, while keeping automated PR creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->