### PR TITLE
fix: resolve MyPy type check failures

### DIFF
--- a/airbyte_cdk/connector_builder/connector_builder_handler.py
+++ b/airbyte_cdk/connector_builder/connector_builder_handler.py
@@ -48,7 +48,7 @@ def should_migrate_manifest(config: Mapping[str, Any]) -> bool:
 
     This flag is set by the UI.
     """
-    return config.get("__should_migrate", False)
+    return bool(config.get("__should_migrate", False))
 
 
 def should_normalize_manifest(config: Mapping[str, Any]) -> bool:
@@ -57,7 +57,7 @@ def should_normalize_manifest(config: Mapping[str, Any]) -> bool:
     :param config: The configuration to check
     :return: True if the manifest should be normalized, False otherwise.
     """
-    return config.get("__should_normalize", False)
+    return bool(config.get("__should_normalize", False))
 
 
 def create_source(

--- a/airbyte_cdk/manifest_server/command_processor/utils.py
+++ b/airbyte_cdk/manifest_server/command_processor/utils.py
@@ -42,7 +42,7 @@ def should_migrate_manifest(manifest: Mapping[str, Any]) -> bool:
 
     This flag is set by the UI.
     """
-    return manifest.get(SHOULD_MIGRATE_KEY, False)
+    return bool(manifest.get(SHOULD_MIGRATE_KEY, False))
 
 
 def should_normalize_manifest(manifest: Mapping[str, Any]) -> bool:
@@ -52,7 +52,7 @@ def should_normalize_manifest(manifest: Mapping[str, Any]) -> bool:
 
     This flag is set by the UI.
     """
-    return manifest.get(SHOULD_NORMALIZE_KEY, False)
+    return bool(manifest.get(SHOULD_NORMALIZE_KEY, False))
 
 
 def build_source(

--- a/airbyte_cdk/sources/file_based/stream/default_file_based_stream.py
+++ b/airbyte_cdk/sources/file_based/stream/default_file_based_stream.py
@@ -93,7 +93,7 @@ class DefaultFileBasedStream(AbstractFileBasedStream, IncrementalMixin):
     def cursor(self) -> Optional[AbstractFileBasedCursor]:
         return self._cursor
 
-    @cursor.setter
+    @cursor.setter  # type: ignore[override]
     def cursor(self, value: AbstractFileBasedCursor) -> None:
         if self._cursor is not None:
             raise RuntimeError(

--- a/airbyte_cdk/sources/streams/checkpoint/checkpoint_reader.py
+++ b/airbyte_cdk/sources/streams/checkpoint/checkpoint_reader.py
@@ -245,11 +245,12 @@ class LegacyCursorBasedCheckpointReader(CursorBasedCheckpointReader):
 
     def next(self) -> Optional[Mapping[str, Any]]:
         try:
-            self.current_slice = self._find_next_slice()
+            current = self._find_next_slice()
+            self.current_slice = current
 
-            if "partition" in dict(self.current_slice):
+            if "partition" in dict(current):
                 raise ValueError("Stream is configured to use invalid stream slice key 'partition'")
-            elif "cursor_slice" in dict(self.current_slice):
+            elif "cursor_slice" in dict(current):
                 raise ValueError(
                     "Stream is configured to use invalid stream slice key 'cursor_slice'"
                 )
@@ -257,9 +258,9 @@ class LegacyCursorBasedCheckpointReader(CursorBasedCheckpointReader):
             # We convert StreamSlice to a regular mapping because legacy connectors operate on the basic Mapping object. We
             # also duplicate all fields at the top level for backwards compatibility for existing Python sources
             return {
-                "partition": self.current_slice.partition,
-                "cursor_slice": self.current_slice.cursor_slice,
-                **dict(self.current_slice),
+                "partition": current.partition,
+                "cursor_slice": current.cursor_slice,
+                **dict(current),
             }
         except StopIteration:
             self._finished_sync = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -25,3 +25,4 @@ plugins = ["pydantic.mypy", "pytest-mypy-plugins"]
 
 [mypy-airbyte_cdk.models]
 ignore_errors = True
+


### PR DESCRIPTION
## Summary\n\nFixes 10 MyPy type check errors that fail in CI but not locally (likely due to CI using Python 3.10 + Poetry 1.8.4 with different dependency resolution):\n\n- `checkpoint_reader.py`: `self.current_slice` typed as `StreamSlice | None` — use local `current` variable after `_find_next_slice()` to avoid repeated property access through `Optional` type\n- `utils.py` / `connector_builder_handler.py`: `Mapping.get()` returns `Any` — wrap with `bool()` to satisfy `-> bool` return type\n- `default_file_based_stream.py`: cursor setter override type mismatch — add `# type: ignore[override]` (matching existing ignore on the getter)\n\nRequested by: @aaronsteers

Link to Devin session: https://app.devin.ai/sessions/9f900ef4021147adb369727617d08827