### PR TITLE
ci: fix release drafter race condition

### DIFF
--- a/.github/workflows/release_drafter.yml
+++ b/.github/workflows/release_drafter.yml
@@ -11,6 +11,10 @@ on:
   # pull_request_target:
   #   types: [opened, reopened, synchronize]
 
+concurrency:
+  group: release-drafter-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   update_release_draft:
     permissions:
@@ -19,7 +23,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       # Drafts the next Release notes as Pull Requests are merged into "main"
-      - uses: release-drafter/release-drafter@v6
+      # Pinned to v6.0.0 to avoid v6.1.0 bug: https://github.com/release-drafter/release-drafter/issues/1425
+      - uses: release-drafter/release-drafter@v6.0.0
         with:
           config-name: release-drafter.yml
         env:


### PR DESCRIPTION
## Summary

Fixes a race condition in the release-drafter workflow where merged PRs sometimes don't appear in the draft release notes when multiple PRs merge in quick succession.

**Changes:**
1. Add `concurrency` group with `cancel-in-progress: false` to queue (not cancel) overlapping runs
2. Pin to `@v6.0.0` to avoid v6.1.0 bug where the action fails to find existing draft releases and creates duplicates

Note: Uses `release-drafter-${{ github.ref }}` for the concurrency group since this workflow has both `push` and `pull_request` triggers, ensuring PR runs don't block each other while still serializing runs on the same ref.

## Review & Testing Checklist for Human

- [ ] Verify [release-drafter#1425](https://github.com/release-drafter/release-drafter/issues/1425) is still open before merging
- [ ] After merging, test by merging 2-3 PRs in quick succession and verify all appear in the draft release

### Notes

- Same fix already applied to `airbyte-ops-mcp`, `awesome-python-template`, `airbyte-interop-catalog`, and several other repos
- Requested by: AJ Steers (@aaronsteers)
- Link to Devin run: https://app.devin.ai/sessions/0dafc41101d144fe975937184b356eb3

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release workflow stability through configuration enhancements to prevent concurrent release operations and ensure consistent behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->