### PR TITLE
fix(declarative): ignore full-refresh sentinel in parent state seeding

### DIFF
--- a/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -633,6 +633,7 @@ from airbyte_cdk.sources.message import (
     NoopMessageRepository,
 )
 from airbyte_cdk.sources.message.repository import StateFilteringMessageRepository
+from airbyte_cdk.sources.streams import NO_CURSOR_STATE_KEY
 from airbyte_cdk.sources.streams.call_rate import (
     APIBudget,
     FixedWindowCallRatePolicy,
@@ -4131,6 +4132,14 @@ class ModelToComponentFactory:
         self, model: ParentStreamConfigModel, config: Config, *, stream_name: str, **kwargs: Any
     ) -> Any:
         child_state = self._connector_state_manager.get_stream_state(stream_name, None)
+        if NO_CURSOR_STATE_KEY in child_state:
+            # Full refresh streams checkpoint a `{NO_CURSOR_STATE_KEY: true}` sentinel. When such a
+            # stream is later converted to incremental with an incremental_dependency parent,
+            # `_instantiate_parent_stream_state_manager` would treat the sentinel's boolean as a legacy
+            # cursor value and re-key it under the parent's cursor field, crashing cursor initialization.
+            child_state = {
+                key: value for key, value in child_state.items() if key != NO_CURSOR_STATE_KEY
+            }
 
         parent_state: Optional[Mapping[str, Any]] = (
             child_state if model.incremental_dependency and child_state else None

--- a/unit_tests/sources/declarative/parsers/test_model_to_component_factory.py
+++ b/unit_tests/sources/declarative/parsers/test_model_to_component_factory.py
@@ -3968,6 +3968,108 @@ def test_create_concurrent_cursor_from_perpartition_cursor_runs_state_migrations
     )
 
 
+def test_create_concurrent_cursor_from_perpartition_cursor_ignores_full_refresh_sentinel_state():
+    """
+    A stream that synced as full refresh checkpoints `{"__ab_no_cursor_state_message": true}`. If a later
+    connector version converts that stream to incremental with an `incremental_dependency` parent, the
+    sentinel must not be re-keyed under the parent's cursor field as if it were a legacy cursor value —
+    doing so crashed cursor initialization with `ValueError: No format in [...] matching True`.
+    """
+    content = """
+    type: DeclarativeStream
+    primary_key: "id"
+    name: test
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        $schema: "http://json-schema.org/draft-07/schema"
+        type: object
+        properties:
+          id:
+            type: string
+    incremental_sync:
+      type: "DatetimeBasedCursor"
+      cursor_field: "updated_at"
+      datetime_format: "%Y-%m-%dT%H:%M:%S.%f%z"
+      start_datetime: "{{ config['start_time'] }}"
+    retriever:
+      type: SimpleRetriever
+      name: test
+      requester:
+        type: HttpRequester
+        name: "test"
+        url_base: "https://api.test.com/v3/"
+        http_method: "GET"
+        authenticator:
+          type: NoAuth
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: []
+      partition_router:
+        type: SubstreamPartitionRouter
+        parent_stream_configs:
+          - type: ParentStreamConfig
+            parent_key: id
+            partition_field: id
+            incremental_dependency: true
+            stream:
+              type: DeclarativeStream
+              primary_key: id
+              name: parent_stream
+              schema_loader:
+                type: InlineSchemaLoader
+                schema:
+                  $schema: "http://json-schema.org/draft-07/schema"
+                  type: object
+                  properties:
+                    id:
+                      type: string
+              incremental_sync:
+                type: "DatetimeBasedCursor"
+                cursor_field: "updated_at"
+                datetime_format: "%Y-%m-%dT%H:%M:%S.%f%z"
+                start_datetime: "{{ config['start_time'] }}"
+              retriever:
+                type: SimpleRetriever
+                requester:
+                  type: HttpRequester
+                  url_base: "https://api.test.com/v3/parent"
+                  http_method: "GET"
+                record_selector:
+                  type: RecordSelector
+                  extractor:
+                    type: DpathExtractor
+                    field_path: []
+      """
+
+    connector_state_manager = ConnectorStateManager(
+        state=[
+            AirbyteStateMessage(
+                type=AirbyteStateType.STREAM,
+                stream=AirbyteStreamState(
+                    stream_descriptor=StreamDescriptor(name="test"),
+                    stream_state=AirbyteStateBlob({"__ab_no_cursor_state_message": True}),
+                ),
+            )
+        ]
+    )
+    factory = ModelToComponentFactory(
+        emit_connector_builder_messages=True, connector_state_manager=connector_state_manager
+    )
+    stream = factory.create_component(
+        model_type=DeclarativeStreamModel,
+        component_definition=YamlDeclarativeSource._parse(content),
+        config=input_config,
+    )
+
+    parent_cursor_state = stream.cursor._partition_router.parent_stream_configs[
+        0
+    ].stream.cursor.state
+    assert all(value is not True for value in parent_cursor_state.values())
+
+
 def test_incrementing_count_cursor_with_partition_router_raises_error():
     content = """
     type: DeclarativeStream


### PR DESCRIPTION
## Summary

Converting a previously full-refresh stream to incremental with an `incremental_dependency` parent crashes cursor initialization whenever the connection has legacy state. Full refresh streams checkpoint `{"__ab_no_cursor_state_message": true}`; the single-value fallback in `_instantiate_parent_stream_state_manager` re-keys that boolean under the parent's cursor field (producing e.g. `{"created_at": true}`), and `DatetimeStreamStateConverter.parse_value` raises `ValueError: No format in [...] matching True` before any records are read. Every existing connection with such a stream selected fails on its next sync after upgrade — regardless of configured sync mode — until its state is reset.

This filters the `NO_CURSOR_STATE_KEY` sentinel out of the child state in `create_parent_stream_config_with_substream_wrapper` before it is used to seed parent stream state, so a converted stream starts its first incremental sync from empty state, matching how `abstract_source.py` already discards the sentinel.

Found while validating airbytehq/airbyte#72784 (source-zoom), which had to revert its full-refresh → incremental conversion of existing streams because of this crash.

Note: `SubstreamPartitionRouter._migrate_child_state_to_parent_state` has the same boolean-passthrough flaw but currently has no callers, so it is left untouched here.

## Test plan

- [x] New unit test `test_create_concurrent_cursor_from_perpartition_cursor_ignores_full_refresh_sentinel_state`: on current main it reproduces the crash (`ValueError: No format in ['%Y-%m-%dT%H:%M:%S.%f%z'] matching True`); with the fix it passes
- [x] `poetry run pytest unit_tests/sources/declarative/parsers/ unit_tests/sources/declarative/partition_routers/` — 237 passed
- [x] `ruff format --check` and `ruff check` clean on changed files
- [x] End-to-end repro: `airbyte/source-zoom:1.3.0-preview.6a84bb0` (which declares incremental + `incremental_dependency` on previously full-refresh meeting streams) exits 1 on `read` when given `{"__ab_no_cursor_state_message": true}` stream state; the same read succeeds with this change applied to the installed CDK


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where full-refresh state could be incorrectly carried into incremental substream cursor initialization.
  * Ensured nested streams preserve correct cursor state when transitioning between full-refresh and incremental behavior.

* **Tests**
  * Added coverage verifying that full-refresh sentinel values are not converted into invalid parent cursor state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->