### PR TITLE
fix: schema inferrer supports more than two types

### DIFF
--- a/airbyte_cdk/utils/schema_inferrer.py
+++ b/airbyte_cdk/utils/schema_inferrer.py
@@ -120,7 +120,7 @@ class SchemaInferrer:
             node[_TYPE] = [node[_TYPE], _NULL_TYPE]
             node.pop(_ANY_OF)
         # populate `type` for `anyOf` if it's not present to pass all other checks
-        elif len(node[_ANY_OF]) == 2 and not self._null_type_in_any_of(node):
+        elif len(node[_ANY_OF]) > 1:
             node[_TYPE] = [_NULL_TYPE]
 
     def _clean_properties(self, node: InferredSchema) -> None:

--- a/unit_tests/utils/test_schema_inferrer.py
+++ b/unit_tests/utils/test_schema_inferrer.py
@@ -228,6 +228,7 @@ NOW = 1234567
                                         "nested_key_2": "United Kingdom",
                                     },
                                 },
+                                {"title": "Nested_3", "type": "string", "value": "XL"},
                             ],
                         }
                     },
@@ -247,6 +248,7 @@ NOW = 1234567
                                         "type": {"type": ["string", "null"]},
                                         "value": {
                                             "anyOf": [
+                                                {"type": "string"},
                                                 {"type": "array", "items": {"type": "string"}},
                                                 {
                                                     "type": "object",


### PR DESCRIPTION
## What

https://github.com/airbytehq/oncall/issues/9920

More specifically following [this comment](https://github.com/airbytehq/airbyte/pull/40667#discussion_r1664382651), I'm not sure why we only supported two entries in the `anyOf` so I've updated to code to support any number higher than 1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced schema type inference to more robustly handle anyOf structures with multiple type options and null types, improving consistency in schema cleaning and normalization across varying configurations.

* **Tests**
  * Updated test cases to validate the improved handling of complex anyOf type structures with expanded type options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->