### PR TITLE
fix(cli): make test imports lazy so secrets command works without [dev] extra

### DIFF
--- a/airbyte_cdk/cli/airbyte_cdk/_connector.py
+++ b/airbyte_cdk/cli/airbyte_cdk/_connector.py
@@ -172,7 +172,8 @@ def run_connector_tests(
             "pytest is not installed. Please install pytest to run the connector tests."
         )
 
-    from airbyte_cdk.test.standard_tests.util import create_connector_test_suite  # Lazy import: requires pytest, which is only available via the [dev] extra
+    # Lazy import: this module requires pytest, which is only available via the [dev] extra.
+    from airbyte_cdk.test.standard_tests.util import create_connector_test_suite
 
     connector_test_suite = create_connector_test_suite(
         connector_name=connector_name if not connector_directory else None,


### PR DESCRIPTION
## Summary

Moves the `create_connector_test_suite` import in `_connector.py` from module-level to inside `run_connector_tests()`, making it lazy. This fixes `uvx airbyte-cdk secrets list ...` (and all other CLI commands) failing with `ModuleNotFoundError: No module named 'pytest'` when the `[dev]` extra is not installed.

**Root cause:** `__init__.py` eagerly imports `_connector.py`, which eagerly imports `create_connector_test_suite` from `test.standard_tests.util`, which transitively imports `docker_base.py`, which does a hard `import pytest`. This breaks the entire CLI—not just `connector test`—when pytest isn't installed.

The import is placed after the existing `pytest is None` guard, so users still get a clean error if they run `connector test` without pytest.

## Review & Testing Checklist for Human

- [ ] Verify `uvx airbyte-cdk secrets list <connector>` works without `[dev]` (can test locally: `pip install airbyte-cdk` in a clean venv, then run `airbyte-cdk secrets list source-postgres`)
- [ ] Verify `airbyte-cdk connector test` still works when pytest IS installed (e.g. in a dev environment with `[dev]` extra)

### Notes

- Requested by: @aaronsteers
- [Link to Devin run](https://app.devin.ai/sessions/a0820d603a4b4a97af13bb2eefb220c4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte-python-cdk/pull/900" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized dependency loading to improve performance during test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->