### PR TITLE
fix: pass API budget to custom requesters

### DIFF
--- a/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -1801,8 +1801,6 @@ class ModelToComponentFactory:
         component_fields = get_type_hints(custom_component_class)
         model_args = model.dict()
         model_args["config"] = config
-        if "api_budget" in component_fields:
-            model_args["api_budget"] = self._api_budget
 
         # There are cases where a parent component will pass arguments to a child component via kwargs. When there are field collisions
         # we defer to these arguments over the component's definition
@@ -1861,6 +1859,10 @@ class ModelToComponentFactory:
             for class_field in component_fields.keys()
             if class_field in model_args
         }
+
+        if "api_budget" in component_fields and kwargs.get("api_budget") is None:
+            kwargs["api_budget"] = self._api_budget
+
         return custom_component_class(**kwargs)
 
     @staticmethod

--- a/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -1801,6 +1801,8 @@ class ModelToComponentFactory:
         component_fields = get_type_hints(custom_component_class)
         model_args = model.dict()
         model_args["config"] = config
+        if "api_budget" in component_fields:
+            model_args["api_budget"] = self._api_budget
 
         # There are cases where a parent component will pass arguments to a child component via kwargs. When there are field collisions
         # we defer to these arguments over the component's definition

--- a/unit_tests/sources/declarative/parsers/test_model_to_component_factory.py
+++ b/unit_tests/sources/declarative/parsers/test_model_to_component_factory.py
@@ -4285,6 +4285,47 @@ def test_api_budget_passed_to_custom_requester():
     assert len(custom_requester._http_client._api_budget._policies) == 1
 
 
+def test_api_budget_does_not_override_custom_requester_default_value():
+    manifest = {
+        "type": "DeclarativeSource",
+        "api_budget": {
+            "type": "HTTPAPIBudget",
+            "policies": [
+                {
+                    "type": "MovingWindowCallRatePolicy",
+                    "rates": [
+                        {
+                            "limit": 3,
+                            "interval": "PT0.1S",
+                        }
+                    ],
+                    "matchers": [],
+                }
+            ],
+        },
+        "my_requester": {
+            "type": "CustomRequester",
+            "class_name": "unit_tests.sources.declarative.parsers.testing_components.TestingRequesterWithDefaultBudget",
+            "path": "/v3/marketing/lists",
+            "url_base": "https://api.sendgrid.com",
+            "http_method": "GET",
+        },
+    }
+
+    factory = ModelToComponentFactory()
+    factory.set_api_budget(manifest["api_budget"], input_config)
+
+    custom_requester = factory.create_component(
+        model_type=CustomRequesterModel,
+        component_definition=manifest["my_requester"],
+        config=input_config,
+        name="lists_stream",
+        decoder=None,
+    )
+
+    assert custom_requester.api_budget is None
+
+
 def test_api_budget_fixed_window_policy():
     manifest = {
         "type": "DeclarativeSource",

--- a/unit_tests/sources/declarative/parsers/test_model_to_component_factory.py
+++ b/unit_tests/sources/declarative/parsers/test_model_to_component_factory.py
@@ -90,6 +90,9 @@ from airbyte_cdk.sources.declarative.models import (
     SubstreamPartitionRouter as SubstreamPartitionRouterModel,
 )
 from airbyte_cdk.sources.declarative.models.declarative_component_schema import (
+    CustomRequester as CustomRequesterModel,
+)
+from airbyte_cdk.sources.declarative.models.declarative_component_schema import (
     OffsetIncrement as OffsetIncrementModel,
 )
 from airbyte_cdk.sources.declarative.models.declarative_component_schema import (
@@ -173,7 +176,7 @@ from airbyte_cdk.sources.declarative.transformations.keys_replace_transformation
 )
 from airbyte_cdk.sources.declarative.yaml_declarative_source import YamlDeclarativeSource
 from airbyte_cdk.sources.message.repository import StateFilteringMessageRepository
-from airbyte_cdk.sources.streams.call_rate import MovingWindowCallRatePolicy
+from airbyte_cdk.sources.streams.call_rate import HttpAPIBudget, MovingWindowCallRatePolicy
 from airbyte_cdk.sources.streams.concurrent.clamping import (
     ClampingEndProvider,
     DayClampingStrategy,
@@ -4237,6 +4240,49 @@ def test_api_budget():
     # The 0.1s from 'PT0.1S' is stored in ms by PyRateLimiter internally
     # but here just check that the limit and interval exist
     assert policy._bucket.rates[0].interval == 100  # 100 ms
+
+
+def test_api_budget_passed_to_custom_requester():
+    manifest = {
+        "type": "DeclarativeSource",
+        "api_budget": {
+            "type": "HTTPAPIBudget",
+            "policies": [
+                {
+                    "type": "MovingWindowCallRatePolicy",
+                    "rates": [
+                        {
+                            "limit": 3,
+                            "interval": "PT0.1S",
+                        }
+                    ],
+                    "matchers": [],
+                }
+            ],
+        },
+        "my_requester": {
+            "type": "CustomRequester",
+            "class_name": "unit_tests.sources.declarative.parsers.testing_components.TestingRequester",
+            "path": "/v3/marketing/lists",
+            "url_base": "https://api.sendgrid.com",
+            "http_method": "GET",
+        },
+    }
+
+    factory = ModelToComponentFactory()
+    factory.set_api_budget(manifest["api_budget"], input_config)
+
+    custom_requester = factory.create_component(
+        model_type=CustomRequesterModel,
+        component_definition=manifest["my_requester"],
+        config=input_config,
+        name="lists_stream",
+        decoder=None,
+    )
+
+    assert isinstance(custom_requester.api_budget, HttpAPIBudget)
+    assert custom_requester._http_client._api_budget is custom_requester.api_budget
+    assert len(custom_requester._http_client._api_budget._policies) == 1
 
 
 def test_api_budget_fixed_window_policy():

--- a/unit_tests/sources/declarative/parsers/testing_components.py
+++ b/unit_tests/sources/declarative/parsers/testing_components.py
@@ -114,3 +114,10 @@ class TestingRequester(HttpRequester):
             parameters=parameters or {},
         )
         super().__post_init__(parameters)
+
+
+@dataclass
+class TestingRequesterWithDefaultBudget(TestingRequester):
+    def __post_init__(self, parameters: Mapping[str, Any]) -> None:
+        self.api_budget = None
+        super().__post_init__(parameters)


### PR DESCRIPTION
## Summary
- Pass the root declarative `api_budget` into custom components that accept an `api_budget` field, covering `CustomRequester` subclasses of `HttpRequester` instantiated through the generic custom component path.
- Preserve connector-owned custom requester behavior: if a custom requester sets or receives its own `api_budget`, that value still wins; this change does not sync or override `_http_client` after construction.
- Add regression coverage for both cases: a custom requester receives the manifest `HttpAPIBudget` when it does not override it, and a custom requester that sets its own default budget is not overwritten.
- This fixes the source-amazon-seller-partner report creation regression where `ReportCreationRequester` extends `HttpRequester` but was not receiving the manifest API budget from the CDK.

## Review & Testing Checklist for Human
- [x] Confirm the generic custom-component pass-through is appropriate for custom components that declare `api_budget`.
- [x] Confirm connector-specific custom requesters that intentionally override `self.api_budget` in `__post_init__()` should continue owning their own budget behavior.
- [ ] Verify source-amazon-seller-partner picks up this CDK change in the connector dependency flow before release.
- [x] Optional end-to-end check: run an Amazon Seller Partner report stream sync and confirm `POST /reports/2021-06-30/reports` and the preflight `GET /reports/2021-06-30/reports` are rate-limited by the manifest `api_budget`.

### Notes
Requested by Daryna Ishchenko.

Useful context from the related closed PR: some connectors already use custom requester API-budget overrides as a workaround or for connector-specific behavior. This PR only passes the CDK budget into the constructor path; it intentionally does not apply CDK-side `_http_client` sync logic.

Local checks run:
- `poetry run ruff check airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py unit_tests/sources/declarative/parsers/test_model_to_component_factory.py unit_tests/sources/declarative/parsers/testing_components.py`
- `poetry run pytest unit_tests/sources/declarative/parsers/test_model_to_component_factory.py::test_api_budget_passed_to_custom_requester unit_tests/sources/declarative/parsers/test_model_to_component_factory.py::test_api_budget_does_not_override_custom_requester_default_value -q`

Link to Devin session: https://app.devin.ai/sessions/2f69c7eea1164909b1e03b09862574a1
Requested by: @darynaishchenko

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed API budget propagation to custom component requesters. Custom requesters now properly inherit rate limiting configuration from the declarative source manifest, enabling consistent API rate limiting behavior across custom components.

* **Tests**
  * Added comprehensive unit tests for API budget propagation to custom requesters, verifying budget settings are properly shared with underlying HTTP clients and do not override existing default values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/airbytehq/airbyte-python-cdk/pull/1034?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->