### PR TITLE
ci: notify Slack when a PR is opened

### DIFF
--- a/.github/workflows/slack-pr-notification.yml
+++ b/.github/workflows/slack-pr-notification.yml
@@ -1,7 +1,7 @@
 name: Slack PR Notification
 
-# Posts a message to #agent-patrick-nilan whenever a PR is opened (or a draft
-# is marked ready for review) and tags @patrick.nilan.
+# Posts a message to the configured Slack channel whenever a PR is opened, or
+# when a draft is marked ready for review, mentioning the configured Slack user.
 #
 # Uses `pull_request_target` rather than `pull_request` so that the Slack bot
 # token resolves for PRs from forks -- `pull_request` workflows triggered by a
@@ -26,15 +26,14 @@ on:
       # - synchronize
 
 env:
-  # Channel: #agent-patrick-nilan
-  # Link (internal): https://airbytehq-team.slack.com/archives/C0B89MR7YRK
+  # Destination channel for PR notifications.
   SLACK_CHANNEL_ID: C0B89MR7YRK
-  # User: @patrick.nilan
+  # Slack user mentioned in each notification.
   SLACK_USER_ID: U063M9WHWTU
 
 jobs:
   notify-slack:
-    name: Post New PR to #agent-patrick-nilan
+    name: Post New PR to Slack
     # Draft PRs stay quiet until their author flips them to ready for review.
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-24.04
@@ -133,7 +132,7 @@ jobs:
             ' | tee "$PAYLOAD_FILE"
           echo "file=$PAYLOAD_FILE" | tee -a "$GITHUB_OUTPUT"
 
-      - name: Post to Slack channel agent-patrick-nilan
+      - name: Post to Slack channel
         # Pinned to an immutable SHA rather than a tag: this workflow runs on
         # `pull_request_target` with a Slack bot token in scope, so a retagged
         # release must not be able to execute with that secret. Same pattern as

--- a/.github/workflows/slack-pr-notification.yml
+++ b/.github/workflows/slack-pr-notification.yml
@@ -1,0 +1,141 @@
+name: Slack PR Notification
+
+# Posts a message to #team-apis whenever a PR is opened (or a draft is marked
+# ready for review) and tags the @apis-team user group.
+#
+# Uses `pull_request_target` rather than `pull_request` so that the Slack bot
+# token resolves for PRs from forks -- `pull_request` workflows triggered by a
+# fork receive no secrets, which would silently drop community PRs, the ones
+# most in need of a nudge. This is safe here because the workflow never checks
+# out or executes PR code; it only reads the webhook payload. The job requests
+# no token permissions at all, and all contributor-controlled fields (title,
+# author) are passed through `env:` and JSON-escaped by `jq` before reaching
+# the Slack payload.
+#
+# MANUAL TESTING INSTRUCTIONS:
+# To manually test this workflow, temporarily uncomment the "synchronize" event
+# type below. The workflow will then run for all new commits. Remember to
+# comment it out again before merging.
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - ready_for_review
+      # Toggle this line, uncommenting for testing:
+      # - synchronize
+
+env:
+  # Channel: #team-apis
+  # Link (internal): https://airbytehq-team.slack.com/archives/C0BHDAPNPCY
+  SLACK_CHANNEL_ID: C0BHDAPNPCY
+  # User group: @apis-team
+  SLACK_GROUP_ID: S077U1TH43D
+
+jobs:
+  notify-slack:
+    name: Post New PR to #team-apis
+    # Draft PRs stay quiet until their author flips them to ready for review.
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-24.04
+    # No GitHub API calls are made -- everything comes from the webhook payload.
+    permissions: {}
+    steps:
+      # ---------- Resolve message headline ----------
+
+      - name: Resolve headline (opened)
+        if: github.event.action == 'opened'
+        id: headline-opened
+        run: echo "text=New pull request opened" | tee -a "$GITHUB_OUTPUT"
+
+      - name: Resolve headline (ready for review)
+        if: github.event.action == 'ready_for_review'
+        id: headline-ready
+        run: echo "text=Pull request ready for review" | tee -a "$GITHUB_OUTPUT"
+
+      # ---------- Build and send ----------
+
+      - name: Build Slack payload
+        id: payload
+        env:
+          HEADLINE: ${{ steps.headline-opened.outputs.text || steps.headline-ready.outputs.text }}
+          PAYLOAD_FILE: ${{ runner.temp }}/slack-payload.json
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_AUTHOR_URL: ${{ github.event.pull_request.user.html_url }}
+          PR_ADDITIONS: ${{ github.event.pull_request.additions }}
+          PR_DELETIONS: ${{ github.event.pull_request.deletions }}
+          PR_CHANGED_FILES: ${{ github.event.pull_request.changed_files }}
+          PR_IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
+        run: |
+          set -euo pipefail
+          jq -n \
+            --arg headline "$HEADLINE" \
+            --arg channel "$SLACK_CHANNEL_ID" \
+            --arg group_id "$SLACK_GROUP_ID" \
+            --arg repo "$GITHUB_REPOSITORY" \
+            --arg number "$PR_NUMBER" \
+            --arg title "$PR_TITLE" \
+            --arg url "$PR_URL" \
+            --arg author "$PR_AUTHOR" \
+            --arg author_url "$PR_AUTHOR_URL" \
+            --arg additions "$PR_ADDITIONS" \
+            --arg deletions "$PR_DELETIONS" \
+            --arg changed_files "$PR_CHANGED_FILES" \
+            --arg is_fork "$PR_IS_FORK" \
+            '
+            # Contributor-controlled text is escaped so that a crafted PR title
+            # cannot inject Slack markup such as <!channel> or a fake link.
+            def esc: gsub("&"; "&amp;") | gsub("<"; "&lt;") | gsub(">"; "&gt;");
+            {
+              channel: $channel,
+              text: "<!subteam^\($group_id)> \($headline): #\($number) \($title | esc)",
+              unfurl_links: false,
+              unfurl_media: false,
+              blocks: [
+                {
+                  type: "section",
+                  text: {
+                    type: "mrkdwn",
+                    text: "<!subteam^\($group_id)> *\($headline)* in `\($repo)`"
+                  }
+                },
+                {
+                  type: "section",
+                  text: {
+                    type: "mrkdwn",
+                    text: "*<\($url)|#\($number) — \($title | esc)>*\nby <\($author_url)|\($author | esc)>"
+                  }
+                },
+                {
+                  type: "context",
+                  elements: [
+                    {
+                      type: "mrkdwn",
+                      text: (
+                        (if $is_fork == "true" then ":globe_with_meridians: community fork" else ":lock: internal branch" end)
+                        + "  ·  `+\($additions)` `-\($deletions)` across \($changed_files) file(s)"
+                      )
+                    }
+                  ]
+                }
+              ]
+            }
+            ' | tee "$PAYLOAD_FILE"
+          echo "file=$PAYLOAD_FILE" | tee -a "$GITHUB_OUTPUT"
+
+      - name: Post to Slack channel team-apis
+        uses: slackapi/slack-github-action@v4.0.0
+        # Slack being down, or the bot being removed from the channel, must
+        # never turn a contributor's PR checks red. The step still surfaces as
+        # a warning in the Actions UI thanks to `errors: true`.
+        continue-on-error: true
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN_AIRBYTE_TEAM }}
+          # `payload-templated` defaults to false, so nothing in this file is
+          # re-expanded as a GitHub expression.
+          payload-file-path: ${{ steps.payload.outputs.file }}
+          errors: true

--- a/.github/workflows/slack-pr-notification.yml
+++ b/.github/workflows/slack-pr-notification.yml
@@ -53,12 +53,19 @@ jobs:
         id: headline-ready
         run: echo "text=Pull request ready for review" | tee -a "$GITHUB_OUTPUT"
 
+      # Keeps the documented `synchronize` testing toggle -- and any event type
+      # added later -- from posting a message with an empty headline.
+      - name: Resolve headline (other events)
+        if: github.event.action != 'opened' && github.event.action != 'ready_for_review'
+        id: headline-other
+        run: echo "text=Pull request updated" | tee -a "$GITHUB_OUTPUT"
+
       # ---------- Build and send ----------
 
       - name: Build Slack payload
         id: payload
         env:
-          HEADLINE: ${{ steps.headline-opened.outputs.text || steps.headline-ready.outputs.text }}
+          HEADLINE: ${{ steps.headline-opened.outputs.text || steps.headline-ready.outputs.text || steps.headline-other.outputs.text }}
           PAYLOAD_FILE: ${{ runner.temp }}/slack-payload.json
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_TITLE: ${{ github.event.pull_request.title }}
@@ -127,7 +134,11 @@ jobs:
           echo "file=$PAYLOAD_FILE" | tee -a "$GITHUB_OUTPUT"
 
       - name: Post to Slack channel agent-patrick-nilan
-        uses: slackapi/slack-github-action@v4.0.0
+        # Pinned to an immutable SHA rather than a tag: this workflow runs on
+        # `pull_request_target` with a Slack bot token in scope, so a retagged
+        # release must not be able to execute with that secret. Same pattern as
+        # `label-community-prs.yml`, the repo's other `pull_request_target` job.
+        uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
         # Slack being down, or the bot being removed from the channel, must
         # never turn a contributor's PR checks red. The step still surfaces as
         # a warning in the Actions UI thanks to `errors: true`.

--- a/.github/workflows/slack-pr-notification.yml
+++ b/.github/workflows/slack-pr-notification.yml
@@ -1,7 +1,7 @@
 name: Slack PR Notification
 
-# Posts a message to #team-apis whenever a PR is opened (or a draft is marked
-# ready for review) and tags the @apis-team user group.
+# Posts a message to #agent-patrick-nilan whenever a PR is opened (or a draft
+# is marked ready for review) and tags @patrick.nilan.
 #
 # Uses `pull_request_target` rather than `pull_request` so that the Slack bot
 # token resolves for PRs from forks -- `pull_request` workflows triggered by a
@@ -26,15 +26,15 @@ on:
       # - synchronize
 
 env:
-  # Channel: #team-apis
-  # Link (internal): https://airbytehq-team.slack.com/archives/C0BHDAPNPCY
-  SLACK_CHANNEL_ID: C0BHDAPNPCY
-  # User group: @apis-team
-  SLACK_GROUP_ID: S077U1TH43D
+  # Channel: #agent-patrick-nilan
+  # Link (internal): https://airbytehq-team.slack.com/archives/C0B89MR7YRK
+  SLACK_CHANNEL_ID: C0B89MR7YRK
+  # User: @patrick.nilan
+  SLACK_USER_ID: U063M9WHWTU
 
 jobs:
   notify-slack:
-    name: Post New PR to #team-apis
+    name: Post New PR to #agent-patrick-nilan
     # Draft PRs stay quiet until their author flips them to ready for review.
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-24.04
@@ -74,7 +74,7 @@ jobs:
           jq -n \
             --arg headline "$HEADLINE" \
             --arg channel "$SLACK_CHANNEL_ID" \
-            --arg group_id "$SLACK_GROUP_ID" \
+            --arg user_id "$SLACK_USER_ID" \
             --arg repo "$GITHUB_REPOSITORY" \
             --arg number "$PR_NUMBER" \
             --arg title "$PR_TITLE" \
@@ -91,7 +91,7 @@ jobs:
             def esc: gsub("&"; "&amp;") | gsub("<"; "&lt;") | gsub(">"; "&gt;");
             {
               channel: $channel,
-              text: "<!subteam^\($group_id)> \($headline): #\($number) \($title | esc)",
+              text: "<@\($user_id)> \($headline): #\($number) \($title | esc)",
               unfurl_links: false,
               unfurl_media: false,
               blocks: [
@@ -99,7 +99,7 @@ jobs:
                   type: "section",
                   text: {
                     type: "mrkdwn",
-                    text: "<!subteam^\($group_id)> *\($headline)* in `\($repo)`"
+                    text: "<@\($user_id)> *\($headline)* in `\($repo)`"
                   }
                 },
                 {
@@ -126,7 +126,7 @@ jobs:
             ' | tee "$PAYLOAD_FILE"
           echo "file=$PAYLOAD_FILE" | tee -a "$GITHUB_OUTPUT"
 
-      - name: Post to Slack channel team-apis
+      - name: Post to Slack channel agent-patrick-nilan
         uses: slackapi/slack-github-action@v4.0.0
         # Slack being down, or the bot being removed from the channel, must
         # never turn a contributor's PR checks red. The step still surfaces as


### PR DESCRIPTION
> 🤖 *This PR was generated by an AI Agent.*

## What

Adds `.github/workflows/slack-pr-notification.yml`, which posts a message to a configured Slack channel whenever a PR is opened, or when a draft PR is marked ready for review, mentioning a configured Slack user.

The destination channel and mentioned user are set as opaque IDs in the workflow's `env:` block, so retargeting is a two-line change.

Rendered message:

> **@pnilan** **New pull request opened** in `airbytehq/airbyte-python-cdk`
>
> **#1099 — fix(declarative): allow bundled custom components**
> by devin-ai-integration[bot]
>
> 🌐 community fork · `+120` `-34` across 5 file(s)

## ⚠️ Required before this does anything

The Slack bot must be a member of the destination channel — `chat.postMessage` returns `not_in_channel` otherwise, and the workflow logs a warning rather than failing, so this fails *silently*. The token is `SLACK_BOT_TOKEN_AIRBYTE_TEAM`, the same one already posting to #dev-connectors-extensibility-releases from `publish.yml`.

## Design notes

**Why `pull_request_target` and not `pull_request`.** GitHub does not pass secrets to workflows triggered from a fork, so under `pull_request` the Slack step would fail for exactly the community PRs most worth a notification. `pull_request_target` runs in base-repo context and resolves the token.

The usual `pull_request_target` hazard is checking out and executing untrusted code. This workflow does neither — it reads only the webhook payload and declares `permissions: {}`, so there is no token for a malicious PR to abuse. The Slack action is pinned to an immutable commit SHA so that a retagged release cannot execute with the bot token in scope, matching the pattern in `label-community-prs.yml`.

**Payload injection.** PR titles are contributor-controlled. Interpolating `${{ github.event.pull_request.title }}` directly into a JSON payload breaks on a quote character and lets a fork PR titled `<!channel>` ping the entire channel. Instead, every contributor-controlled field goes through `env:` → `jq --arg` (JSON escaping) → an explicit `esc` filter for Slack's `&`/`<`/`>`. `payload-templated` is left at its default of `false`, so nothing in the generated file is re-expanded as a GitHub expression.

Verified against a hostile title — `<!channel>` comes out as inert `&lt;!channel&gt;`, and `${{ secrets.X }}` stays literal.

**Drafts.** The job is gated on `draft == false`, and `ready_for_review` fires the message later, so a draft PR notifies once — when it is actually reviewable — rather than twice or too early.

**Headline resolution.** Three mutually exclusive steps set the headline, including a fallback for event types outside `opened`/`ready_for_review`. Without the fallback, uncommenting the documented `synchronize` testing toggle would post a message with an empty headline.

**Failure isolation.** The post step is `continue-on-error: true` with `errors: true`, so a Slack outage or a deauthorized bot surfaces as a warning in the Actions UI without turning a contributor's PR checks red.

## Scope

Included: `opened`, `ready_for_review`. Bot-authored PRs (Devin, Dependabot) are included and do get the mention, per an explicit decision — roughly 58% of recent PRs in this repo are `devin-ai-integration`, so if that volume becomes annoying, the fix is to move the mention behind a `jq` conditional on author type.

Not included: `reopened`, merge/close notifications, `review_requested`, and any threading of follow-up messages.

## Testing

- `actionlint` passes clean on the new file.
- The payload builder was extracted and dry-run against a PR title containing quotes, `&`, `<!channel>`, a spoofed Slack link, and a `${{ }}` expression; output was valid JSON with all markup neutralized.
- For a live test, uncomment the `synchronize` trigger (noted in the file header, mirroring the convention in `welcome-message.yml`) and push a commit.

Note that merging this PR will not itself produce a notification — `pull_request_target` runs the workflow as it exists on the base branch, so the first message fires on the next PR opened after merge.

**Please squash-merge.** Intermediate commit messages on this branch are not meant for `main`'s history.
