### PR TITLE
fix: JsonItemsParser should yield floats, not Decimals

### DIFF
--- a/airbyte_cdk/sources/declarative/decoders/composite_raw_decoder.py
+++ b/airbyte_cdk/sources/declarative/decoders/composite_raw_decoder.py
@@ -149,7 +149,9 @@ class JsonItemsParser(Parser):
         # ijson auto-selects the best available backend (yajl2_c when present)
         # and reads from `data` lazily — it does not call `.read()` on the
         # whole stream up front.
-        yield from ijson.items(data, f"{self.items_path}.item")
+        # use_float=True yields floats for non-integer numbers instead of Decimal, matching
+        # json.loads/orjson behavior so downstream JSON serialization doesn't choke on Decimal.
+        yield from ijson.items(data, f"{self.items_path}.item", use_float=True)
 
 
 @dataclass

--- a/unit_tests/sources/declarative/decoders/test_composite_decoder.py
+++ b/unit_tests/sources/declarative/decoders/test_composite_decoder.py
@@ -451,6 +451,22 @@ def test_json_items_parser_composes_with_gzip(requests_mock) -> None:
     assert list(decoder.decode(response)) == payload["dataByAsin"]
 
 
+def test_json_items_parser_yields_floats_not_decimals(requests_mock) -> None:
+    """Non-integer numbers must be parsed as float (not Decimal) so downstream JSON
+    serialization (orjson) does not fail on Decimal values."""
+    import orjson
+
+    payload = {"data": [{"ratio": 0.5, "rank": 3, "amount": 0.0000}]}
+    requests_mock.register_uri("GET", "https://airbyte.io/", content=json.dumps(payload).encode("utf-8"))
+    response = requests.get("https://airbyte.io/", stream=True)
+
+    records = list(CompositeRawDecoder(parser=JsonItemsParser(items_path="data")).decode(response))
+    assert isinstance(records[0]["ratio"], float)
+    assert isinstance(records[0]["rank"], int)
+    # Must be serializable by orjson (which rejects Decimal).
+    orjson.dumps(records[0])
+
+
 def test_json_items_parser_requires_items_path() -> None:
     parser = JsonItemsParser()
     with pytest.raises(ValueError, match="items_path"):

--- a/unit_tests/sources/declarative/decoders/test_composite_decoder.py
+++ b/unit_tests/sources/declarative/decoders/test_composite_decoder.py
@@ -457,7 +457,9 @@ def test_json_items_parser_yields_floats_not_decimals(requests_mock) -> None:
     import orjson
 
     payload = {"data": [{"ratio": 0.5, "rank": 3, "amount": 0.0000}]}
-    requests_mock.register_uri("GET", "https://airbyte.io/", content=json.dumps(payload).encode("utf-8"))
+    requests_mock.register_uri(
+        "GET", "https://airbyte.io/", content=json.dumps(payload).encode("utf-8")
+    )
     response = requests.get("https://airbyte.io/", stream=True)
 
     records = list(CompositeRawDecoder(parser=JsonItemsParser(items_path="data")).decode(response))


### PR DESCRIPTION
## What

Follow-up to #1049. `JsonItemsParser` calls `ijson.items(...)` without `use_float=True`, so non-integer JSON numbers are parsed as `decimal.Decimal`. The CDK can't serialize `Decimal` downstream — `orjson` raises `TypeError: Type is not JSON serializable: decimal.Decimal` — so **any `JsonItemsDecoder` stream with decimal fields fails at serialization**.

Discovered while migrating `source-amazon-seller-partner`'s report streams: Brand Analytics (`clickShare`, `conversionShare`), Sales & Traffic, and Vendor reports all carry decimals and broke on read. The original `GzipJsonDecoder` used `json.loads` (floats), so this is a regression.

## How

Pass `use_float=True` to `ijson.items`, so non-integer numbers come back as `float` (integers stay `int`), matching the `json.loads`/`orjson` behavior of `JsonParser`/`JsonLineParser`. Adds a regression test asserting floats and `orjson`-serializability.

## Validation

Verified on a real 3.45 GB Amazon Search Terms report: `clickShare`/`conversionShare` now `float` (were `Decimal`), and `orjson.dumps` succeeds. 42 decoder unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected JSON numeric parsing so non-integer numbers are produced as standard floating-point values, resolving downstream serialization errors and improving compatibility with JSON serialization libraries.
* **Tests**
  * Added unit coverage to verify numeric types and serialization compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->