### PR TITLE
docs: add CONTRIBUTING.md with Releasing section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 
 Thank you for your interest in contributing to the Airbyte Python CDK!
 
-## Releasing
+## 🚀 Releasing
 
-This project uses [`semantic-pr-release-drafter`](https://github.com/aaronsteers/semantic-pr-release-drafter) for automated release management. For full details on how releases work, see the [Releasing Guide](https://github.com/aaronsteers/semantic-pr-release-drafter/blob/main/docs/releasing.md).
+This project uses [`semantic-pr-release-drafter`](https://github.com/aaronsteers/semantic-pr-release-drafter) for automated release management. To release, simply click "`Edit`" on the latest release draft from the [releases page](https://github.com/airbytehq/airbyte-python-cdk/releases), and then click "`Publish release`". This publish operation will trigger all necessary downstream publish operations.
+
+ℹ️ For more detailed instructions, please see the [Releasing Guide](https://github.com/aaronsteers/semantic-pr-release-drafter/blob/main/docs/releasing.md).


### PR DESCRIPTION
# docs: add CONTRIBUTING.md with Releasing section

## Summary

Adds a new `CONTRIBUTING.md` to `airbyte-python-cdk` with a `## 🚀 Releasing` section that includes:
- Inline release instructions: click "Edit" on the latest draft from the [releases page](https://github.com/airbytehq/airbyte-python-cdk/releases), then click "Publish release"
- A link to the shared [Releasing Guide](https://github.com/aaronsteers/semantic-pr-release-drafter/blob/main/docs/releasing.md) in `semantic-pr-release-drafter` for more detail

This is part of a cross-repo effort to ensure all repos using `semantic-pr-release-drafter` have a consistent "Releasing" entry in their CONTRIBUTING.md, pointing to a single source of truth rather than duplicating instructions.

The companion PR adding the shared releasing guide itself: https://github.com/aaronsteers/semantic-pr-release-drafter/pull/41

### Updates since last revision

- Updated section heading to `## 🚀 Releasing` per reviewer feedback
- Added inline release instructions with a direct link to this repo's [releases page](https://github.com/airbytehq/airbyte-python-cdk/releases)
- Added ℹ️ callout linking to the detailed Releasing Guide

## Review & Testing Checklist for Human

- [ ] **Verify the [releases page link](https://github.com/airbytehq/airbyte-python-cdk/releases) points to the correct repo** — should go to `airbytehq/airbyte-python-cdk`, not another repo.
- [ ] **Verify the releasing guide link will resolve.** The linked `docs/releasing.md` is being added via [aaronsteers/semantic-pr-release-drafter#41](https://github.com/aaronsteers/semantic-pr-release-drafter/pull/41) — that PR should land first or concurrently to avoid a dead link.

### Notes

- This is one of 9 consumer-repo PRs created alongside the shared releasing guide PR.
- No code changes — docs only.

---
Requested by: @aaronsteers
[Devin session](https://app.devin.ai/sessions/d59fa353515f488ab1818b8888d0c3bf)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte-python-cdk/pull/916" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive contributing guidelines for the Airbyte Python CDK with detailed instructions for the development workflow, release process, and automated release management. The guidelines include resources for understanding the complete contribution and release cycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->