### PR TITLE
feat(cli): fall back to Application Default Credentials for secrets commands

### DIFF
--- a/airbyte_cdk/cli/airbyte_cdk/_secrets.py
+++ b/airbyte_cdk/cli/airbyte_cdk/_secrets.py
@@ -433,6 +433,9 @@ def _get_gsm_secrets_client() -> "secretmanager.SecretManagerServiceClient":  # 
 
     credentials_json = os.environ.get("GCP_GSM_CREDENTIALS")
     if credentials_json:
+        click.echo(
+            "Using GCP service account credentials from GCP_GSM_CREDENTIALS env var.", err=True
+        )
         return cast(
             "secretmanager.SecretManagerServiceClient",
             secretmanager.SecretManagerServiceClient.from_service_account_info(
@@ -440,6 +443,9 @@ def _get_gsm_secrets_client() -> "secretmanager.SecretManagerServiceClient":  # 
             ),
         )
 
+    click.echo(
+        "GCP_GSM_CREDENTIALS not set. Using Application Default Credentials (ADC).", err=True
+    )
     try:
         return secretmanager.SecretManagerServiceClient()
     except google.auth.exceptions.DefaultCredentialsError:


### PR DESCRIPTION
## Summary

Previously, `airbyte-cdk secrets list` and `airbyte-cdk secrets fetch` required the `GCP_GSM_CREDENTIALS` environment variable (service account JSON) and raised a `ValueError` if it was missing. This change makes the env var optional by falling back to [Application Default Credentials (ADC)](https://cloud.google.com/docs/authentication/application-default-credentials) when it's not set.

This means engineers can use `gcloud auth application-default login` to authenticate, without needing to export a service account key.

When `GCP_GSM_CREDENTIALS` **is** set, behavior is unchanged (service account credentials are used).

## Review & Testing Checklist for Human

- [ ] **Verify ADC error UX**: When neither `GCP_GSM_CREDENTIALS` nor ADC credentials are available, the GCP client will raise `google.auth.exceptions.DefaultCredentialsError` instead of the previous `ValueError` with a specific message. Confirm this error is clear enough, or decide if a try/except wrapper with a friendlier message is warranted.
- [ ] **Test the ADC path locally**: Run `gcloud auth application-default login`, unset `GCP_GSM_CREDENTIALS`, and verify `airbyte-cdk secrets list source-pokeapi` works with your user credentials.
- [ ] **Confirm service account path unchanged**: With `GCP_GSM_CREDENTIALS` set, verify `secrets list` / `secrets fetch` still work as before.

### Notes

- Requested by: @aaronsteers
- [Link to Devin run](https://app.devin.ai/sessions/9b0ee26d0d3245dd947e501525ba8f31)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte-python-cdk/pull/898" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GCP Secret Manager authentication: accepts credentials from an environment variable or falls back to Application Default Credentials (ADC). Previously required the environment variable; now ADC is attempted and a clearer, actionable error is shown if authentication fails.

* **Documentation**
  * Expanded guidance on authenticating with GCP Secret Manager, including the new ADC fallback and recommended remediation steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._

> [!NOTE]
> **Auto-merge may have been disabled. Please check the PR status to confirm.**