### PR TITLE
fix(declarative): require `AIRBYTE_ENABLE_UNSAFE_CODE` to instantiate `Custom*` components from YAML

### DIFF
--- a/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -477,6 +477,10 @@ from airbyte_cdk.sources.declarative.models.declarative_component_schema import 
 from airbyte_cdk.sources.declarative.models.declarative_component_schema import (
     ZipfileDecoder as ZipfileDecoderModel,
 )
+from airbyte_cdk.sources.declarative.parsers.custom_code_compiler import (
+    AirbyteCustomCodeNotPermittedError,
+    custom_code_execution_permitted,
+)
 from airbyte_cdk.sources.declarative.partition_routers import (
     CartesianProductStreamSlicer,
     GroupingPartitionRouter,
@@ -1809,6 +1813,14 @@ class ModelToComponentFactory:
         :param config: The custom defined connector config
         :return: The declarative component built from the Pydantic model to be used at runtime
         """
+        # Instantiating a custom component means importing and executing arbitrary code referenced
+        # by `class_name`. This is only permitted when custom code execution is explicitly enabled,
+        # mirroring the gate applied to injected `components.py` code. Without this check, a manifest
+        # could point `class_name` at any importable callable and have it invoked, bypassing the
+        # `AIRBYTE_ENABLE_UNSAFE_CODE` protection.
+        if not custom_code_execution_permitted():
+            raise AirbyteCustomCodeNotPermittedError
+
         custom_component_class = self._get_class_from_fully_qualified_class_name(model.class_name)
         component_fields = get_type_hints(custom_component_class)
         model_args = model.dict()

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -7,24 +7,6 @@ import datetime
 import freezegun
 import pytest
 
-from airbyte_cdk.sources.declarative.parsers.custom_code_compiler import (
-    ENV_VAR_ALLOW_CUSTOM_CODE,
-)
-
-
-@pytest.fixture(autouse=True)
-def _allow_custom_code(monkeypatch):
-    """Enable custom-component code execution for unit tests by default.
-
-    `ModelToComponentFactory.create_custom_component` requires
-    `AIRBYTE_ENABLE_UNSAFE_CODE` to be set before it will resolve and instantiate a
-    component's `class_name`, matching the gate already applied to injected
-    `components.py` code. The unit tests exercise custom components extensively, so
-    enable the flag by default here. Tests that verify the gate itself opt out by
-    deleting the env var through their own `monkeypatch` fixture.
-    """
-    monkeypatch.setenv(ENV_VAR_ALLOW_CUSTOM_CODE, "true")
-
 
 @pytest.fixture()
 def mock_sleep(monkeypatch):

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -7,6 +7,24 @@ import datetime
 import freezegun
 import pytest
 
+from airbyte_cdk.sources.declarative.parsers.custom_code_compiler import (
+    ENV_VAR_ALLOW_CUSTOM_CODE,
+)
+
+
+@pytest.fixture(autouse=True)
+def _allow_custom_code(monkeypatch):
+    """Enable custom-component code execution for unit tests by default.
+
+    `ModelToComponentFactory.create_custom_component` requires
+    `AIRBYTE_ENABLE_UNSAFE_CODE` to be set before it will resolve and instantiate a
+    component's `class_name`, matching the gate already applied to injected
+    `components.py` code. The unit tests exercise custom components extensively, so
+    enable the flag by default here. Tests that verify the gate itself opt out by
+    deleting the env var through their own `monkeypatch` fixture.
+    """
+    monkeypatch.setenv(ENV_VAR_ALLOW_CUSTOM_CODE, "true")
+
 
 @pytest.fixture()
 def mock_sleep(monkeypatch):

--- a/unit_tests/legacy/sources/declarative/conftest.py
+++ b/unit_tests/legacy/sources/declarative/conftest.py
@@ -1,0 +1,33 @@
+#
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+#
+
+import os
+
+import pytest
+
+from airbyte_cdk.sources.declarative.parsers.custom_code_compiler import (
+    ENV_VAR_ALLOW_CUSTOM_CODE,
+)
+
+
+@pytest.fixture(autouse=True)
+def _allow_custom_code():
+    """Enable custom-component code execution for the declarative unit tests.
+
+    `ModelToComponentFactory.create_custom_component` requires
+    `AIRBYTE_ENABLE_UNSAFE_CODE` to be set before it will resolve and instantiate a
+    component's `class_name`, matching the gate already applied to injected
+    `components.py` code. These tests exercise custom components extensively, so enable
+    the flag by default here. Tests that verify the gate itself opt out by deleting the
+    env var (e.g. through their own `monkeypatch` fixture).
+    """
+    previous = os.environ.get(ENV_VAR_ALLOW_CUSTOM_CODE)
+    os.environ[ENV_VAR_ALLOW_CUSTOM_CODE] = "true"
+    try:
+        yield
+    finally:
+        if previous is None:
+            os.environ.pop(ENV_VAR_ALLOW_CUSTOM_CODE, None)
+        else:
+            os.environ[ENV_VAR_ALLOW_CUSTOM_CODE] = previous

--- a/unit_tests/sources/declarative/conftest.py
+++ b/unit_tests/sources/declarative/conftest.py
@@ -1,0 +1,33 @@
+#
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+#
+
+import os
+
+import pytest
+
+from airbyte_cdk.sources.declarative.parsers.custom_code_compiler import (
+    ENV_VAR_ALLOW_CUSTOM_CODE,
+)
+
+
+@pytest.fixture(autouse=True)
+def _allow_custom_code():
+    """Enable custom-component code execution for the declarative unit tests.
+
+    `ModelToComponentFactory.create_custom_component` requires
+    `AIRBYTE_ENABLE_UNSAFE_CODE` to be set before it will resolve and instantiate a
+    component's `class_name`, matching the gate already applied to injected
+    `components.py` code. These tests exercise custom components extensively, so enable
+    the flag by default here. Tests that verify the gate itself opt out by deleting the
+    env var (e.g. through their own `monkeypatch` fixture).
+    """
+    previous = os.environ.get(ENV_VAR_ALLOW_CUSTOM_CODE)
+    os.environ[ENV_VAR_ALLOW_CUSTOM_CODE] = "true"
+    try:
+        yield
+    finally:
+        if previous is None:
+            os.environ.pop(ENV_VAR_ALLOW_CUSTOM_CODE, None)
+        else:
+            os.environ[ENV_VAR_ALLOW_CUSTOM_CODE] = previous

--- a/unit_tests/sources/declarative/parsers/test_model_to_component_factory.py
+++ b/unit_tests/sources/declarative/parsers/test_model_to_component_factory.py
@@ -107,6 +107,10 @@ from airbyte_cdk.sources.declarative.models.declarative_component_schema import 
 from airbyte_cdk.sources.declarative.models.declarative_component_schema import (
     SelectiveAuthenticator,
 )
+from airbyte_cdk.sources.declarative.parsers.custom_code_compiler import (
+    ENV_VAR_ALLOW_CUSTOM_CODE,
+    AirbyteCustomCodeNotPermittedError,
+)
 from airbyte_cdk.sources.declarative.parsers.manifest_component_transformer import (
     ManifestComponentTransformer,
 )
@@ -2507,6 +2511,40 @@ def test_create_custom_components(manifest, field_name, expected_value, expected
 
         assert isinstance(getattr(custom_component, field_name), type(expected_value))
         assert getattr(custom_component, field_name) == expected_value
+
+
+@pytest.mark.parametrize(
+    "class_name",
+    [
+        pytest.param(
+            "unit_tests.sources.declarative.parsers.testing_components.TestingSomeComponent",
+            id="bundled_custom_component_class",
+        ),
+        pytest.param(
+            "os.getcwd",
+            id="arbitrary_importable_callable",
+        ),
+    ],
+)
+def test_create_custom_component_requires_custom_code_enabled(class_name, monkeypatch):
+    """A `Custom*` component must not be instantiated unless custom code execution is
+    explicitly enabled via `AIRBYTE_ENABLE_UNSAFE_CODE`.
+
+    Resolving and instantiating a component's `class_name` executes arbitrary
+    importable code, so it must honor the same gate as injected `components.py` code.
+    The gate must fire regardless of whether `class_name` points at a bundled custom
+    component or at an arbitrary importable callable, and it must fire before the
+    referenced module is imported.
+    """
+    monkeypatch.delenv(ENV_VAR_ALLOW_CUSTOM_CODE, raising=False)
+
+    manifest = {
+        "type": "CustomErrorHandler",
+        "class_name": class_name,
+    }
+
+    with pytest.raises(AirbyteCustomCodeNotPermittedError):
+        factory.create_component(CustomErrorHandlerModel, manifest, input_config)
 
 
 def test_custom_components_do_not_contain_extra_fields():

--- a/unit_tests/sources/declarative/parsers/test_model_to_component_factory.py
+++ b/unit_tests/sources/declarative/parsers/test_model_to_component_factory.py
@@ -2538,6 +2538,13 @@ def test_create_custom_component_requires_custom_code_enabled(class_name, monkey
     """
     monkeypatch.delenv(ENV_VAR_ALLOW_CUSTOM_CODE, raising=False)
 
+    def _fail_if_resolved(*args, **kwargs):
+        raise AssertionError(
+            "`class_name` must not be resolved or imported when custom code is disabled"
+        )
+
+    monkeypatch.setattr(factory, "_get_class_from_fully_qualified_class_name", _fail_if_resolved)
+
     manifest = {
         "type": "CustomErrorHandler",
         "class_name": class_name,


### PR DESCRIPTION
## Summary

Hardens the custom-component path so that instantiating a `Custom*` component honors the same `AIRBYTE_ENABLE_UNSAFE_CODE` gate that already protects injected `components.py` source.

Previously, only injected `components.py` source was gated (in `get_registered_components_module`). The `class_name` resolution path in `ModelToComponentFactory.create_custom_component` was **not** gated: it resolves an arbitrary fully-qualified `class_name` via `importlib.import_module` + `getattr` and then calls it with manifest-supplied kwargs, regardless of `AIRBYTE_ENABLE_UNSAFE_CODE`. This meant a manifest could cause arbitrary importable code to be executed even in environments where custom code execution is meant to be disabled.

Fix — add a guard at the top of `create_custom_component`, before the class is resolved/imported:

```python
def create_custom_component(self, model, config, **kwargs):
    if not custom_code_execution_permitted():
        raise AirbyteCustomCodeNotPermittedError
    custom_component_class = self._get_class_from_fully_qualified_class_name(model.class_name)
    ...
```

This centralizes enforcement for every `Custom*` model type (they all route through `create_custom_component`), and the check fires *before* any import happens.

## Tests

- New regression test `test_create_custom_component_requires_custom_code_enabled` asserts `AirbyteCustomCodeNotPermittedError` is raised when the env var is unset — both for a bundled custom-component class and for an arbitrary importable callable — verifying the gate fires before import.
- Unit tests exercise custom components extensively; added an autouse fixture in `unit_tests/conftest.py` that enables `AIRBYTE_ENABLE_UNSAFE_CODE` by default, reflecting the new precondition for building custom components. Gate-focused tests opt out via their own `monkeypatch`.

Ran `unit_tests/sources/declarative` custom-component tests, the injected-code gate tests, and the previously-affected source/manifest suites locally — all green. `ruff format`/`ruff check` clean.

Relates to advisory `GHSA-g35w-6r6v-h4r7`. Draft pending maintainer review of disclosure timing.


Link to Devin session: https://app.devin.ai/sessions/091d09a568eb48018f82dd6ed27d2445
Requested by: @aaronsteers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a safety check that blocks custom component code from running unless explicitly permitted.
  * Custom components now fail with a clear permission error when custom code execution is disabled.
  * Prevented blocked components from being resolved or imported before permission is verified.

* **Tests**
  * Added coverage for custom-code restrictions and safe environment cleanup during declarative component tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._