### PR TITLE
fix(manifest-server): bind to `::` for dual-stack support

### DIFF
--- a/airbyte_cdk/manifest_server/Dockerfile
+++ b/airbyte_cdk/manifest_server/Dockerfile
@@ -42,4 +42,5 @@ USER airbyte:airbyte
 
 EXPOSE 8080
 
-CMD ["uvicorn", "airbyte_cdk.manifest_server.app:app", "--host", "0.0.0.0", "--port", "8080"]
+# `::` binds dual-stack (IPv4 + IPv6); `0.0.0.0` is IPv4-only.
+CMD ["uvicorn", "airbyte_cdk.manifest_server.app:app", "--host", "::", "--port", "8080"]


### PR DESCRIPTION
## What

Change `manifest-server`'s Uvicorn bind from `--host 0.0.0.0` to `--host ::` in `airbyte_cdk/manifest_server/Dockerfile`.

## Why

The Dockerfile's CMD hardcoded `--host 0.0.0.0`, which only binds the IPv4 wildcard address. On dual-stack Kubernetes clusters that allocate IPv6 pod IPs (or pure-IPv6 clusters), the kubelet probes the pod's IPv6 IP for liveness/readiness — Uvicorn doesn't accept those connections, the pod fails health checks, and ends up in `CrashLoopBackOff`.

Switching to `--host ::` binds the IPv6 wildcard. On Linux, an IPv6 listener on `::` accepts both IPv6 connections and IPv4-mapped connections by default (unless `IPV6_V6ONLY=1`), so this is a **strict superset** of the prior behavior — single-stack IPv4 clusters keep working and dual-stack / IPv6-preferred clusters start working.

## Repro

EKS cluster with `ipFamilies: [IPv6, IPv4]` (IPv6 first):

1. Pod is allocated only an IPv6 IP (e.g. `2600:1f18:2090:c503:1190::15`).
2. Pod logs show `Uvicorn running on http://0.0.0.0:8080`.
3. Kubelet liveness probe to `http://[<pod-ipv6>]:8080/health` returns `connection refused`.
4. After 30s `initialDelaySeconds` + 30s of failed probes, kubelet sends SIGTERM → graceful shutdown → restart loop.

After this change, the same cluster sees `Uvicorn running on http://[::]:8080` and the liveness probe succeeds.

## Notes

- Tested with `airbyte/manifest-server:7.10.0` from the chart V2 / Airbyte v2.1.0 release.
- No env-var-driven fallback added — the bind address is invariant in the typical Kubernetes deployment, and the existing CLI-driven entry point in `airbyte_cdk/manifest_server/cli/_start.py` already supports `--host` overrides for the local-dev path.
- Other Airbyte components (Java/Micronaut) bind dual-stack by default, so this brings manifest-server in line with the rest of the platform.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Kubernetes compatibility by enabling IPv6 support in the manifest server, preventing connection refusals during health probe checks that caused pod restarts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->