### PR TITLE
feat(test): auto-discover smoke-test scenarios from metadata.yaml

### DIFF
--- a/airbyte_cdk/test/standard_tests/docker_base.py
+++ b/airbyte_cdk/test/standard_tests/docker_base.py
@@ -27,6 +27,9 @@ from airbyte_cdk.models import (
 from airbyte_cdk.models.connector_metadata import MetadataFile
 from airbyte_cdk.test.entrypoint_wrapper import EntrypointOutput
 from airbyte_cdk.test.models import ConnectorTestScenario
+from airbyte_cdk.test.standard_tests.scenario_loader import (
+    load_metadata_smoke_test_scenarios,
+)
 from airbyte_cdk.utils.connector_paths import (
     ACCEPTANCE_TEST_CONFIG,
     find_connector_root,
@@ -122,9 +125,25 @@ class DockerConnectorTestSuite:
     ) -> list[ConnectorTestScenario]:
         """Get acceptance tests for a given category.
 
+        Scenarios are sourced from two files, in this order:
+
+        1. `acceptance-test-config.yml` (CAT-style scenarios), parsed as today.
+        2. `metadata.yaml` `connectorTestSuitesOptions[].suite == 'smokeTests'`,
+           with `${secret-ref:...}` and `${relative-date:...}` sigils resolved.
+
+        Smoke-test scenarios are additive; CAT-style scenarios are unchanged
+        for any connector that has not opted into the metadata.yaml dialect.
+
         This has to be a separate function because pytest does not allow
         parametrization of fixtures with arguments from the test class itself.
         """
+        cat_scenarios = cls._get_acceptance_test_scenarios()
+        smoke_scenarios = cls._get_smoke_test_scenarios()
+        return cat_scenarios + smoke_scenarios
+
+    @classmethod
+    def _get_acceptance_test_scenarios(cls) -> list[ConnectorTestScenario]:
+        """Load CAT-style scenarios from `acceptance-test-config.yml`."""
         try:
             all_tests_config = cls.acceptance_test_config
         except FileNotFoundError as e:
@@ -158,9 +177,17 @@ class DockerConnectorTestSuite:
 
                 test_scenarios.append(scenario)
 
-        deduped_test_scenarios = cls._dedup_scenarios(test_scenarios)
+        return cls._dedup_scenarios(test_scenarios)
 
-        return deduped_test_scenarios
+    @classmethod
+    def _get_smoke_test_scenarios(cls) -> list[ConnectorTestScenario]:
+        """Load smoke-test scenarios declared in `metadata.yaml`, if any."""
+        connector_root = cls.get_connector_root_dir()
+        metadata_path = connector_root / "metadata.yaml"
+        return load_metadata_smoke_test_scenarios(
+            metadata_path=metadata_path,
+            connector_root=connector_root,
+        )
 
     @pytest.mark.skipif(
         shutil.which("docker") is None,

--- a/airbyte_cdk/test/standard_tests/scenario_loader.py
+++ b/airbyte_cdk/test/standard_tests/scenario_loader.py
@@ -1,0 +1,288 @@
+# Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+"""Load smoke-test scenarios from a connector's `metadata.yaml`.
+
+Scenarios declared under
+`data.connectorTestSuitesOptions[].suite == 'smokeTests'` are converted into
+`ConnectorTestScenario` instances so they can be parametrized by the standard
+test suite alongside scenarios discovered from `acceptance-test-config.yml`.
+
+`configSettings` values support two interpolation sigils:
+
+- `${secret-ref:<item>/<section>/<field>}` resolves a credential previously
+  written to `secrets/.env.<section>` by an out-of-band fetcher (today the
+  airbyte-ops-mcp `secrets fetch` command). All three segments are required.
+- `${relative-date:-P<duration>}` resolves an ISO-8601 duration anchored at
+  today's UTC midnight and renders as an RFC 3339 timestamp
+  (e.g. `2026-03-22T00:00:00Z`).
+
+`AIRBYTE_TEST_CREDS_PROVIDER=1pass` and `AIRBYTE_TEST_CREDS_1PASS_VAULT_NAME`
+are required *only when* a `${secret-ref:...}` sigil is actually present in
+the resolved scenario. Pure `${relative-date:...}` or literal scenarios resolve
+without any provider env vars.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import isodate
+import yaml
+
+from airbyte_cdk.test.models import ConnectorTestScenario
+
+SMOKE_TEST_SUITE_NAME = "smokeTests"
+SECRETS_DIRNAME = "secrets"
+ENV_FILE_PREFIX = ".env."
+
+_SECRET_REF_PATTERN = re.compile(
+    r"^\$\{secret-ref:(?P<item>[^/}]+)/(?P<section>[^/}]+)/(?P<field>[^/}]+)\}$"
+)
+_RELATIVE_DATE_PATTERN = re.compile(r"^\$\{relative-date:-(?P<duration>P[^}]+)\}$")
+
+
+class SigilResolutionError(ValueError):
+    """Raised when a sigil cannot be resolved into a concrete value."""
+
+
+def load_metadata_smoke_test_scenarios(
+    metadata_path: Path,
+    connector_root: Path,
+) -> list[ConnectorTestScenario]:
+    """Return smoke-test scenarios declared in a connector's `metadata.yaml`.
+
+    Returns an empty list when the file does not exist or contains no
+    `smokeTests` suite. Sigil resolution is eager: each scenario's
+    `configSettings` is fully materialized before the `ConnectorTestScenario`
+    is constructed, so downstream test code never sees an unresolved sigil.
+    """
+    if not metadata_path.exists():
+        return []
+
+    metadata = yaml.safe_load(metadata_path.read_text()) or {}
+    suites = metadata.get("data", {}).get("connectorTestSuitesOptions", [])
+
+    scenarios: list[ConnectorTestScenario] = []
+    for suite in suites:
+        if not isinstance(suite, dict) or suite.get("suite") != SMOKE_TEST_SUITE_NAME:
+            continue
+
+        for raw_scenario in suite.get("scenarios", []) or []:
+            scenarios.append(
+                _build_scenario(
+                    raw_scenario=raw_scenario,
+                    connector_root=connector_root,
+                )
+            )
+
+    return scenarios
+
+
+def _build_scenario(
+    *,
+    raw_scenario: dict[str, Any],
+    connector_root: Path,
+) -> ConnectorTestScenario:
+    name = raw_scenario.get("name")
+    if not name or not isinstance(name, str):
+        raise SigilResolutionError("Smoke-test scenario is missing a string `name` field.")
+
+    raw_settings = raw_scenario.get("configSettings", {}) or {}
+    if not isinstance(raw_settings, dict):
+        raise SigilResolutionError(
+            f"Smoke-test scenario `{name}` has non-mapping `configSettings`."
+        )
+
+    env_cache: dict[str, dict[str, str]] = {}
+    has_secret_ref = _contains_secret_ref(raw_settings)
+    if has_secret_ref:
+        _validate_provider_env()
+
+    resolved_settings = _resolve_sigils(
+        value=raw_settings,
+        connector_root=connector_root,
+        env_cache=env_cache,
+    )
+
+    scenario = ConnectorTestScenario.model_validate({"config_dict": resolved_settings})
+    # `_id` is a Pydantic v2 private attribute, so it is not populated by
+    # `model_validate` and the model is frozen. Bypass `__setattr__` once at
+    # construction time so the scenario reports a stable, human-readable id.
+    object.__setattr__(scenario, "_id", f"smoke-{name}")
+    return scenario
+
+
+def _resolve_sigils(
+    *,
+    value: Any,
+    connector_root: Path,
+    env_cache: dict[str, dict[str, str]],
+) -> Any:
+    """Recursively resolve `${...}` sigils inside `value`."""
+    if isinstance(value, dict):
+        return {
+            k: _resolve_sigils(
+                value=v,
+                connector_root=connector_root,
+                env_cache=env_cache,
+            )
+            for k, v in value.items()
+        }
+    if isinstance(value, list):
+        return [
+            _resolve_sigils(
+                value=item,
+                connector_root=connector_root,
+                env_cache=env_cache,
+            )
+            for item in value
+        ]
+    if isinstance(value, str):
+        return _resolve_string(
+            raw=value,
+            connector_root=connector_root,
+            env_cache=env_cache,
+        )
+    return value
+
+
+def _resolve_string(
+    *,
+    raw: str,
+    connector_root: Path,
+    env_cache: dict[str, dict[str, str]],
+) -> str:
+    secret_match = _SECRET_REF_PATTERN.match(raw)
+    if secret_match is not None:
+        return _resolve_secret_ref(
+            item=secret_match.group("item"),
+            section=secret_match.group("section"),
+            field=secret_match.group("field"),
+            connector_root=connector_root,
+            env_cache=env_cache,
+        )
+
+    date_match = _RELATIVE_DATE_PATTERN.match(raw)
+    if date_match is not None:
+        return _resolve_relative_date(duration_str=date_match.group("duration"))
+
+    if raw.startswith("${") and raw.endswith("}"):
+        raise SigilResolutionError(
+            f"Unrecognized smoke-test sigil: `{raw}`. Supported forms are "
+            "`${secret-ref:<item>/<section>/<field>}` and "
+            "`${relative-date:-P<duration>}`."
+        )
+
+    return raw
+
+
+def _resolve_secret_ref(
+    *,
+    item: str,
+    section: str,
+    field: str,
+    connector_root: Path,
+    env_cache: dict[str, dict[str, str]],
+) -> str:
+    """Resolve `${secret-ref:item/section/field}` against `secrets/.env.<section>`.
+
+    The section segment is the literal 1Password section name (no prefix
+    stripping). Env var names inside each `.env.<section>` file are flat:
+    `<ITEM_UPPER>_<FIELD_UPPER>`.
+    """
+    env_path = connector_root / SECRETS_DIRNAME / f"{ENV_FILE_PREFIX}{section}"
+    env_vars = _load_env_file(path=env_path, cache=env_cache)
+
+    var_name = f"{item.upper()}_{field.upper()}"
+    if var_name not in env_vars:
+        raise SigilResolutionError(
+            f"Env var `{var_name}` not found in `{env_path}` for sigil "
+            f"`${{secret-ref:{item}/{section}/{field}}}`."
+        )
+    return env_vars[var_name]
+
+
+def _resolve_relative_date(*, duration_str: str) -> str:
+    """Render `${relative-date:-P<duration>}` as RFC 3339 at today midnight UTC."""
+    duration = isodate.parse_duration(duration_str)
+    now = datetime.now(tz=timezone.utc)
+    today_midnight = datetime(
+        year=now.year,
+        month=now.month,
+        day=now.day,
+        tzinfo=timezone.utc,
+    )
+    rendered: datetime = today_midnight - duration
+    if rendered.tzinfo is None:
+        rendered = rendered.replace(tzinfo=timezone.utc)
+    return rendered.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _load_env_file(
+    *,
+    path: Path,
+    cache: dict[str, dict[str, str]],
+) -> dict[str, str]:
+    """Parse a `.env.<section>` file into a name->value mapping.
+
+    Supports `KEY=value` and `KEY="value"` lines. Comments (`#`) and blank
+    lines are ignored. The result is cached per `path` so that scenarios with
+    multiple sigils against the same section pay the parse cost once.
+    """
+    cache_key = str(path)
+    if cache_key in cache:
+        return cache[cache_key]
+
+    if not path.exists():
+        raise SigilResolutionError(
+            f"Env file `{path}` not found. Run `airbyte-ops secrets fetch "
+            "<connector>` to populate it before invoking the test suite."
+        )
+
+    parsed: dict[str, str] = {}
+    for raw_line in path.read_text().splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        key = key.strip()
+        value = value.strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in ('"', "'"):
+            value = value[1:-1]
+        parsed[key] = value
+
+    cache[cache_key] = parsed
+    return parsed
+
+
+def _contains_secret_ref(value: Any) -> bool:
+    """Walk `value` and return True if any string contains a `secret-ref` sigil."""
+    if isinstance(value, dict):
+        return any(_contains_secret_ref(v) for v in value.values())
+    if isinstance(value, list):
+        return any(_contains_secret_ref(item) for item in value)
+    if isinstance(value, str):
+        return _SECRET_REF_PATTERN.match(value) is not None
+    return False
+
+
+def _validate_provider_env() -> None:
+    """Fail fast if the secret-provider env var contract is unmet."""
+    provider = os.environ.get("AIRBYTE_TEST_CREDS_PROVIDER", "")
+    vault = os.environ.get("AIRBYTE_TEST_CREDS_1PASS_VAULT_NAME", "")
+    if provider != "1pass":
+        raise SigilResolutionError(
+            "Smoke-test scenario uses `${secret-ref:...}` sigils but "
+            "`AIRBYTE_TEST_CREDS_PROVIDER` is not set to `1pass` "
+            "(only supported provider today)."
+        )
+    if not vault:
+        raise SigilResolutionError(
+            "Smoke-test scenario uses `${secret-ref:...}` sigils but "
+            "`AIRBYTE_TEST_CREDS_1PASS_VAULT_NAME` is not set."
+        )

--- a/unit_tests/test/test_scenario_loader.py
+++ b/unit_tests/test/test_scenario_loader.py
@@ -1,0 +1,438 @@
+# Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+"""Unit tests for `airbyte_cdk.test.standard_tests.scenario_loader`."""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+from airbyte_cdk.test.standard_tests.scenario_loader import (
+    SigilResolutionError,
+    load_metadata_smoke_test_scenarios,
+)
+
+_RFC3339 = re.compile(r"^\d{4}-\d{2}-\d{2}T00:00:00Z$")
+
+
+@pytest.fixture
+def connector_root(tmp_path: Path) -> Path:
+    """Return a temp directory laid out like a connector root."""
+    (tmp_path / "secrets").mkdir()
+    return tmp_path
+
+
+def _write_metadata(connector_root: Path, body: str) -> Path:
+    metadata_path = connector_root / "metadata.yaml"
+    metadata_path.write_text(dedent(body))
+    return metadata_path
+
+
+def _write_env(connector_root: Path, section: str, contents: str) -> None:
+    (connector_root / "secrets" / f".env.{section}").write_text(dedent(contents))
+
+
+def test_no_metadata_file_returns_empty(tmp_path: Path) -> None:
+    """A missing metadata.yaml is not an error; scenario discovery is opt-in."""
+    scenarios = load_metadata_smoke_test_scenarios(
+        metadata_path=tmp_path / "metadata.yaml",
+        connector_root=tmp_path,
+    )
+    assert scenarios == []
+
+
+def test_metadata_without_smoke_test_suite_returns_empty(connector_root: Path) -> None:
+    metadata_path = _write_metadata(
+        connector_root,
+        """
+        data:
+          connectorTestSuitesOptions:
+            - suite: acceptanceTests
+        """,
+    )
+    assert (
+        load_metadata_smoke_test_scenarios(
+            metadata_path=metadata_path,
+            connector_root=connector_root,
+        )
+        == []
+    )
+
+
+def test_literal_only_scenario_resolves_without_provider_env(
+    connector_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """source-faker-style scenarios resolve without any provider env vars."""
+    monkeypatch.delenv("AIRBYTE_TEST_CREDS_PROVIDER", raising=False)
+    monkeypatch.delenv("AIRBYTE_TEST_CREDS_1PASS_VAULT_NAME", raising=False)
+
+    metadata_path = _write_metadata(
+        connector_root,
+        """
+        data:
+          connectorTestSuitesOptions:
+            - suite: smokeTests
+              scenarios:
+                - name: default
+                  configSettings:
+                    count: 100
+                    seed: "42"
+        """,
+    )
+
+    scenarios = load_metadata_smoke_test_scenarios(
+        metadata_path=metadata_path,
+        connector_root=connector_root,
+    )
+
+    assert len(scenarios) == 1
+    assert scenarios[0].id == "smoke-default"
+    assert scenarios[0].config_dict == {"count": 100, "seed": "42"}
+
+
+def test_relative_date_renders_rfc3339_at_midnight_utc(connector_root: Path) -> None:
+    metadata_path = _write_metadata(
+        connector_root,
+        """
+        data:
+          connectorTestSuitesOptions:
+            - suite: smokeTests
+              scenarios:
+                - name: default
+                  configSettings:
+                    start_date: "${relative-date:-P30D}"
+        """,
+    )
+
+    scenarios = load_metadata_smoke_test_scenarios(
+        metadata_path=metadata_path,
+        connector_root=connector_root,
+    )
+
+    assert len(scenarios) == 1
+    rendered = scenarios[0].config_dict["start_date"]
+    assert _RFC3339.match(rendered), rendered
+
+    today = datetime.now(tz=timezone.utc)
+    parsed = datetime.strptime(rendered, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+    delta = today.replace(hour=0, minute=0, second=0, microsecond=0) - parsed
+    assert delta.days == 30
+
+
+def test_secret_ref_resolves_from_per_section_env_file(
+    connector_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AIRBYTE_TEST_CREDS_PROVIDER", "1pass")
+    monkeypatch.setenv("AIRBYTE_TEST_CREDS_1PASS_VAULT_NAME", "test-vault")
+
+    _write_env(
+        connector_root,
+        "test-credentials-api_key",
+        """
+        ASHBY_API_KEY="super-secret"
+        """,
+    )
+
+    metadata_path = _write_metadata(
+        connector_root,
+        """
+        data:
+          connectorTestSuitesOptions:
+            - suite: smokeTests
+              scenarios:
+                - name: default
+                  configSettings:
+                    api_key: "${secret-ref:ashby/test-credentials-api_key/api_key}"
+                    start_date: "${relative-date:-P30D}"
+        """,
+    )
+
+    scenarios = load_metadata_smoke_test_scenarios(
+        metadata_path=metadata_path,
+        connector_root=connector_root,
+    )
+
+    assert scenarios[0].config_dict["api_key"] == "super-secret"
+
+
+def test_secret_ref_uses_literal_section_name(
+    connector_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Literal section names with dashes/underscores must not be transformed."""
+    monkeypatch.setenv("AIRBYTE_TEST_CREDS_PROVIDER", "1pass")
+    monkeypatch.setenv("AIRBYTE_TEST_CREDS_1PASS_VAULT_NAME", "test-vault")
+
+    _write_env(
+        connector_root,
+        "test-credentials-oauth",
+        """
+        ASHBY_CLIENT_ID="client-abc"
+        ASHBY_CLIENT_SECRET=client-secret-xyz
+        """,
+    )
+
+    metadata_path = _write_metadata(
+        connector_root,
+        """
+        data:
+          connectorTestSuitesOptions:
+            - suite: smokeTests
+              scenarios:
+                - name: oauth
+                  configSettings:
+                    client_id: "${secret-ref:ashby/test-credentials-oauth/client_id}"
+                    client_secret: "${secret-ref:ashby/test-credentials-oauth/client_secret}"
+        """,
+    )
+
+    scenarios = load_metadata_smoke_test_scenarios(
+        metadata_path=metadata_path,
+        connector_root=connector_root,
+    )
+
+    assert scenarios[0].config_dict == {
+        "client_id": "client-abc",
+        "client_secret": "client-secret-xyz",
+    }
+
+
+def test_secret_ref_without_provider_env_fails(
+    connector_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("AIRBYTE_TEST_CREDS_PROVIDER", raising=False)
+    monkeypatch.delenv("AIRBYTE_TEST_CREDS_1PASS_VAULT_NAME", raising=False)
+
+    metadata_path = _write_metadata(
+        connector_root,
+        """
+        data:
+          connectorTestSuitesOptions:
+            - suite: smokeTests
+              scenarios:
+                - name: default
+                  configSettings:
+                    api_key: "${secret-ref:ashby/test-credentials-api_key/api_key}"
+        """,
+    )
+
+    with pytest.raises(SigilResolutionError, match="AIRBYTE_TEST_CREDS_PROVIDER"):
+        load_metadata_smoke_test_scenarios(
+            metadata_path=metadata_path,
+            connector_root=connector_root,
+        )
+
+
+def test_secret_ref_without_vault_name_fails(
+    connector_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AIRBYTE_TEST_CREDS_PROVIDER", "1pass")
+    monkeypatch.delenv("AIRBYTE_TEST_CREDS_1PASS_VAULT_NAME", raising=False)
+
+    metadata_path = _write_metadata(
+        connector_root,
+        """
+        data:
+          connectorTestSuitesOptions:
+            - suite: smokeTests
+              scenarios:
+                - name: default
+                  configSettings:
+                    api_key: "${secret-ref:ashby/test-credentials-api_key/api_key}"
+        """,
+    )
+
+    with pytest.raises(SigilResolutionError, match="VAULT_NAME"):
+        load_metadata_smoke_test_scenarios(
+            metadata_path=metadata_path,
+            connector_root=connector_root,
+        )
+
+
+def test_secret_ref_missing_env_file_fails(
+    connector_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AIRBYTE_TEST_CREDS_PROVIDER", "1pass")
+    monkeypatch.setenv("AIRBYTE_TEST_CREDS_1PASS_VAULT_NAME", "test-vault")
+
+    metadata_path = _write_metadata(
+        connector_root,
+        """
+        data:
+          connectorTestSuitesOptions:
+            - suite: smokeTests
+              scenarios:
+                - name: default
+                  configSettings:
+                    api_key: "${secret-ref:ashby/test-credentials-api_key/api_key}"
+        """,
+    )
+
+    with pytest.raises(SigilResolutionError, match=r"\.env\.test-credentials-api_key"):
+        load_metadata_smoke_test_scenarios(
+            metadata_path=metadata_path,
+            connector_root=connector_root,
+        )
+
+
+def test_secret_ref_missing_env_var_in_file_fails(
+    connector_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AIRBYTE_TEST_CREDS_PROVIDER", "1pass")
+    monkeypatch.setenv("AIRBYTE_TEST_CREDS_1PASS_VAULT_NAME", "test-vault")
+
+    _write_env(
+        connector_root,
+        "test-credentials-api_key",
+        """
+        ASHBY_OTHER=irrelevant
+        """,
+    )
+
+    metadata_path = _write_metadata(
+        connector_root,
+        """
+        data:
+          connectorTestSuitesOptions:
+            - suite: smokeTests
+              scenarios:
+                - name: default
+                  configSettings:
+                    api_key: "${secret-ref:ashby/test-credentials-api_key/api_key}"
+        """,
+    )
+
+    with pytest.raises(SigilResolutionError, match="ASHBY_API_KEY"):
+        load_metadata_smoke_test_scenarios(
+            metadata_path=metadata_path,
+            connector_root=connector_root,
+        )
+
+
+def test_unknown_sigil_fails(connector_root: Path) -> None:
+    metadata_path = _write_metadata(
+        connector_root,
+        """
+        data:
+          connectorTestSuitesOptions:
+            - suite: smokeTests
+              scenarios:
+                - name: default
+                  configSettings:
+                    weird: "${unknown-sigil:foo}"
+        """,
+    )
+
+    with pytest.raises(SigilResolutionError, match="Unrecognized smoke-test sigil"):
+        load_metadata_smoke_test_scenarios(
+            metadata_path=metadata_path,
+            connector_root=connector_root,
+        )
+
+
+def test_two_segment_secret_ref_is_not_supported(connector_root: Path) -> None:
+    """3-segment-only is locked: 2-segment must fail loudly."""
+    metadata_path = _write_metadata(
+        connector_root,
+        """
+        data:
+          connectorTestSuitesOptions:
+            - suite: smokeTests
+              scenarios:
+                - name: default
+                  configSettings:
+                    api_key: "${secret-ref:ashby/api_key}"
+        """,
+    )
+
+    with pytest.raises(SigilResolutionError, match="Unrecognized smoke-test sigil"):
+        load_metadata_smoke_test_scenarios(
+            metadata_path=metadata_path,
+            connector_root=connector_root,
+        )
+
+
+def test_multiple_scenarios_resolve_independently(
+    connector_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AIRBYTE_TEST_CREDS_PROVIDER", "1pass")
+    monkeypatch.setenv("AIRBYTE_TEST_CREDS_1PASS_VAULT_NAME", "test-vault")
+
+    _write_env(connector_root, "test-credentials-api_key", 'ASHBY_API_KEY="k1"')
+    _write_env(
+        connector_root,
+        "test-credentials-oauth",
+        'ASHBY_CLIENT_ID="cid"\nASHBY_CLIENT_SECRET="csec"',
+    )
+
+    metadata_path = _write_metadata(
+        connector_root,
+        """
+        data:
+          connectorTestSuitesOptions:
+            - suite: smokeTests
+              scenarios:
+                - name: default
+                  configSettings:
+                    api_key: "${secret-ref:ashby/test-credentials-api_key/api_key}"
+                - name: oauth
+                  configSettings:
+                    client_id: "${secret-ref:ashby/test-credentials-oauth/client_id}"
+                    client_secret: "${secret-ref:ashby/test-credentials-oauth/client_secret}"
+        """,
+    )
+
+    scenarios = load_metadata_smoke_test_scenarios(
+        metadata_path=metadata_path,
+        connector_root=connector_root,
+    )
+
+    assert [s.id for s in scenarios] == ["smoke-default", "smoke-oauth"]
+    assert scenarios[0].config_dict == {"api_key": "k1"}
+    assert scenarios[1].config_dict == {"client_id": "cid", "client_secret": "csec"}
+
+
+def test_nested_structures_are_resolved_recursively(
+    connector_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AIRBYTE_TEST_CREDS_PROVIDER", "1pass")
+    monkeypatch.setenv("AIRBYTE_TEST_CREDS_1PASS_VAULT_NAME", "test-vault")
+    _write_env(connector_root, "test-credentials-api_key", 'ASHBY_API_KEY="k1"')
+
+    metadata_path = _write_metadata(
+        connector_root,
+        """
+        data:
+          connectorTestSuitesOptions:
+            - suite: smokeTests
+              scenarios:
+                - name: default
+                  configSettings:
+                    credentials:
+                      auth_type: api_key
+                      api_key: "${secret-ref:ashby/test-credentials-api_key/api_key}"
+                    streams:
+                      - name: candidates
+                        cursor: "${relative-date:-P30D}"
+        """,
+    )
+
+    scenarios = load_metadata_smoke_test_scenarios(
+        metadata_path=metadata_path,
+        connector_root=connector_root,
+    )
+
+    config = scenarios[0].config_dict
+    assert config["credentials"] == {"auth_type": "api_key", "api_key": "k1"}
+    assert _RFC3339.match(config["streams"][0]["cursor"])


### PR DESCRIPTION
## Summary

Teaches the standard-tests suite to read smoke-test scenarios declared in a connector's `metadata.yaml`, so connectors can opt into 1Password-backed scenarios without per-connector CI YAML edits.

New module `airbyte_cdk.test.standard_tests.scenario_loader`:

- Parses `data.connectorTestSuitesOptions[].suite == 'smokeTests'` from `metadata.yaml`
- Converts each scenario into a `ConnectorTestScenario` (with `config_dict` populated and a stable `smoke-<name>` id)
- Resolves two sigils inside `configSettings` recursively:
  - `${secret-ref:<item>/<section>/<field>}` — 3-segment-only. Reads `secrets/.env.<section>` (literal 1P section name, no prefix stripping) and looks up `<ITEM_UPPER>_<FIELD_UPPER>`. The OPS CLI is responsible for writing those `.env.<section>` files ahead of test execution.
  - `${relative-date:-P<duration>}` — ISO-8601 duration anchored at today midnight UTC, rendered as RFC 3339 (`YYYY-MM-DDTHH:MM:SSZ`).
- Validates the provider env-var contract (`AIRBYTE_TEST_CREDS_PROVIDER=1pass`, `AIRBYTE_TEST_CREDS_1PASS_VAULT_NAME`) **only when** a `${secret-ref:...}` sigil is actually present. Pure literal or `${relative-date:...}`-only scenarios (source-faker style) resolve with no provider env vars.

`DockerConnectorTestSuite.get_scenarios()` now returns CAT-derived scenarios + smoke-test scenarios. Smoke-test scenarios are additive — connectors that have not opted in see no behavior change.

Companion to:
- `airbytehq/airbyte-connector-models#42` — schema for the metadata.yaml smoke-test dialect (literal section names, 3-segment sigils only)
- `airbytehq/airbyte-ops-mcp#733` — current `secrets fetch` flow; a follow-up will teach it to write per-section `.env.<section>` files when a connector has a smoke-test block

## Review & Testing Checklist for Human

- [ ] Confirm the sigil shape matches the locked design: 3-segment only, section is the literal 1P section name (e.g. `test-credentials-api_key`), no `.env.default` fallback.
- [ ] Confirm the env-var contract feels right: `AIRBYTE_TEST_CREDS_PROVIDER` + `AIRBYTE_TEST_CREDS_1PASS_VAULT_NAME` required only when secret-ref sigils are present. The vault env var is read by the OPS CLI; CDK only checks it is set, since CDK reads pre-fetched `.env.<section>` files rather than calling `op` itself.
- [ ] Spot-check `_load_env_file` parsing — supports `KEY=value` and `KEY="value"` / `KEY='value'`, ignores comments and blank lines. Multi-line values inside quotes are NOT supported here (the OPS CLI multi-line writer in #733 produces them, but at parse time the test runner only consumes single-line values; flag if this is wrong).
- [ ] Try a local end-to-end run once a connector adopts the dialect: write `secrets/.env.test-credentials-api_key`, set the two env vars, and confirm `pytest` parametrizes a `smoke-default` scenario.

### Notes

- 14 unit tests cover: missing metadata, no smoke-test suite, literal-only resolves without env vars, relative-date math, secret-ref resolution, literal section name preservation, missing provider env vars, missing vault name, missing `.env.<section>` file, missing var inside file, unknown sigil, 2-segment sigil rejected, multi-scenario, recursive nested resolution.
- Held intentionally out of scope: OPS CLI changes to write per-section `.env.<section>` files, monorepo CI workflow updates to add the env vars, and the source-ashby `metadata.yaml` block. Each will follow as its own PR after this one is reviewed.
- Drafted as draft per project convention; not for merge without explicit approval.


Link to Devin session: https://app.devin.ai/sessions/5c2ccf537b70486b9e6fbc974d26063e
Requested by: @aaronsteers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Test scenarios can now be loaded from connector metadata files alongside traditional configuration files.
  * Added support for dynamic secret and relative date resolution in test configurations using specialized notation.

* **Tests**
  * Comprehensive test coverage added for scenario discovery, secret injection, and date handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->