### PR TITLE
ci: bump semantic-pr-release-drafter to v2.2.0

### DIFF
--- a/.github/workflows/release_drafter.yml
+++ b/.github/workflows/release_drafter.yml
@@ -16,6 +16,6 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: aaronsteers/semantic-pr-release-drafter@v0.3.0
+      - uses: aaronsteers/semantic-pr-release-drafter@v2.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Bumps `aaronsteers/semantic-pr-release-drafter` from `@v0.3.0` to `@v2.2.0` in `.github/workflows/release_drafter.yml`.

This is a single-step consumer (no `not-ready` → finalize handoff) that uses the action with default config, so there's no `prepared-release-id` migration and no input changes — the bump just picks up v2.x, including the new point-in-time `resolved-sha` output and `target_commitish` SHA pin. The only 2.0 breaking change (default footer link moving into the `footer` template) doesn't apply here since this workflow uses the default templates.

Requested by @aaronsteers, following up on aaronsteers/semantic-pr-release-drafter#57 (released in v2.2.0).

Link to Devin session: https://app.devin.ai/sessions/c5aa9e420587440b9e2e5f4e92f65383