### PR TITLE
Fix: GzipDecoder - add support for responses with content-type 'application/a-gzip'  (Apple Connect API)

### DIFF
--- a/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -2629,6 +2629,7 @@ class ModelToComponentFactory:
             "application/gzip",
             "application/x-gzip",
             "application/x-zip-compressed",
+            "application/a-gzip",
         }
 
         gzip_parser: GzipParser = ModelToComponentFactory._get_parser(model, config)  # type: ignore  # based on the model, we know this will be a GzipParser


### PR DESCRIPTION
Related: [airbytehq/airbyte/#66208](https://github.com/airbytehq/airbyte/issues/66208)

"application/a-gzip" content type is used in Apple Connect API. [Apple Connect API docs](https://developer.apple.com/documentation/appstoreconnectapi/get-v1-salesreports) 
Without this fix GzipDecoder fails to decode responses with this content-type. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of gzip-compressed responses by expanding support for additional compression content types, ensuring better compatibility with various data sources that use gzip encoding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->