### PR TITLE
fix(concurrent-cdk): enforce runtime cap on concurrent partition generators to prevent deadlock

### DIFF
--- a/airbyte_cdk/sources/concurrent_source/concurrent_read_processor.py
+++ b/airbyte_cdk/sources/concurrent_source/concurrent_read_processor.py
@@ -45,6 +45,7 @@ class ConcurrentReadProcessor:
         slice_logger: SliceLogger,
         message_repository: MessageRepository,
         partition_reader: PartitionReader,
+        max_concurrent_partition_generators: Optional[int] = None,
     ):
         """
         This class is responsible for handling items from a concurrent stream read process.
@@ -55,6 +56,10 @@ class ConcurrentReadProcessor:
         :param slice_logger: SliceLogger instance
         :param message_repository: MessageRepository instance
         :param partition_reader: PartitionReader instance
+        :param max_concurrent_partition_generators: Maximum number of partition generators allowed
+            to run concurrently. None means no limit. When set, must be less than the number of
+            workers so at least one worker slot is always available for partition reading,
+            preventing thread pool starvation. ConcurrentSource passes this explicitly.
         """
         self._stream_name_to_instance = {s.name: s for s in stream_instances_to_read_from}
         self._record_counter = {}
@@ -64,6 +69,7 @@ class ConcurrentReadProcessor:
             self._record_counter[stream.name] = 0
         self._thread_pool_manager = thread_pool_manager
         self._partition_enqueuer = partition_enqueuer
+        self._max_concurrent_partition_generators = max_concurrent_partition_generators
         self._stream_instances_to_start_partition_generation = stream_instances_to_read_from
         self._streams_currently_generating_partitions: List[str] = []
         self._logger = logger
@@ -253,6 +259,16 @@ class ConcurrentReadProcessor:
         :return: A status message if a partition generator was started, otherwise None
         """
         if not self._stream_instances_to_start_partition_generation:
+            return None
+
+        # Enforce the concurrent generator cap so at least one worker slot is always available
+        # for partition reading. Recovery is guaranteed: on_partition_generation_completed
+        # decrements the count before calling here, so the guard always passes there.
+        if (
+            self._max_concurrent_partition_generators is not None
+            and len(self._streams_currently_generating_partitions)
+            >= self._max_concurrent_partition_generators
+        ):
             return None
 
         # Remember initial queue size to avoid infinite loops if all streams are blocked

--- a/airbyte_cdk/sources/concurrent_source/concurrent_read_processor.py
+++ b/airbyte_cdk/sources/concurrent_source/concurrent_read_processor.py
@@ -67,7 +67,10 @@ class ConcurrentReadProcessor:
         for stream in stream_instances_to_read_from:
             self._streams_to_running_partitions[stream.name] = set()
             self._record_counter[stream.name] = 0
-        if max_concurrent_partition_generators is not None and max_concurrent_partition_generators < 1:
+        if (
+            max_concurrent_partition_generators is not None
+            and max_concurrent_partition_generators < 1
+        ):
             raise ValueError(
                 f"max_concurrent_partition_generators must be >= 1 or None, got {max_concurrent_partition_generators}"
             )

--- a/airbyte_cdk/sources/concurrent_source/concurrent_read_processor.py
+++ b/airbyte_cdk/sources/concurrent_source/concurrent_read_processor.py
@@ -67,6 +67,10 @@ class ConcurrentReadProcessor:
         for stream in stream_instances_to_read_from:
             self._streams_to_running_partitions[stream.name] = set()
             self._record_counter[stream.name] = 0
+        if max_concurrent_partition_generators is not None and max_concurrent_partition_generators < 1:
+            raise ValueError(
+                f"max_concurrent_partition_generators must be >= 1 or None, got {max_concurrent_partition_generators}"
+            )
         self._thread_pool_manager = thread_pool_manager
         self._partition_enqueuer = partition_enqueuer
         self._max_concurrent_partition_generators = max_concurrent_partition_generators
@@ -269,6 +273,10 @@ class ConcurrentReadProcessor:
             and len(self._streams_currently_generating_partitions)
             >= self._max_concurrent_partition_generators
         ):
+            self._logger.debug(
+                f"Concurrent partition generator cap ({self._max_concurrent_partition_generators}) reached "
+                f"({len(self._streams_currently_generating_partitions)} active). Deferring next generator start."
+            )
             return None
 
         # Remember initial queue size to avoid infinite loops if all streams are blocked

--- a/airbyte_cdk/sources/concurrent_source/concurrent_read_processor.py
+++ b/airbyte_cdk/sources/concurrent_source/concurrent_read_processor.py
@@ -57,9 +57,11 @@ class ConcurrentReadProcessor:
         :param message_repository: MessageRepository instance
         :param partition_reader: PartitionReader instance
         :param max_concurrent_partition_generators: Maximum number of partition generators allowed
-            to run concurrently. None means no limit. When set, must be less than the number of
-            workers so at least one worker slot is always available for partition reading,
-            preventing thread pool starvation. ConcurrentSource passes this explicitly.
+            to run concurrently. None means no limit. When set, should be less than the number of
+            workers in multi-worker mode so at least one worker slot is always available for
+            partition reading, preventing thread pool starvation. In single-threaded mode
+            (num_workers=1) the value may equal num_workers; ConcurrentSource.create() handles
+            this distinction. ConcurrentSource.read() passes this value explicitly.
         """
         self._stream_name_to_instance = {s.name: s for s in stream_instances_to_read_from}
         self._record_counter = {}

--- a/airbyte_cdk/sources/concurrent_source/concurrent_source.py
+++ b/airbyte_cdk/sources/concurrent_source/concurrent_source.py
@@ -117,6 +117,7 @@ class ConcurrentSource:
                 self._queue,
                 PartitionLogger(self._slice_logger, self._logger, self._message_repository),
             ),
+            max_concurrent_partition_generators=self._initial_number_partitions_to_generate,
         )
 
         # Enqueue initial partition generation tasks

--- a/airbyte_cdk/sources/concurrent_source/concurrent_source.py
+++ b/airbyte_cdk/sources/concurrent_source/concurrent_source.py
@@ -47,6 +47,10 @@ class ConcurrentSource:
         queue: Optional[Queue[QueueItem]] = None,
         timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
     ) -> "ConcurrentSource":
+        if initial_number_of_partitions_to_generate < 1:
+            raise ValueError(
+                f"initial_number_of_partitions_to_generate must be >= 1, got {initial_number_of_partitions_to_generate}"
+            )
         is_single_threaded = initial_number_of_partitions_to_generate == 1 and num_workers == 1
         too_many_generator = (
             not is_single_threaded and initial_number_of_partitions_to_generate >= num_workers

--- a/unit_tests/sources/streams/concurrent/test_concurrent_read_processor.py
+++ b/unit_tests/sources/streams/concurrent/test_concurrent_read_processor.py
@@ -851,6 +851,20 @@ class TestConcurrentReadProcessor(unittest.TestCase):
             self._partition_enqueuer.generate_partitions, self._stream
         )
 
+    def test_invalid_max_concurrent_partition_generators_raises(self):
+        for invalid in (0, -1):
+            with self.assertRaises(ValueError):
+                ConcurrentReadProcessor(
+                    [self._stream],
+                    self._partition_enqueuer,
+                    self._thread_pool_manager,
+                    self._logger,
+                    self._slice_logger,
+                    self._message_repository,
+                    self._partition_reader,
+                    max_concurrent_partition_generators=invalid,
+                )
+
     def test_start_next_partition_generator_respects_concurrent_limit(self):
         stream_instances_to_read_from = [self._stream]
         handler = ConcurrentReadProcessor(

--- a/unit_tests/sources/streams/concurrent/test_concurrent_read_processor.py
+++ b/unit_tests/sources/streams/concurrent/test_concurrent_read_processor.py
@@ -868,7 +868,9 @@ class TestConcurrentReadProcessor(unittest.TestCase):
         status_message = handler.start_next_partition_generator()
 
         assert status_message is None
-        assert handler._stream_instances_to_start_partition_generation == stream_instances_to_read_from
+        assert (
+            handler._stream_instances_to_start_partition_generation == stream_instances_to_read_from
+        )
         self._thread_pool_manager.submit.assert_not_called()
 
     def test_start_next_partition_generator_starts_when_below_limit(self):

--- a/unit_tests/sources/streams/concurrent/test_concurrent_read_processor.py
+++ b/unit_tests/sources/streams/concurrent/test_concurrent_read_processor.py
@@ -851,6 +851,55 @@ class TestConcurrentReadProcessor(unittest.TestCase):
             self._partition_enqueuer.generate_partitions, self._stream
         )
 
+    def test_start_next_partition_generator_respects_concurrent_limit(self):
+        stream_instances_to_read_from = [self._stream]
+        handler = ConcurrentReadProcessor(
+            stream_instances_to_read_from,
+            self._partition_enqueuer,
+            self._thread_pool_manager,
+            self._logger,
+            self._slice_logger,
+            self._message_repository,
+            self._partition_reader,
+            max_concurrent_partition_generators=1,
+        )
+        handler._streams_currently_generating_partitions.append(_STREAM_NAME)
+
+        status_message = handler.start_next_partition_generator()
+
+        assert status_message is None
+        assert handler._stream_instances_to_start_partition_generation == stream_instances_to_read_from
+        self._thread_pool_manager.submit.assert_not_called()
+
+    def test_start_next_partition_generator_starts_when_below_limit(self):
+        other_stream = Mock(spec=AbstractStream)
+        other_stream.name = "other_stream"
+        other_stream.block_simultaneous_read = ""
+        other_stream.as_airbyte_stream.return_value = AirbyteStream(
+            name="other_stream",
+            json_schema={},
+            supported_sync_modes=[SyncMode.full_refresh],
+        )
+        handler = ConcurrentReadProcessor(
+            [other_stream],
+            self._partition_enqueuer,
+            self._thread_pool_manager,
+            self._logger,
+            self._slice_logger,
+            self._message_repository,
+            self._partition_reader,
+            max_concurrent_partition_generators=2,
+        )
+        handler._streams_currently_generating_partitions.append(_STREAM_NAME)
+
+        status_message = handler.start_next_partition_generator()
+
+        assert status_message is not None
+        assert "other_stream" in handler._streams_currently_generating_partitions
+        self._thread_pool_manager.submit.assert_called_with(
+            self._partition_enqueuer.generate_partitions, other_stream
+        )
+
 
 class TestBlockSimultaneousRead(unittest.TestCase):
     """Tests for block_simultaneous_read functionality"""


### PR DESCRIPTION
## Summary

- Adds `max_concurrent_partition_generators: Optional[int]` to `ConcurrentReadProcessor.__init__`. Default `None` = no cap (preserves all existing behaviour).
- In `start_next_partition_generator`, returns `None` immediately when the cap is reached, preventing generator tasks from consuming all worker slots and starving partition readers.
- `ConcurrentSource.read()` now passes `max_concurrent_partition_generators=self._initial_number_partitions_to_generate`, tying the runtime enforcement to the same value as the construction-time assertion in `ConcurrentSource.create()`.
- Two new unit tests: one verifying the cap blocks a new generator when the limit is reached, one verifying a generator does start when below the limit.

## Root cause

`ConcurrentSource.create()` asserts `initial_number_of_partitions_to_generate < num_workers` at construction time, but there was no runtime enforcement. PR #870 (feat: Add `block_simultaneous_read`) introduced a second call site: `on_partition_complete_sentinel` also calls `start_next_partition_generator`. When multiple stream completions land in the queue back-to-back, both `on_partition_generation_completed` and `on_partition_complete_sentinel` fire in sequence and each independently starts a new generator — accumulating more concurrent generators than workers can safely accommodate.

When all worker slots are occupied by sleeping `generate_partitions` tasks (see `partition_enqueuer.py:59`), no partition readers can run, leaving the main thread blocked on `queue.get()` indefinitely.

**Observed in production:** source-google-ads 4.2.5, job 82903962 — final freeze at 2026-05-07 06:07:30 with `msgs=2063, queue_size=0`. All workers sleeping at `partition_enqueuer.py:59 → time.sleep()`, main thread at `concurrent_source.py → queue.get() → not_empty.wait()`.

## Recovery guarantee

`on_partition_generation_completed` always removes the stream from `_streams_currently_generating_partitions` **before** calling `start_next_partition_generator`, so the guard always passes there and the pipeline keeps moving forward. No stream is permanently stuck.

## Relation to PR #977

PR #977 (merged) fixed a different deadlock: the main thread blocking on `queue.put()` when the queue was full. This PR fixes a separate root cause (generator starvation via thread pool exhaustion) and touches different files. Keeping them separate makes the git history bisectable.

## Test plan

- [x] `unit_tests/sources/streams/concurrent/test_concurrent_read_processor.py` — 41 tests pass (including 2 new + all `TestBlockSimultaneousRead` tests)
- [x] Full concurrent suite (`unit_tests/sources/concurrent_source/` + `unit_tests/sources/streams/concurrent/`) — 244 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional cap on how many partition generators can run concurrently to better control resource usage during concurrent source operations.
  * The cap is enforced at runtime to prevent starting new generators once the limit is reached.

* **Tests**
  * Added unit tests covering behavior when the concurrent-generator limit is reached and validating that invalid cap values raise an error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->