### PR TITLE
feat: Add regex_replace Jinja filter for low-code connector builder

### DIFF
--- a/airbyte_cdk/sources/declarative/interpolation/filters.py
+++ b/airbyte_cdk/sources/declarative/interpolation/filters.py
@@ -136,6 +136,13 @@ def regex_search(value: str, regex: str) -> str:
     return ""
 
 
+def regex_replace(value: str, regex: str, replacement: str) -> str:
+    """
+    Replace all occurrences of a regular expression pattern in a string.
+    """
+    return re.sub(regex, replacement, value)
+
+
 def hmac(value: Any, key: str, hash_type: str = "sha256") -> str:
     """
     Implementation of a custom Jinja2 hmac filter with SHA-256 support.
@@ -181,6 +188,7 @@ _filters_list = [
     base64binascii_decode,
     string,
     regex_search,
+    regex_replace,
     hmac,
 ]
 filters = {f.__name__: f for f in _filters_list}

--- a/unit_tests/sources/declarative/interpolation/test_filters.py
+++ b/unit_tests/sources/declarative/interpolation/test_filters.py
@@ -108,6 +108,36 @@ def test_regex_search_no_match() -> None:
     assert val is None
 
 
+@pytest.mark.parametrize(
+    "expression, expected",
+    [
+        pytest.param(
+            "{{ 'hello world' | regex_replace('world', 'there') }}",
+            "hello there",
+            id="basic_replacement",
+        ),
+        pytest.param(
+            "{{ 'abc123def456' | regex_replace('[0-9]+', '') }}",
+            "abcdef",
+            id="regex_pattern_strip_digits",
+        ),
+        pytest.param(
+            "{{ 'hello world' | regex_replace('xyz', 'replaced') }}",
+            "hello world",
+            id="no_match_returns_original",
+        ),
+        pytest.param(
+            "{{ 'aaa bbb aaa' | regex_replace('aaa', 'ccc') }}",
+            "ccc bbb ccc",
+            id="multiple_occurrences",
+        ),
+    ],
+)
+def test_regex_replace(expression: str, expected: str) -> None:
+    val = interpolation.eval(expression, {})
+    assert val == expected
+
+
 def test_hmac_sha256_default() -> None:
     message = "test_message"
     secret_key = "test_secret_key"


### PR DESCRIPTION
## Summary

Adds a `regex_replace` Jinja filter to the low-code connector builder's interpolation system, complementing the existing `regex_search` filter. This wraps Python's `re.sub()` and enables regex-based string replacement in declarative manifests:

```yaml
value: "{{ record['some_field'] | regex_replace('[0-9]+', '') }}"
```

Closes https://github.com/airbytehq/airbyte-python-cdk/issues/902

## Review & Testing Checklist for Human

- [ ] Verify that no error handling is needed for invalid regex patterns (current behavior matches `regex_search` — both will raise `re.error` on bad patterns). Decide if that's acceptable or if a try/except should be added.
- [ ] Consider whether this filter should be tested end-to-end within a declarative manifest context (e.g. via `ManifestDeclarativeSource`) rather than only at the interpolation level.

### Notes
- Requested by @lleadbet
- [Devin session](https://app.devin.ai/sessions/ea4c5e6dfb5b41818963118ece23c539)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added regex pattern matching and replacement functionality for advanced text transformation in declarative workflows.

* **Tests**
  * Added comprehensive test coverage for regex pattern replacement scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte-python-cdk/pull/904" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
