### PR TITLE
fix: route RequestBodyPlainText to request_body_data instead of request_body_json

### DIFF
--- a/airbyte_cdk/manifest_migrations/migrations/http_requester_request_body_json_data_to_request_body.py
+++ b/airbyte_cdk/manifest_migrations/migrations/http_requester_request_body_json_data_to_request_body.py
@@ -26,9 +26,14 @@ class HttpRequesterRequestBodyJsonDataToRequestBody(ManifestMigration):
     replacement_key = "request_body"
 
     def should_migrate(self, manifest: ManifestType) -> bool:
-        return manifest[TYPE_TAG] == self.component_type and any(
-            key in list(manifest.keys()) for key in self.original_keys
-        )
+        if manifest[TYPE_TAG] != self.component_type:
+            return False
+        for key in self.original_keys:
+            if key in manifest:
+                if key == self.body_json_key and isinstance(manifest[key], str):
+                    continue
+                return True
+        return False
 
     def migrate(self, manifest: ManifestType) -> None:
         for key in self.original_keys:
@@ -38,9 +43,18 @@ class HttpRequesterRequestBodyJsonDataToRequestBody(ManifestMigration):
                 self._migrate_body_data(manifest, key)
 
     def validate(self, manifest: ManifestType) -> bool:
-        return self.replacement_key in manifest and all(
-            key not in manifest for key in self.original_keys
+        has_replacement = self.replacement_key in manifest
+        has_unmigrated = any(
+            key in manifest
+            for key in self.original_keys
+            if not (key == self.body_json_key and isinstance(manifest.get(key), str))
         )
+        has_string_json = self.body_json_key in manifest and isinstance(
+            manifest[self.body_json_key], str
+        )
+        if has_string_json:
+            return not has_unmigrated
+        return has_replacement and not has_unmigrated
 
     def _migrate_body_json(self, manifest: ManifestType, key: str) -> None:
         """
@@ -52,7 +66,7 @@ class HttpRequesterRequestBodyJsonDataToRequestBody(ManifestMigration):
         json_object_type = "RequestBodyJsonObject"
 
         if isinstance(manifest[key], str):
-            self._migrate_value(manifest, key, text_type)
+            return
         elif isinstance(manifest[key], dict):
             if isinstance(manifest[key].get(query_key), str):
                 self._migrate_value(manifest, key, graph_ql_type)

--- a/airbyte_cdk/manifest_migrations/migrations/http_requester_request_body_json_data_to_request_body.py
+++ b/airbyte_cdk/manifest_migrations/migrations/http_requester_request_body_json_data_to_request_body.py
@@ -15,6 +15,23 @@ class HttpRequesterRequestBodyJsonDataToRequestBody(ManifestMigration):
     This migration is responsible for migrating the `request_body_json` and `request_body_data` keys
     to a unified `request_body` key in the HttpRequester component.
     The migration will copy the value of either original key to `request_body` and remove the original key.
+
+    **String-valued `request_body_json` is intentionally left unmigrated.**
+
+    When `request_body_json` is a string (e.g. a Jinja template like
+    `'{"nested": {"key": "{{ config.option }}"}}'`), it is NOT converted to a
+    `RequestBodyPlainText` or any other typed `request_body` object. This is because:
+
+    1. The `InterpolatedRequestOptionsProvider` already handles string `request_body_json`
+       natively via `InterpolatedNestedRequestInputProvider`, which interpolates the
+       template and parses the result into a dict using `ast.literal_eval`, then sends
+       it as a JSON body.
+    2. Converting it to `RequestBodyPlainText` would route it to `request_body_data`
+       (raw string body) instead of `request_body_json` (JSON body), breaking connectors
+       that rely on the body being sent as JSON with the correct Content-Type header.
+    3. We cannot convert it to `RequestBodyJsonObject` because migrations run before
+       interpolation, so Jinja templates have not been resolved yet and the string
+       cannot be parsed into a dict at migration time.
     """
 
     component_type = "HttpRequester"
@@ -59,6 +76,10 @@ class HttpRequesterRequestBodyJsonDataToRequestBody(ManifestMigration):
     def _migrate_body_json(self, manifest: ManifestType, key: str) -> None:
         """
         Migrate the value of the request_body_json.
+
+        String values are left as-is (not migrated) because they are Jinja templates
+        that will be interpolated and parsed into dicts at runtime by
+        InterpolatedNestedRequestInputProvider. See class docstring for details.
         """
         query_key = "query"
         graph_ql_type = "RequestBodyGraphQL"

--- a/airbyte_cdk/manifest_migrations/migrations/http_requester_request_body_json_data_to_request_body.py
+++ b/airbyte_cdk/manifest_migrations/migrations/http_requester_request_body_json_data_to_request_body.py
@@ -61,7 +61,6 @@ class HttpRequesterRequestBodyJsonDataToRequestBody(ManifestMigration):
         Migrate the value of the request_body_json.
         """
         query_key = "query"
-        text_type = "RequestBodyPlainText"
         graph_ql_type = "RequestBodyGraphQL"
         json_object_type = "RequestBodyJsonObject"
 

--- a/airbyte_cdk/sources/declarative/requesters/request_options/interpolated_request_options_provider.py
+++ b/airbyte_cdk/sources/declarative/requesters/request_options/interpolated_request_options_provider.py
@@ -101,7 +101,9 @@ class InterpolatedRequestOptionsProvider(RequestOptionsProvider):
                 self.request_body_data = self.request_body.value
             elif self.request_body.type == "RequestBodyGraphQL":
                 self.request_body_json = self.request_body.value.dict(exclude_none=True)
-            elif self.request_body.type in ("RequestBodyJsonObject", "RequestBodyPlainText"):
+            elif self.request_body.type == "RequestBodyPlainText":
+                self.request_body_data = self.request_body.value
+            elif self.request_body.type == "RequestBodyJsonObject":
                 self.request_body_json = self.request_body.value
             else:
                 raise ValueError(f"Unsupported request body type: {self.request_body.type}")

--- a/unit_tests/manifest_migrations/conftest.py
+++ b/unit_tests/manifest_migrations/conftest.py
@@ -941,10 +941,7 @@ def expected_manifest_with_migrated_to_request_body() -> Dict[str, Any]:
                             "type": "HttpRequester",
                             "http_method": "GET",
                             "url": "https://example.com/v2/path_to_B",
-                            "request_body": {
-                                "type": "RequestBodyPlainText",
-                                "value": '{"nested": { "key": "{{ config[\'option\'] }}" }}',
-                            },
+                            "request_body_json": '{"nested": { "key": "{{ config[\'option\'] }}" }}',
                         },
                         "record_selector": {
                             "type": "RecordSelector",
@@ -1102,10 +1099,7 @@ def expected_manifest_with_migrated_to_request_body() -> Dict[str, Any]:
                         "type": "HttpRequester",
                         "http_method": "GET",
                         "url": "https://example.com/v2/path_to_B",
-                        "request_body": {
-                            "type": "RequestBodyPlainText",
-                            "value": '{"nested": { "key": "{{ config[\'option\'] }}" }}',
-                        },
+                        "request_body_json": '{"nested": { "key": "{{ config[\'option\'] }}" }}',
                     },
                     "record_selector": {
                         "type": "RecordSelector",

--- a/unit_tests/sources/declarative/requesters/request_options/test_interpolated_request_options_provider.py
+++ b/unit_tests/sources/declarative/requesters/request_options/test_interpolated_request_options_provider.py
@@ -212,14 +212,6 @@ def test_interpolated_request_json(test_name, input_request_json, expected_reque
             {},
         ),
         (
-            "test_string",
-            RequestBodyPlainText(
-                type="RequestBodyPlainText",
-                value="""{"nested": { "key": "{{ config['option'] }}" }}""",
-            ),
-            {"nested": {"key": "OPTION"}},
-        ),
-        (
             "test_nested_objects",
             RequestBodyJsonObject(
                 type="RequestBodyJsonObject", value={"nested": {"key": "{{ config['option'] }}"}}
@@ -344,6 +336,22 @@ def test_interpolated_request_data(test_name, input_request_data, expected_reque
                 },
             ),
             {"2020-01-01 - 12345": "ABC"},
+        ),
+        (
+            "test_plain_text_body",
+            RequestBodyPlainText(
+                type="RequestBodyPlainText",
+                value="plain text body content",
+            ),
+            "plain text body content",
+        ),
+        (
+            "test_plain_text_with_interpolation",
+            RequestBodyPlainText(
+                type="RequestBodyPlainText",
+                value="interpolate_me=5&option={{ config['option'] }}",
+            ),
+            "interpolate_me=5&option=OPTION",
         ),
     ],
 )


### PR DESCRIPTION
## Summary

`RequestBodyPlainText` was incorrectly grouped with `RequestBodyJsonObject` in `InterpolatedRequestOptionsProvider._resolve_request_body()`, causing plain text body values to be assigned to `request_body_json` instead of `request_body_data`. This resulted in a `ValueError("Request body json cannot be a string")` whenever a user configured a plain-text request body in the Connector Builder — for example, when creating an asynchronous job with a non-JSON body.

The fix splits the combined `elif` branch so that `RequestBodyPlainText` routes to `self.request_body_data` (like `RequestBodyUrlEncodedForm` already does), while `RequestBodyJsonObject` continues to route to `self.request_body_json`.

### Migration backward compatibility

The manifest migration (`HttpRequesterRequestBodyJsonDataToRequestBody`) previously converted string-valued `request_body_json` fields to `RequestBodyPlainText`. Before this fix, that worked by accident because `RequestBodyPlainText` was (incorrectly) routed to `request_body_json`. Now that `RequestBodyPlainText` correctly routes to `request_body_data`, the migration would break existing connectors that rely on string JSON templates being sent as JSON bodies.

The fix: string-valued `request_body_json` fields are now **skipped by the migration** and left as `request_body_json`, where `InterpolatedNestedRequestInputProvider` already handles them natively (interpolating the template string and parsing it via `ast.literal_eval` into a dict).

Changes to the migration:
- `should_migrate` returns `False` when the only migratable key is a string `request_body_json`
- `_migrate_body_json` returns early (no-op) for string values instead of converting to `RequestBodyPlainText`
- `validate` accepts manifests where string `request_body_json` remains unmigrated
- Removed unused `text_type` variable
- Added class and method docstrings explaining why string `request_body_json` is intentionally preserved

## Review & Testing Checklist for Human

- [ ] **End-to-end in Connector Builder**: Configure an async job creation request with a plain-text request body and confirm the request is sent correctly without the `"Request body json cannot be a string"` error. This is the primary user-facing scenario.
- [ ] **Existing connectors with string `request_body_json`**: Confirm that connectors currently using string-valued `request_body_json` (e.g., Shopify GraphQL) continue to send JSON bodies with the correct `Content-Type` after this change. @agarctfi verified that without the migration fix, Shopify gets a `415 Unsupported Media Type`; with it, the connector works. Worth a second verification.
- [ ] **Migration `validate()` logic**: The three-state validation (`has_replacement`, `has_unmigrated`, `has_string_json`) is the most complex part of this change. Verify that manifests with only a string `request_body_json` (no other body keys) pass validation without requiring `request_body` to be present.
- [ ] **Known limitation — `ast.literal_eval` in interpolation layer**: `JinjaInterpolation` applies `ast.literal_eval` to rendered string values. A plain-text body whose content looks like a Python literal (e.g., `{"a": 1}` or `5`) could be parsed into a dict/int rather than staying a string. This is pre-existing behavior not introduced by this PR, but is now more relevant for `RequestBodyPlainText` bodies routed through `request_body_data`.

### Notes

- The old test `"test_string"` in `test_interpolated_request_json_using_request_body` was encoding the buggy behavior: it expected `RequestBodyPlainText` with value `'{"nested": { "key": "..." }}'` to produce a parsed JSON dict. This test has been removed and replaced with two new cases in `test_interpolated_request_data_using_request_body`.
- The migration test fixtures in `conftest.py` have been updated so the expected output for stream "D" (string `request_body_json`) retains the original `request_body_json` key rather than converting to `RequestBodyPlainText`.
- Verified locally by @agarctfi ([comment](https://github.com/airbytehq/airbyte-python-cdk/pull/971#issuecomment-4209374200)).
- Related oncall issue: `airbytehq/oncall#10360`

Link to Devin session: https://app.devin.ai/sessions/8a5ed7c6c890468ca63a35469e5c58c1
Requested by: @Airbyte-Support

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved migration and validation to stop converting string-encoded JSON into structured request bodies and to correctly distinguish plain-text vs JSON request bodies.
* **Tests**
  * Updated tests to focus on plain-text request bodies and interpolation, removed cases that treated plain-text as parsed JSON, and adjusted expected migrated manifests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->