### PR TITLE
fix: Register regex_replace and regex_search as Jinja macros for direct function call syntax

### DIFF
--- a/airbyte_cdk/sources/declarative/interpolation/macros.py
+++ b/airbyte_cdk/sources/declarative/interpolation/macros.py
@@ -16,6 +16,7 @@ from dateutil import parser
 from isodate import parse_duration
 
 from airbyte_cdk.sources.declarative.datetime.datetime_parser import DatetimeParser
+from airbyte_cdk.sources.declarative.interpolation.filters import regex_replace, regex_search
 
 """
 This file contains macros that can be evaluated by a `JinjaInterpolation` object
@@ -232,5 +233,7 @@ _macros_list = [
     sanitize_url,
     camel_case_to_snake_case,
     generate_uuid,
+    regex_replace,
+    regex_search,
 ]
 macros = {f.__name__: f for f in _macros_list}

--- a/unit_tests/sources/declarative/interpolation/test_filters.py
+++ b/unit_tests/sources/declarative/interpolation/test_filters.py
@@ -138,6 +138,56 @@ def test_regex_replace(expression: str, expected: str) -> None:
     assert val == expected
 
 
+@pytest.mark.parametrize(
+    "expression, expected",
+    [
+        pytest.param(
+            "{{ regex_replace('hello world', 'world', 'there') }}",
+            "hello there",
+            id="basic_replacement",
+        ),
+        pytest.param(
+            "{{ regex_replace('abc123def456', '[0-9]+', '') }}",
+            "abcdef",
+            id="regex_pattern_strip_digits",
+        ),
+        pytest.param(
+            "{{ regex_replace('hello world', 'xyz', 'replaced') }}",
+            "hello world",
+            id="no_match_returns_original",
+        ),
+        pytest.param(
+            "{{ regex_replace('aaa bbb aaa', 'aaa', 'ccc') }}",
+            "ccc bbb ccc",
+            id="multiple_occurrences",
+        ),
+    ],
+)
+def test_regex_replace_as_macro(expression: str, expected: str) -> None:
+    val = interpolation.eval(expression, {})
+    assert val == expected
+
+
+@pytest.mark.parametrize(
+    "expression, expected",
+    [
+        pytest.param(
+            "{{ regex_search('<https://example.com/?page=2>; rel=\"next\"', '<(.*)>; rel=.*') }}",
+            "https://example.com/?page=2",
+            id="valid_match",
+        ),
+        pytest.param(
+            "{{ regex_search('no match here', 'WATWATWAT') }}",
+            None,
+            id="no_match",
+        ),
+    ],
+)
+def test_regex_search_as_macro(expression: str, expected: str) -> None:
+    val = interpolation.eval(expression, {})
+    assert val == expected
+
+
 def test_hmac_sha256_default() -> None:
     message = "test_message"
     secret_key = "test_secret_key"


### PR DESCRIPTION
# fix: Register regex_replace and regex_search as Jinja macros

## Summary

`regex_replace` and `regex_search` were only registered as Jinja **filters** (via `_ENVIRONMENT.filters`), which means they only worked with pipe syntax:
```
{{ 'abc123' | regex_replace('[0-9]+', '') }}  ✓ works
{{ regex_replace('abc123', '[0-9]+', '') }}   ✗ fails
```

This PR adds both functions to the `_macros_list` in `macros.py` (which feeds `_ENVIRONMENT.globals`), making them available as direct function calls as well. The functions are imported from `filters.py` — no logic is duplicated.

## Review & Testing Checklist for Human
- [ ] Verify no circular import between `macros.py` → `filters.py` (currently `filters.py` does not import from `macros.py`, so this should be safe)
- [ ] Test in the Connector Builder UI that `{{ regex_replace('abc123def456', '[0-9]+', '') }}` works as a direct function call

### Notes
- [Link to Devin run](https://app.devin.ai/sessions/64a34a42036b4e528c568875fd9f2629)
- Requested by @lleadbet