### PR TITLE
fix: prevent record filters from prematurely stopping CursorPagination via last_page_size

### DIFF
--- a/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -1791,9 +1791,9 @@ class ModelToComponentFactory:
                 self._UNSUPPORTED_DECODER_ERROR.format(decoder_type=type(inner_decoder))
             )
 
-        # Like OffsetIncrement, we instantiate a separate extractor with identical behavior to the
-        # RecordSelector's so the strategy can count the raw records in the response, keeping
-        # `last_page_size` in stop_condition/cursor_value interpolation pre-record-filter.
+        # Like OffsetIncrement and PageIncrement, we instantiate a separate extractor with identical
+        # behavior to the RecordSelector's so the strategy can count the raw records in the response,
+        # keeping `last_page_size` in stop_condition/cursor_value interpolation pre-record-filter.
         extractor = (
             self._create_component_from_model(
                 model=extractor_model, config=config, decoder=decoder_to_use

--- a/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -1771,7 +1771,12 @@ class ModelToComponentFactory:
             raise ValueError("jitter_range_in_seconds must be greater than or equal to 0")
 
     def create_cursor_pagination(
-        self, model: CursorPaginationModel, config: Config, decoder: Decoder, **kwargs: Any
+        self,
+        model: CursorPaginationModel,
+        config: Config,
+        decoder: Decoder,
+        extractor_model: Optional[Union[CustomRecordExtractorModel, DpathExtractorModel]] = None,
+        **kwargs: Any,
     ) -> CursorPaginationStrategy:
         if isinstance(decoder, PaginationDecoderDecorator):
             inner_decoder = decoder.decoder
@@ -1786,6 +1791,17 @@ class ModelToComponentFactory:
                 self._UNSUPPORTED_DECODER_ERROR.format(decoder_type=type(inner_decoder))
             )
 
+        # Like OffsetIncrement, we instantiate a separate extractor with identical behavior to the
+        # RecordSelector's so the strategy can count the raw records in the response, keeping
+        # `last_page_size` in stop_condition/cursor_value interpolation pre-record-filter.
+        extractor = (
+            self._create_component_from_model(
+                model=extractor_model, config=config, decoder=decoder_to_use
+            )
+            if extractor_model
+            else None
+        )
+
         # Pydantic v1 Union type coercion can convert int to string depending on Union order.
         # If page_size is a string that represents an integer (not an interpolation), convert it back.
         page_size = model.page_size
@@ -1795,6 +1811,7 @@ class ModelToComponentFactory:
         return CursorPaginationStrategy(
             cursor_value=model.cursor_value,
             decoder=decoder_to_use,
+            extractor=extractor,
             page_size=page_size,
             stop_condition=model.stop_condition,
             config=config,

--- a/airbyte_cdk/sources/declarative/requesters/paginators/strategies/cursor_pagination_strategy.py
+++ b/airbyte_cdk/sources/declarative/requesters/paginators/strategies/cursor_pagination_strategy.py
@@ -12,6 +12,7 @@ from airbyte_cdk.sources.declarative.decoders import (
     JsonDecoder,
     PaginationDecoderDecorator,
 )
+from airbyte_cdk.sources.declarative.extractors.record_extractor import RecordExtractor
 from airbyte_cdk.sources.declarative.interpolation.interpolated_boolean import InterpolatedBoolean
 from airbyte_cdk.sources.declarative.interpolation.interpolated_string import InterpolatedString
 from airbyte_cdk.sources.declarative.requesters.paginators.strategies.pagination_strategy import (
@@ -41,6 +42,7 @@ class CursorPaginationStrategy(PaginationStrategy):
     decoder: Decoder = field(
         default_factory=lambda: PaginationDecoderDecorator(decoder=JsonDecoder(parameters={}))
     )
+    extractor: Optional[RecordExtractor] = None
 
     def __post_init__(self, parameters: Mapping[str, Any]) -> None:
         if isinstance(self.cursor_value, str):
@@ -83,6 +85,13 @@ class CursorPaginationStrategy(PaginationStrategy):
         # is not indexable or useful for parsing the cursor, so we replace it with the link dictionary from response.links
         headers: Dict[str, Any] = dict(response.headers)
         headers["link"] = response.links
+
+        if self.extractor:
+            # The incoming last_page_size is the number of records emitted after the RecordSelector ran, so a
+            # record filter (e.g. client-side incremental) can make it smaller than the page the API returned.
+            # Stop conditions like `{{ last_page_size < page_size }}` would then stop pagination prematurely.
+            # Re-counting the raw records in the response keeps pagination driven by the API's page size.
+            last_page_size = len(list(self.extractor.extract_records(response=response)))
         if self._stop_condition:
             should_stop = self._stop_condition.eval(
                 self.config,

--- a/unit_tests/sources/declarative/parsers/test_model_to_component_factory.py
+++ b/unit_tests/sources/declarative/parsers/test_model_to_component_factory.py
@@ -63,6 +63,7 @@ from airbyte_cdk.sources.declarative.models import (
     CompositeErrorHandler as CompositeErrorHandlerModel,
 )
 from airbyte_cdk.sources.declarative.models import ConcurrencyLevel as ConcurrencyLevelModel
+from airbyte_cdk.sources.declarative.models import CursorPagination as CursorPaginationModel
 from airbyte_cdk.sources.declarative.models import CustomErrorHandler as CustomErrorHandlerModel
 from airbyte_cdk.sources.declarative.models import (
     CustomPartitionRouter as CustomPartitionRouterModel,
@@ -2318,7 +2319,7 @@ def test_create_default_paginator():
         component_definition=paginator_manifest,
         config=input_config,
         url_base="https://airbyte.io",
-        extractor_model=DpathExtractor(field_path=["results"], config=input_config, parameters={}),
+        extractor_model=DpathExtractorModel(type="DpathExtractor", field_path=["results"]),
         decoder=JsonDecoder(parameters={}),
     )
 
@@ -2328,6 +2329,8 @@ def test_create_default_paginator():
     assert isinstance(paginator.pagination_strategy, CursorPaginationStrategy)
     assert paginator.pagination_strategy.page_size == 50
     assert paginator.pagination_strategy._cursor_value.string == "{{ response._metadata.next }}"
+    assert isinstance(paginator.pagination_strategy.extractor, DpathExtractor)
+    assert paginator.pagination_strategy.extractor.field_path == ["results"]
 
     assert isinstance(paginator.page_size_option, RequestOption)
     assert paginator.page_size_option.inject_into == RequestOptionType.request_parameter
@@ -3179,6 +3182,30 @@ def test_create_offset_increment():
 
     assert strategy.page_size == expected_strategy.page_size
     assert strategy.inject_on_first_request == expected_strategy.inject_on_first_request
+    assert strategy.config == input_config
+
+    assert isinstance(strategy.extractor, DpathExtractor)
+    assert strategy.extractor.field_path == expected_extractor.field_path
+
+
+def test_create_cursor_pagination():
+    model = CursorPaginationModel(
+        type="CursorPagination",
+        cursor_value="{{ response.next_token }}",
+        stop_condition="{{ last_page_size < 2 }}",
+        page_size=2,
+    )
+
+    expected_extractor = DpathExtractor(field_path=["results"], config=input_config, parameters={})
+    extractor_model = DpathExtractorModel(
+        type="DpathExtractor", field_path=expected_extractor.field_path
+    )
+
+    strategy = factory.create_cursor_pagination(
+        model, input_config, extractor_model=extractor_model, decoder=JsonDecoder(parameters={})
+    )
+
+    assert strategy.get_page_size() == 2
     assert strategy.config == input_config
 
     assert isinstance(strategy.extractor, DpathExtractor)

--- a/unit_tests/sources/declarative/requesters/paginators/test_cursor_pagination_strategy.py
+++ b/unit_tests/sources/declarative/requesters/paginators/test_cursor_pagination_strategy.py
@@ -8,6 +8,7 @@ import pytest
 import requests
 
 from airbyte_cdk.sources.declarative.decoders.json_decoder import JsonDecoder
+from airbyte_cdk.sources.declarative.extractors import DpathExtractor
 from airbyte_cdk.sources.declarative.interpolation.interpolated_boolean import InterpolatedBoolean
 from airbyte_cdk.sources.declarative.requesters.paginators.strategies.cursor_pagination_strategy import (
     CursorPaginationStrategy,

--- a/unit_tests/sources/declarative/requesters/paginators/test_cursor_pagination_strategy.py
+++ b/unit_tests/sources/declarative/requesters/paginators/test_cursor_pagination_strategy.py
@@ -88,6 +88,77 @@ def test_cursor_pagination_strategy(template_string, stop_condition, expected_to
     assert page_size == strategy.get_page_size()
 
 
+@pytest.mark.parametrize(
+    "response_results, last_page_size, expected_next_page_token",
+    [
+        pytest.param(
+            [{"id": 1}, {"id": 2}],
+            0,
+            "next_token",
+            id="test_full_page_continues_even_if_all_records_filtered",
+        ),
+        pytest.param(
+            [{"id": 1}, {"id": 2}],
+            1,
+            "next_token",
+            id="test_full_page_continues_even_if_some_records_filtered",
+        ),
+        pytest.param(
+            [{"id": 1}],
+            1,
+            None,
+            id="test_partial_page_stops_pagination",
+        ),
+        pytest.param(
+            [],
+            0,
+            None,
+            id="test_empty_page_stops_pagination",
+        ),
+    ],
+)
+def test_cursor_pagination_strategy_with_extractor(
+    response_results, last_page_size, expected_next_page_token
+):
+    extractor = DpathExtractor(field_path=["results"], parameters={}, config={})
+    strategy = CursorPaginationStrategy(
+        page_size=2,
+        cursor_value="{{ response.next_token }}",
+        stop_condition="{{ last_page_size < 2 }}",
+        extractor=extractor,
+        config={},
+        parameters={},
+    )
+
+    response = requests.Response()
+    response._content = json.dumps(
+        {"results": response_results, "next_token": "next_token"}
+    ).encode("utf-8")
+    last_record = (
+        Record(data=response_results[-1], stream_name="stream_name") if response_results else None
+    )
+
+    next_page_token = strategy.next_page_token(response, last_page_size, last_record)
+    assert expected_next_page_token == next_page_token
+
+
+def test_cursor_pagination_strategy_with_extractor_interpolates_raw_count_in_cursor_value():
+    extractor = DpathExtractor(field_path=["results"], parameters={}, config={})
+    strategy = CursorPaginationStrategy(
+        page_size=2,
+        cursor_value="{{ last_page_size }}",
+        extractor=extractor,
+        config={},
+        parameters={},
+    )
+
+    response = requests.Response()
+    response._content = json.dumps({"results": [{"id": 1}, {"id": 2}]}).encode("utf-8")
+
+    next_page_token = strategy.next_page_token(response, 0, None)
+    assert next_page_token == 2
+
+
 def test_last_record_points_to_the_last_item_in_last_records_array():
     last_records = [{"id": 0, "more_records": True}, {"id": 1, "more_records": True}]
     strategy = CursorPaginationStrategy(


### PR DESCRIPTION
## Summary

Completes the record-filter pagination fix family started in #484 (`OffsetIncrement`) and #1073 (`PageIncrement`), this time for `CursorPaginationStrategy`.

`SimpleRetriever._read_pages` computes `last_page_size` from records *after* the `RecordSelector` runs (extract → filter), so a record filter (e.g. client-side incremental filtering) makes it smaller than the page the API actually returned. `CursorPaginationStrategy` exposes `last_page_size` in the interpolation context for both `stop_condition` and `cursor_value`, so a manifest with a stop condition like `{{ last_page_size < 100 }}` stops paginating prematurely when a full API page is partially or fully filtered out — silently dropping the remaining pages.

## Changes

- `CursorPaginationStrategy` gains an optional `extractor: Optional[RecordExtractor]` field; when set, `next_page_token` recomputes `last_page_size = len(extractor.extract_records(response))` (the raw, pre-filter count) before evaluating `stop_condition` and `cursor_value`.
- `ModelToComponentFactory.create_cursor_pagination` now accepts the `extractor_model` that `create_default_paginator` has been passing to every pagination strategy since #484 (previously silently swallowed by `**kwargs`) and builds the extractor from it — same pattern as `create_offset_increment` and `create_page_increment`.
- `last_record` is intentionally left post-filter: raw extracted records don't have RecordSelector transformations applied, so overriding it could break `cursor_value` expressions referencing transformed fields.

Behavior is unchanged for direct `CursorPaginationStrategy` instantiations without an extractor.

## Tests

- Strategy-level: full page with all/some records filtered continues paginating; genuine partial/empty pages still stop; raw count also visible to `cursor_value` interpolation.
- Factory-level: `create_cursor_pagination` wires the extractor from `extractor_model` — the wiring gap that let #484 miss this strategy (and `PageIncrement`) in the first place.
- Fixed `test_create_default_paginator`, which passed a runtime `DpathExtractor` component instead of a `DpathExtractorModel` as `extractor_model`; the mistake was invisible while `create_cursor_pagination` discarded the kwarg, and now the test also asserts the extractor lands on the strategy.

Note: `unit_tests/sources/declarative/test_concurrent_declarative_source.py` has a pre-existing flaky failure (`sqlite3.OperationalError: database table is locked: responses` from requests-cache) that reproduces on clean `main` and is unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cursor-based pagination to evaluate page size using records extracted directly from API responses.
  * Fixed pagination behavior when downstream filtering reduces the number of records returned from a page.
  * Ensured cursor and stop-condition calculations remain accurate for full, partial, and empty pages.

* **Tests**
  * Added coverage for extracted record counts and cursor pagination scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->