### PR TITLE
chore: test Slack PR notification workflow

### DIFF
--- a/.github/workflows/slack-pr-notification.yml
+++ b/.github/workflows/slack-pr-notification.yml
@@ -149,3 +149,6 @@ jobs:
           # re-expanded as a GitHub expression.
           payload-file-path: ${{ steps.payload.outputs.file }}
           errors: true
+
+# Temporary scaffolding for verifying this workflow end to end. Remove before
+# merging -- this PR exists only to trigger a notification, not to land.


### PR DESCRIPTION
> 🤖 *This PR was generated by an AI Agent.*

> [!WARNING]
> **Test PR — not intended to merge.** Opened solely to verify that the Slack PR notification workflow added in #1092 fires correctly. Close once the notification is confirmed.

## Purpose

`.github/workflows/slack-pr-notification.yml` runs on `pull_request_target`, which executes the base-branch version of the workflow. It could not be tested from its own PR, so this is the first PR opened after the merge and therefore the first real trigger.

## What to check

- A message arrives in the configured Slack channel with the correct user mention.
- The headline reads "New pull request opened".
- The PR link, author, and diff stats render correctly.
- The context line shows `:lock: internal branch` (this branch is not a fork).

## Diff

A comment appended to the workflow file. Functionally irrelevant — the workflow that runs is the one on `main`, not the one in this diff.
