### PR TITLE
docs: add AGENTS.md with ai-skills reference

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+# Agents
+
+## Please Read
+
+- [README.md](./README.md) — project overview.
+- [CONTRIBUTING.md](./CONTRIBUTING.md) — contributor setup, local testing, and development workflows.
+
+## Reusable AI Skills
+
+The [`airbytehq/ai-skills`](https://github.com/airbytehq/ai-skills) repository contains additional reusable skills for Airbyte connector and platform workflows. Skills are located in `.agents/skills/` and follow the [Agent Skills specification](https://agentskills.io/specification).
+
+Relevant skills for this repo include connector type identification, breaking change evaluation, version bumping, documentation review, and more. See the [ai-skills README](https://github.com/airbytehq/ai-skills#readme) for discovery and installation instructions.


### PR DESCRIPTION
## Summary

Adds a root `AGENTS.md` file that points AI agents (Devin, Claude Code, Codex, etc.) to the repo's README/CONTRIBUTING docs and to the shared [`airbytehq/ai-skills`](https://github.com/airbytehq/ai-skills) repository (`.agents/skills/`) for reusable connector and platform workflow skills.

## Review & Testing Checklist for Human

- [ ] Verify the ai-skills repo link and `.agents/skills/` path are correct

### Notes

Requested by @aaronsteers. Part of a cross-repo effort to ensure all key Airbyte repos reference `airbytehq/ai-skills` for reusable AI agent skills.

Link to Devin session: https://app.devin.ai/sessions/ac484c4c4dfe4b93a7ddf6c2668e2b8e