### PR TITLE
fix(declarative): stop coercing static scalar strings in request_body_json

### DIFF
--- a/airbyte_cdk/sources/declarative/interpolation/interpolated_nested_mapping.py
+++ b/airbyte_cdk/sources/declarative/interpolation/interpolated_nested_mapping.py
@@ -39,10 +39,13 @@ class InterpolatedNestedMapping:
     ) -> Any:
         # Recursively interpolate dictionaries and lists
         if isinstance(value, str):
-            # Static values are returned verbatim so that interpolation does not coerce them to
-            # another type, e.g. "478" becoming the integer 478.
             if "{{" not in value and "{%" not in value:
-                return value
+                # Preserve structured static literals for request bodies, but avoid coercing scalar
+                # values such as "478" or "None" through literal evaluation.
+                evaluated = self._interpolation.eval(
+                    value, config, parameters=self._parameters, **kwargs
+                )
+                return evaluated if isinstance(evaluated, (dict, list)) else value
             return self._interpolation.eval(value, config, parameters=self._parameters, **kwargs)
         elif isinstance(value, dict):
             interpolated_dict = {

--- a/airbyte_cdk/sources/declarative/interpolation/interpolated_nested_mapping.py
+++ b/airbyte_cdk/sources/declarative/interpolation/interpolated_nested_mapping.py
@@ -39,6 +39,10 @@ class InterpolatedNestedMapping:
     ) -> Any:
         # Recursively interpolate dictionaries and lists
         if isinstance(value, str):
+            # Static values are returned verbatim so that interpolation does not coerce them to
+            # another type, e.g. "478" becoming the integer 478.
+            if "{{" not in value and "{%" not in value:
+                return value
             return self._interpolation.eval(value, config, parameters=self._parameters, **kwargs)
         elif isinstance(value, dict):
             interpolated_dict = {

--- a/unit_tests/sources/declarative/interpolation/test_interpolated_nested_mapping.py
+++ b/unit_tests/sources/declarative/interpolation/test_interpolated_nested_mapping.py
@@ -52,3 +52,58 @@ def test(test_name, path, expected_value):
     interpolated = mapping.eval(config, **{"kwargs": kwargs})
 
     assert dpath.get(interpolated, path) == expected_value
+
+
+@pytest.mark.parametrize(
+    "mapping, path, expected_value",
+    [
+        pytest.param(
+            {"clientId": "478"},
+            "clientId",
+            "478",
+            id="static_digit_only_string",
+        ),
+        pytest.param(
+            {"value": "0012"},
+            "value",
+            "0012",
+            id="static_leading_zero_string",
+        ),
+        pytest.param(
+            {"value": "None"},
+            "value",
+            "None",
+            id="static_none_string",
+        ),
+        pytest.param(
+            {"478": "value"},
+            "478",
+            "value",
+            id="static_digit_only_key",
+        ),
+        pytest.param(
+            {"nested": {"clientId": "478"}},
+            "nested/clientId",
+            "478",
+            id="static_string_nested_in_dict",
+        ),
+        pytest.param(
+            {"nested": {"values": ["478", "0012", "None"]}},
+            "nested/values",
+            ["478", "0012", "None"],
+            id="static_strings_nested_in_list",
+        ),
+        pytest.param(
+            {"value": "{{ 1 + 1 }}"},
+            "value",
+            2,
+            id="jinja_value_still_coerces",
+        ),
+    ],
+)
+def test_static_strings_are_preserved_and_jinja_values_are_interpolated(
+    mapping, path, expected_value
+):
+    interpolated = InterpolatedNestedMapping(mapping=mapping, parameters={}).eval({})
+
+    assert dpath.get(interpolated, path) == expected_value

--- a/unit_tests/sources/declarative/interpolation/test_interpolated_nested_mapping.py
+++ b/unit_tests/sources/declarative/interpolation/test_interpolated_nested_mapping.py
@@ -76,6 +76,24 @@ def test(test_name, path, expected_value):
             id="static_none_string",
         ),
         pytest.param(
+            {"value": '{"field": "updated_at", "order": "ascending"}'},
+            "value",
+            {"field": "updated_at", "order": "ascending"},
+            id="static_structured_dict",
+        ),
+        pytest.param(
+            {"value": "[1, 2, 3]"},
+            "value",
+            [1, 2, 3],
+            id="static_structured_list",
+        ),
+        pytest.param(
+            {"sort": '{"field": "updated_at", "order": "ascending"}'},
+            "sort",
+            {"field": "updated_at", "order": "ascending"},
+            id="static_intercom_sort_json",
+        ),
+        pytest.param(
             {"478": "value"},
             "478",
             "value",

--- a/unit_tests/sources/declarative/requesters/request_options/test_interpolated_request_options_provider.py
+++ b/unit_tests/sources/declarative/requesters/request_options/test_interpolated_request_options_provider.py
@@ -141,6 +141,15 @@ def test_interpolated_request_json(test_name, input_request_json, expected_reque
 @pytest.mark.parametrize(
     "test_name, input_request_json, expected_request_json",
     [
+        pytest.param(
+            "test_static_digit_only_string",
+            RequestBodyJsonObject(
+                type="RequestBodyJsonObject",
+                value={"clientId": "478"},
+            ),
+            {"clientId": "478"},
+            id="static_digit_only_string",
+        ),
         (
             "test_static_json",
             RequestBodyJsonObject(


### PR DESCRIPTION
## Summary

A Connector Builder user reported that `RequestBodyJsonObject` with `clientId: "478"` sends `{"clientId": 478}` — a number — and that no amount of YAML quoting or Jinja (`"{{ '478' }}"`) fixes it, breaking an API that requires a string.

Cause: every string in `request_body_json` is routed through `JinjaInterpolation.eval`, which runs `ast.literal_eval` on the rendered output. For a static YAML literal there is nothing to render, so the only effect of that round-trip is type coercion. The result looks arbitrary to users: in the reporter's own manifest, `storeId: ["478-1", "478-2", ...]` survives (not valid Python literals) while `clientId: "478"` becomes `478`, and `"None"` becomes `None` and is then dropped from the body entirely.

The naive fix — skip `literal_eval` for all static strings — is too broad, and CI caught why: `source-intercom` deliberately encodes structure as a string and depends on it being parsed.

```yaml
sort: "{\"field\": \"updated_at\", \"order\": \"ascending\"}"   # must stay a dict
```

So the rule is narrowed to **structured vs. scalar**: a static string keeps its literal-eval result only when that result is a `dict` or `list`; scalars are returned verbatim. Encoding a JSON object/array as a string is a deliberate, meaningful use of `literal_eval`; scalar coercion never is.

```python
# InterpolatedNestedMapping._eval
if "{{" not in value and "{%" not in value:
    evaluated = self._interpolation.eval(value, ...)
    return evaluated if isinstance(evaluated, (dict, list)) else value
```

| input | before | after |
| --- | --- | --- |
| `"478"` | `478` | `"478"` |
| `"0012"` | `"0012"` | `"0012"` |
| `"None"` | dropped from body | `"None"` |
| `'{"field": "updated_at"}'` | `{"field": ...}` | `{"field": ...}` |
| `"[1, 2, 3]"` | `[1, 2, 3]` | `[1, 2, 3]` |
| `"{{ next_page_token['offset'] }}"` | `int` | `int` |

The change is confined to `InterpolatedNestedMapping`, which is only wired into `InterpolatedNestedRequestInputProvider` (request body JSON). `jinja.py` and `InterpolatedString` are deliberately untouched — changing `_literal_eval` globally would affect request params, headers, paths, and every other interpolation caller.

**Rollout risk:** a static quoted scalar number in `request_body_json` now stays a string. A scan of every declarative manifest in `airbytehq/airbyte` found exactly one affected value: `source-looker` `manifest.yaml:26`, `request_body_json.limit: "10000"`, which becomes `"10000"`. No quoted `"True"`/`"False"`/`"None"` values exist anywhere.

## Test plan

- Parametrized cases in `test_interpolated_nested_mapping.py`: scalars preserved (as dict keys, nested in dicts, inside lists), structured JSON object/array strings still parsed, a regression case mirroring intercom's `sort`, and `"{{ 1 + 1 }}"` still evaluating to `2`.
- Case in `test_interpolated_request_options_provider.py` asserting `RequestBodyJsonObject(value={"clientId": "478"})` yields `{"clientId": "478"}`.
- `ruff`, `mypy`, `pytest unit_tests/sources/declarative`, and all 27 CI checks pass — including `source-intercom`, which fails on the un-narrowed version.

Reported by Syed Khadeer.


Link to Devin session: https://app.devin.ai/sessions/ba9cc31475fb453fba21067b02845c73
Requested by: @Airbyte-Support