### PR TITLE
fix: fix 'occured' -> 'occurred' typos in error messages

### DIFF
--- a/airbyte_cdk/sources/declarative/extractors/response_to_file_extractor.py
+++ b/airbyte_cdk/sources/declarative/extractors/response_to_file_extractor.py
@@ -113,7 +113,7 @@ class ResponseToFileExtractor(RecordExtractor):
             return tmp_file, response_encoding
         else:
             raise ValueError(
-                f"The IO/Error occured while verifying binary data. Tmp file {tmp_file} doesn't exist."
+                f"The IO/Error occurred while verifying binary data. Tmp file {tmp_file} doesn't exist."
             )
 
     def _read_with_chunks(
@@ -147,7 +147,7 @@ class ResponseToFileExtractor(RecordExtractor):
             self.logger.info(f"Empty data received. {e}")
             yield from []
         except IOError as ioe:
-            raise ValueError(f"The IO/Error occured while reading tmp data. Called: {path}", ioe)
+            raise ValueError(f"The IO/Error occurred while reading tmp data. Called: {path}", ioe)
         finally:
             # remove binary tmp file, after data is read
             os.remove(path)

--- a/airbyte_cdk/sources/file_based/exceptions.py
+++ b/airbyte_cdk/sources/file_based/exceptions.py
@@ -55,7 +55,7 @@ class FileBasedErrorsCollector:
             # raising the single exception
             raise AirbyteTracedException(
                 internal_message="Please check the logged errors for more information.",
-                message="Some errors occured while reading from the source.",
+                message="Some errors occurred while reading from the source.",
                 failure_type=FailureType.config_error,
             )
 


### PR DESCRIPTION
Multiple error messages contained `occured`:
- `airbyte_cdk/sources/file_based/exceptions.py` line 58
- `airbyte_cdk/sources/declarative/extractors/response_to_file_extractor.py` lines 116, 150

Fixed to `occurred`. String-literal-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected spelling in error messages for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->