### PR TITLE
feat(file-based): add configurable source uri to UploadableRemoteFile

### DIFF
--- a/airbyte_cdk/sources/file_based/file_based_stream_reader.py
+++ b/airbyte_cdk/sources/file_based/file_based_stream_reader.py
@@ -207,7 +207,7 @@ class AbstractFileBasedStreamReader(ABC):
             mime_type=file.mime_type,
             created_at=file.created_at,
             updated_at=file.updated_at,
-            source_uri=file.uri,
+            source_uri=file.source_uri,
         )
         file_reference = AirbyteRecordMessageFileReference(
             staging_file_url=local_file_path,

--- a/airbyte_cdk/sources/file_based/remote_file.py
+++ b/airbyte_cdk/sources/file_based/remote_file.py
@@ -55,3 +55,10 @@ class UploadableRemoteFile(RemoteFile, ABC):
         Returns the URI for the file being logged.
         """
         return self.uri
+
+    @property
+    def source_uri(self) -> str:
+        """
+        Returns the Source URI for the file being logged.
+        """
+        return self.uri


### PR DESCRIPTION
Source SFTP Bulk overrides source uri and doesn't use default uri for this purposes -https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connectors/source-sftp-bulk/source_sftp_bulk/stream_reader.py#L182

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated file reference handling to consistently track source URIs during file uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->