### PR TITLE
docs: Add Google-style docstrings to core Python CDK modules

### DIFF
--- a/airbyte_cdk/sources/declarative/yaml_declarative_source.py
+++ b/airbyte_cdk/sources/declarative/yaml_declarative_source.py
@@ -15,7 +15,7 @@ from airbyte_cdk.sources.types import ConnectionDefinition
 
 
 class YamlDeclarativeSource(ConcurrentDeclarativeSource):
-    """Declarative source defined by a yaml file"""
+    """Entry point for declarative YAML-based source connectors that loads and executes manifest files."""
 
     def __init__(
         self,
@@ -26,8 +26,15 @@ class YamlDeclarativeSource(ConcurrentDeclarativeSource):
         state: Optional[List[AirbyteStateMessage]] = None,
         config_path: Optional[str] = None,
     ) -> None:
-        """
-        :param path_to_yaml: Path to the yaml file describing the source
+        """Initializes a declarative source from a YAML manifest file.
+
+        Args:
+            path_to_yaml: Path to the manifest YAML file describing the source.
+            debug: Enable debug logging for manifest parsing and execution.
+            catalog: Configured catalog for the sync operation.
+            config: User-provided configuration for the source.
+            state: Current state for incremental syncs.
+            config_path: Path to the configuration file.
         """
         self._path_to_yaml = path_to_yaml
         source_config = self._read_and_parse_yaml_file(path_to_yaml)


### PR DESCRIPTION
# docs: Add Google-style docstrings to core Python CDK modules

## Summary
Added concise Google-style docstrings to three core Python CDK modules to improve documentation for LLMs and connector developers:

1. **AbstractSource** (`airbyte_cdk/sources/abstract_source.py`): Documented the base class and all public/abstract methods including `check_connection()`, `streams()`, `discover()`, `check()`, `read()`, and helper methods.

2. **HttpStream** (`airbyte_cdk/sources/streams/http/http.py`): Documented the class and key abstract methods that connector developers must implement: `url_base`, `path()`, `next_page_token()`, `parse_response()`, plus common override methods like `request_params()` and `request_headers()`.

3. **YamlDeclarativeSource** (`airbyte_cdk/sources/declarative/yaml_declarative_source.py`): Documented the entry point class and `__init__()` method with full parameter descriptions.

**Style changes:**
- Converted old `:param:` style to Google-style `Args:`/`Returns:` format
- Used concise one-line docstrings for simple methods
- Added multi-line docstrings with Args/Returns sections for complex methods
- Focused on public-facing APIs used by connector developers

## Review & Testing Checklist for Human
- [ ] **Verify Google-style format correctness**: Check that docstrings follow Google style guide and will render properly in PDOCs (first line on same line as `"""`, ends with period, blank line before Args if present)
- [ ] **Check documentation completeness**: Review if HttpStream needs more methods documented beyond the key abstract methods (the file is 674 lines but only ~10 methods were documented)
- [ ] **Verify accuracy**: Confirm that the docstring descriptions accurately match what the methods actually do, especially for `check_connection()`, `parse_response()`, and state management methods
- [ ] **Assess detail level**: Verify the balance between concise one-liners and detailed Args/Returns sections is appropriate for the target audience (LLMs and connector developers)

### Notes
- This is the first pass on Python CDK documentation as requested. Kotlin Bulk CDK documentation will follow in a separate PR.
- Lint and format checks passed locally with Ruff
- Some methods in HttpStream remain undocumented - these can be addressed in follow-up work if needed
- No inline TODO comments were added for unclear code sections (attempted but edit tool rejected as "extraneous comments")

**Session details:**
- Requested by: AJ Steers (aj@airbyte.io), GitHub: @aaronsteers
- Session: https://app.devin.ai/sessions/714fb9c366844fd49a0196e61f99f639

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Comprehensive improvements to internal docstrings and API documentation across core source components for enhanced clarity and consistency.
  * Clarified connection validation behavior with explicit documentation of success status and error handling semantics.
  * Enhanced HTTP stream, abstract source, and YAML-based source documentation standards for better maintainability and developer guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->