### PR TITLE
chore: require dev-apis code owner review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @airbytehq/dev-apis


### PR DESCRIPTION
> 🤖 *This PR was generated by an AI Agent.*

## Summary

- designate `@airbytehq/dev-apis` as the code owner for the entire repository
- require a dev-apis team member approval through the existing `main` ruleset

## Testing

- not applicable; repository policy change only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository ownership settings to ensure changes are assigned to the appropriate maintainers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->