### PR TITLE
fix(cli): allow 'secrets list' to work outside the airbyte repo

### DIFF
--- a/airbyte_cdk/cli/airbyte_cdk/_secrets.py
+++ b/airbyte_cdk/cli/airbyte_cdk/_secrets.py
@@ -235,7 +235,10 @@ def list_(
     """
     click.echo("Scanning secrets...", err=True)
 
-    connector_name, _ = resolve_connector_name_and_directory(connector)
+    if connector and isinstance(connector, str) and "/" not in connector and "\\" not in connector:
+        connector_name = connector
+    else:
+        connector_name, _ = resolve_connector_name_and_directory(connector)
     secrets: list[Secret] = _fetch_secret_handles(  # type: ignore
         connector_name=connector_name,
         gcp_project_id=gcp_project_id,


### PR DESCRIPTION
## Summary

`airbyte-cdk secrets list <connector-name>` fails when run outside the airbyte monorepo because the `list_` command unnecessarily calls `resolve_connector_name_and_directory()`, which tries to locate the connector directory on disk. The `list` command only needs the connector name (to query GCP Secret Manager), not the directory.

This fix short-circuits the directory resolution when a plain connector name string is provided (e.g. `source-postgres`), using it directly. Path-based and cwd-based resolution still falls through to the original function.

The condition (`"/" not in connector and "\\" not in connector`) mirrors the same check in `resolve_connector_name_and_directory` (line 110 of `connector_paths.py`) for consistency.

## Review & Testing Checklist for Human

- [ ] Verify `uvx airbyte-cdk[dev] secrets list source-postgres` works from a directory outside the airbyte repo (e.g. `/tmp`)
- [ ] Verify `uvx airbyte-cdk[dev] secrets list source-postgres` still works from within the airbyte repo
- [ ] Verify `uvx airbyte-cdk[dev] secrets list` (no connector arg) still gives a sensible error when run outside the repo

### Notes
- The `fetch` command intentionally still requires directory resolution since it writes secret files to disk
- No validation is added that the connector name looks like a valid connector (e.g. starts with `source-` or `destination-`), but invalid names will simply return no results from GSM, which is already handled gracefully
- Link to Devin run: https://app.devin.ai/sessions/400fe05f64b34a45b8ecf396997f016b
- Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte-python-cdk/pull/897" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Simplified connector name input handling in the list secrets command for improved usability. The command now directly accepts plain connector names without requiring full path specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

> [!NOTE]
> **Auto-merge may have been disabled. Please check the PR status to confirm.**