### PR TITLE
fix(file-based): override primary_key in PermissionsFileBasedStream to avoid invalid parser-defined key

### DIFF
--- a/airbyte_cdk/sources/file_based/stream/concurrent/adapters.py
+++ b/airbyte_cdk/sources/file_based/stream/concurrent/adapters.py
@@ -155,10 +155,7 @@ class FileBasedStreamFacade(AbstractStreamFacade[DefaultStream], AbstractFileBas
 
     @property
     def primary_key(self) -> PrimaryKeyType:
-        return (
-            self._legacy_stream.config.primary_key
-            or self.get_parser().get_parser_defined_primary_key(self._legacy_stream.config)
-        )
+        return self._legacy_stream.primary_key
 
     def get_parser(self) -> FileTypeParser:
         return self._legacy_stream.get_parser()

--- a/airbyte_cdk/sources/file_based/stream/permissions_file_based_stream.py
+++ b/airbyte_cdk/sources/file_based/stream/permissions_file_based_stream.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, Iterable
 
 from airbyte_cdk.models import AirbyteLogMessage, AirbyteMessage, Level
 from airbyte_cdk.models import Type as MessageType
+from airbyte_cdk.sources.file_based.config.file_based_stream_config import PrimaryKeyType
 from airbyte_cdk.sources.file_based.file_based_stream_permissions_reader import (
     AbstractFileBasedStreamPermissionsReader,
 )
@@ -34,6 +35,10 @@ class PermissionsFileBasedStream(DefaultFileBasedStream):
     ):
         super().__init__(**kwargs)
         self.stream_permissions_reader = stream_permissions_reader
+
+    @property
+    def primary_key(self) -> PrimaryKeyType:
+        return self.config.primary_key
 
     def _filter_schema_invalid_properties(
         self, configured_catalog_json_schema: Dict[str, Any]


### PR DESCRIPTION
# fix(file-based): override primary_key in PermissionsFileBasedStream to avoid invalid parser-defined key

## Summary

When permissions transfer mode is enabled on file-based connectors (e.g. SharePoint Enterprise), the `PermissionsFileBasedStream` uses a completely different schema (with fields like `id`, `file_path`, `publicly_accessible`, `allowed_identity_remote_ids`) than the standard content schema. However, it inherited `DefaultFileBasedStream.primary_key`, which falls back to the parser-defined primary key — `"document_key"` for `UnstructuredParser`. Since `document_key` doesn't exist in the permissions schema, the destination rejects the catalog:

> `ConfigErrorException: A primary key column does not exist in the schema: document_key`

**Changes:**
1. **`PermissionsFileBasedStream`**: Overrides `primary_key` to return only `self.config.primary_key` (user-configured PK or `None`), skipping the parser-defined fallback that returns a key belonging to the content schema.
2. **`FileBasedStreamFacade`**: Delegates `primary_key` to the underlying legacy stream instead of reimplementing the fallback logic. This ensures permissions streams wrapped in the concurrent facade also get the correct behavior. For `DefaultFileBasedStream`, this is functionally equivalent to the previous logic.

## Review & Testing Checklist for Human

- [ ] **Verify behavioral equivalence of the facade change for non-permissions streams**: `FileBasedStreamFacade.primary_key` previously did `config.primary_key or parser.get_parser_defined_primary_key()` inline; now it delegates to `self._legacy_stream.primary_key`. Confirm that `DefaultFileBasedStream.primary_key` has identical logic (it does at time of writing — line 104-108), and that no other subclasses override `primary_key` in a way that would change behavior unexpectedly through the facade.
- [ ] **Verify `None` primary key doesn't break downstream**: When no user-configured PK exists, `PermissionsFileBasedStream.primary_key` now returns `None`. Confirm this is handled correctly in catalog generation (`sourceDefinedPrimaryKey` becomes empty) and that destinations handle the absence of a source-defined PK gracefully (user must configure one for dedup).
- [ ] **Test plan**: Ideally test with a file-based connector in permissions mode (e.g. SharePoint Enterprise with permissions enabled) to confirm (a) discovery no longer advertises `document_key` as PK, and (b) syncs succeed when an appropriate PK from the permissions schema is configured.

### Notes
- [Link to Devin run](https://app.devin.ai/sessions/df4c1b8e8b554e07838870ce95ce2395)
- Requested by: @rwask

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified primary key resolution in file-based streams to use a single source of truth, eliminating complex fallback logic.
  * Exposed primary key configuration as a public property for improved accessibility and consistency across file-based stream implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte-python-cdk/pull/903" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
