### PR TITLE
ci: Upload coverage to GitHub Code Quality

### DIFF
--- a/.github/workflows/pytest_fast.yml
+++ b/.github/workflows/pytest_fast.yml
@@ -6,6 +6,11 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+  code-quality: write
+  pull-requests: read
+
 jobs:
   test-build:
     name: Build and Inspect Python Package
@@ -85,3 +90,11 @@ jobs:
         with:
           name: fasttest-coverage
           path: htmlcov/
+      - name: Upload coverage to GitHub Code Quality
+        if: always()
+        uses: actions/upload-code-coverage@v1
+        with:
+          file: htmlcov/coverage.xml
+          language: Python
+          label: code-coverage/pytest-fast
+          fail-on-error: false

--- a/.github/workflows/pytest_fast.yml
+++ b/.github/workflows/pytest_fast.yml
@@ -42,6 +42,7 @@ jobs:
     name: Pytest (Fast)
     runs-on: ubuntu-24.04
     permissions:
+      checks: write
       contents: read
       code-quality: write
       pull-requests: read

--- a/.github/workflows/pytest_fast.yml
+++ b/.github/workflows/pytest_fast.yml
@@ -8,7 +8,6 @@ on:
 
 permissions:
   contents: read
-  code-quality: write
   pull-requests: read
 
 jobs:

--- a/.github/workflows/pytest_fast.yml
+++ b/.github/workflows/pytest_fast.yml
@@ -50,6 +50,8 @@ jobs:
       # Common steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - name: Set up Poetry
         uses: snok/install-poetry@v1
         with:

--- a/.github/workflows/pytest_fast.yml
+++ b/.github/workflows/pytest_fast.yml
@@ -41,6 +41,10 @@ jobs:
   pytest-fast:
     name: Pytest (Fast)
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      code-quality: write
+      pull-requests: read
     steps:
       # Common steps:
       - name: Checkout code

--- a/.github/workflows/pytest_fast.yml
+++ b/.github/workflows/pytest_fast.yml
@@ -52,6 +52,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
+          persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - name: Set up Poetry
         uses: snok/install-poetry@v1

--- a/.github/workflows/pytest_fast.yml
+++ b/.github/workflows/pytest_fast.yml
@@ -76,7 +76,7 @@ jobs:
         if: always()
         run: |
           poetry run coverage html -d htmlcov
-          poetry run coverage xml -o htmlcov/coverage.xml
+          poetry run coverage xml --include="airbyte_cdk/*" -o htmlcov/coverage.xml
 
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2

--- a/.github/workflows/pytest_fast.yml
+++ b/.github/workflows/pytest_fast.yml
@@ -96,7 +96,7 @@ jobs:
           path: htmlcov/
       - name: Upload coverage to GitHub Code Quality
         if: always()
-        uses: actions/upload-code-coverage@v1
+        uses: actions/upload-code-coverage@b51da2c3c1b23e04d2d6477cfc34350b1f5cd3e9 # v1
         with:
           file: htmlcov/coverage.xml
           language: Python

--- a/.github/workflows/pytest_fast.yml
+++ b/.github/workflows/pytest_fast.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -97,7 +98,7 @@ jobs:
           name: fasttest-coverage
           path: htmlcov/
       - name: Upload coverage to GitHub Code Quality
-        if: always()
+        if: always() && hashFiles('htmlcov/coverage.xml') != ''
         uses: actions/upload-code-coverage@b51da2c3c1b23e04d2d6477cfc34350b1f5cd3e9 # v1
         with:
           file: htmlcov/coverage.xml

--- a/.github/workflows/pytest_matrix.yml
+++ b/.github/workflows/pytest_matrix.yml
@@ -102,7 +102,7 @@ jobs:
         if: always() && steps.changes.outputs.src == 'true'
         run: |
           poetry run coverage html -d htmlcov
-          poetry run coverage xml -o htmlcov/coverage.xml
+          poetry run coverage xml --include="airbyte_cdk/*" -o htmlcov/coverage.xml
 
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2

--- a/.github/workflows/pytest_matrix.yml
+++ b/.github/workflows/pytest_matrix.yml
@@ -61,6 +61,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
+          persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - id: changes
         uses: dorny/paths-filter@v3.0.2

--- a/.github/workflows/pytest_matrix.yml
+++ b/.github/workflows/pytest_matrix.yml
@@ -122,7 +122,7 @@ jobs:
           path: htmlcov/
       - name: Upload coverage to GitHub Code Quality
         if: always() && steps.changes.outputs.src == 'true' && matrix.python-version == '3.11' && matrix.os == 'Ubuntu'
-        uses: actions/upload-code-coverage@v1
+        uses: actions/upload-code-coverage@b51da2c3c1b23e04d2d6477cfc34350b1f5cd3e9 # v1
         with:
           file: htmlcov/coverage.xml
           language: Python

--- a/.github/workflows/pytest_matrix.yml
+++ b/.github/workflows/pytest_matrix.yml
@@ -45,6 +45,10 @@ jobs:
       fail-fast: false
 
     runs-on: "${{ matrix.os }}-latest"
+    permissions:
+      contents: read
+      code-quality: write
+      pull-requests: read
     env:
       # Enforce UTF-8 encoding so Windows runners don't fail inside the connector code.
       # TODO: See if we can fully enforce this within PyAirbyte itself.

--- a/.github/workflows/pytest_matrix.yml
+++ b/.github/workflows/pytest_matrix.yml
@@ -21,7 +21,6 @@ on:
 
 permissions:
   contents: read
-  code-quality: write
   pull-requests: read
 
 jobs:

--- a/.github/workflows/pytest_matrix.yml
+++ b/.github/workflows/pytest_matrix.yml
@@ -121,7 +121,7 @@ jobs:
           name: py${{ matrix.python-version }}-${{ matrix.os }}-test-coverage
           path: htmlcov/
       - name: Upload coverage to GitHub Code Quality
-        if: steps.changes.outputs.src == 'true' && matrix.python-version == '3.11' && matrix.os == 'Ubuntu'
+        if: always() && steps.changes.outputs.src == 'true' && matrix.python-version == '3.11' && matrix.os == 'Ubuntu'
         uses: actions/upload-code-coverage@v1
         with:
           file: htmlcov/coverage.xml

--- a/.github/workflows/pytest_matrix.yml
+++ b/.github/workflows/pytest_matrix.yml
@@ -58,6 +58,8 @@ jobs:
       # Common steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - id: changes
         uses: dorny/paths-filter@v3.0.2
         with:

--- a/.github/workflows/pytest_matrix.yml
+++ b/.github/workflows/pytest_matrix.yml
@@ -18,6 +18,7 @@ on:
       - "pyproject.toml"
       - ".github/workflows/pytest_matrix.yml"
   pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -29,6 +30,7 @@ jobs:
     # Don't run on forks. Run on pushes to main, and on PRs that are not from forks.
     if: >
       github.event_name == 'pull_request' ||
+      github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'push' && github.ref == 'refs/heads/main')
     strategy:
       matrix:
@@ -73,23 +75,23 @@ jobs:
               - '.github/workflows/pytest_matrix.yml'
       - name: Set up Poetry
         uses: snok/install-poetry@v1
-        if: steps.changes.outputs.src == 'true'
+        if: steps.changes.outputs.src == 'true' || github.event_name == 'workflow_dispatch'
         with:
           version: "2.0.1"
       - name: Set up Python
         uses: actions/setup-python@v5
-        if: steps.changes.outputs.src == 'true'
+        if: steps.changes.outputs.src == 'true' || github.event_name == 'workflow_dispatch'
         with:
           python-version: ${{ matrix.python-version }}
           cache: "poetry"
       - name: Install dependencies
-        if: steps.changes.outputs.src == 'true'
+        if: steps.changes.outputs.src == 'true' || github.event_name == 'workflow_dispatch'
         run: poetry install --all-extras
 
       # Job-specific step(s):
       - name: Run Pytest
         timeout-minutes: 60
-        if: steps.changes.outputs.src == 'true'
+        if: steps.changes.outputs.src == 'true' || github.event_name == 'workflow_dispatch'
         env:
           GCP_GSM_CREDENTIALS: ${{ secrets.GCP_GSM_CREDENTIALS }}
         run: >
@@ -98,18 +100,18 @@ jobs:
           -m "not linting and not super_slow and not flaky"
 
       - name: Print Coverage Report
-        if: always() && steps.changes.outputs.src == 'true'
+        if: always() && (steps.changes.outputs.src == 'true' || github.event_name == 'workflow_dispatch')
         run: poetry run coverage report
 
       - name: Create Coverage Artifacts
-        if: always() && steps.changes.outputs.src == 'true'
+        if: always() && (steps.changes.outputs.src == 'true' || github.event_name == 'workflow_dispatch')
         run: |
           poetry run coverage html -d htmlcov
           poetry run coverage xml --include="airbyte_cdk/*" -o htmlcov/coverage.xml
 
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
-        if: always() && !cancelled() && steps.changes.outputs.src == 'true' && matrix.python-version == '3.11'
+        if: always() && !cancelled() && (steps.changes.outputs.src == 'true' || github.event_name == 'workflow_dispatch') && matrix.python-version == '3.11'
         continue-on-error: true
         with:
           check_name: "PyTest Results (Full)"
@@ -117,13 +119,13 @@ jobs:
           files: |
             build/test-results/**/*.xml
       - name: Upload coverage to GitHub Artifacts
-        if: always() && steps.changes.outputs.src == 'true'
+        if: always() && (steps.changes.outputs.src == 'true' || github.event_name == 'workflow_dispatch')
         uses: actions/upload-artifact@v4
         with:
           name: py${{ matrix.python-version }}-${{ matrix.os }}-test-coverage
           path: htmlcov/
       - name: Upload coverage to GitHub Code Quality
-        if: always() && steps.changes.outputs.src == 'true' && matrix.python-version == '3.11' && matrix.os == 'Ubuntu'
+        if: always() && hashFiles('htmlcov/coverage.xml') != '' && matrix.python-version == '3.11' && matrix.os == 'Ubuntu'
         uses: actions/upload-code-coverage@b51da2c3c1b23e04d2d6477cfc34350b1f5cd3e9 # v1
         with:
           file: htmlcov/coverage.xml

--- a/.github/workflows/pytest_matrix.yml
+++ b/.github/workflows/pytest_matrix.yml
@@ -46,6 +46,7 @@ jobs:
 
     runs-on: "${{ matrix.os }}-latest"
     permissions:
+      checks: write
       contents: read
       code-quality: write
       pull-requests: read

--- a/.github/workflows/pytest_matrix.yml
+++ b/.github/workflows/pytest_matrix.yml
@@ -16,7 +16,13 @@ on:
       - "unit_tests/**"
       - "poetry.lock"
       - "pyproject.toml"
+      - ".github/workflows/pytest_matrix.yml"
   pull_request:
+
+permissions:
+  contents: read
+  code-quality: write
+  pull-requests: read
 
 jobs:
   pytest:
@@ -58,6 +64,7 @@ jobs:
               - 'bin/**'
               - 'poetry.lock'
               - 'pyproject.toml'
+              - '.github/workflows/pytest_matrix.yml'
       - name: Set up Poetry
         uses: snok/install-poetry@v1
         if: steps.changes.outputs.src == 'true'
@@ -109,3 +116,11 @@ jobs:
         with:
           name: py${{ matrix.python-version }}-${{ matrix.os }}-test-coverage
           path: htmlcov/
+      - name: Upload coverage to GitHub Code Quality
+        if: steps.changes.outputs.src == 'true' && matrix.python-version == '3.11' && matrix.os == 'Ubuntu'
+        uses: actions/upload-code-coverage@v1
+        with:
+          file: htmlcov/coverage.xml
+          language: Python
+          label: code-coverage/pytest-matrix
+          fail-on-error: false


### PR DESCRIPTION
## Summary
- Add `actions/upload-code-coverage@v1` uploads for the Python CDK's existing Cobertura XML reports from Pytest Fast and the representative full pytest matrix job.
- Scope `code-quality: write` to only the pytest jobs that upload coverage while preserving `checks: write` for jobs that publish test result check runs.
- Limit uploaded coverage XML to `airbyte_cdk/*` package files so GitHub Code Quality does not report stdlib or test-helper paths.
- Checkout the PR head SHA before generating coverage so GitHub Code Quality maps uploaded reports to the reviewed commit.
- Disable checkout credential persistence in coverage-producing jobs.
- Add `workflow_dispatch` to both coverage-producing pytest workflows so maintainers can manually refresh coverage from `main` or a PR branch.
- Guard Code Quality uploads on `htmlcov/coverage.xml` existing so failed/skipped coverage generation does not produce noisy upload errors.
- Keep existing GitHub artifact uploads intact and make Code Quality uploads best-effort with `fail-on-error: false`.
- Include the pytest matrix workflow itself in its path filter so edits to the coverage upload configuration run that workflow.

## Review & Testing Checklist for Human
- [ ] Confirm GitHub Code Quality is enabled for this repository so uploaded coverage appears on PRs.
- [ ] Confirm the two coverage labels, `code-coverage/pytest-fast` and `code-coverage/pytest-matrix`, are useful and not too noisy in the PR coverage UI.
- [ ] After merge, confirm both pytest workflows expose a manual "Run workflow" option and that manual runs from `main` upload coverage.
- [ ] Confirm Code Quality compares PR coverage against `main` after a `main` coverage upload is available.
- [ ] Confirm the `Publish Test Results` check-run summaries still appear after the explicit permissions change.

### Notes
- Requested by AJ Steers in Slack.
- Lessons incorporated from PyAirbyte and airbyte-ops-mcp validation: checkout head SHA, preserve `checks: write`, gate uploads on coverage XML, add manual dispatch, ensure manual dispatch bypasses path-filter skips, and disable checkout credential persistence.
- Local validation: `yq e '.' .github/workflows/pytest_fast.yml`, `yq e '.' .github/workflows/pytest_matrix.yml`, `yq e '.on.workflow_dispatch'` for both workflows, and `git diff --check`.

---
[Devin session](https://app.devin.ai/sessions/8d50d98662104dc58f3bf41ea229b503)

Requested by: @aaronsteers