### PR TITLE
ci: retarget PR notifications to the team channel and user group

### DIFF
--- a/.github/workflows/slack-pr-notification.yml
+++ b/.github/workflows/slack-pr-notification.yml
@@ -1,7 +1,7 @@
 name: Slack PR Notification
 
 # Posts a message to the configured Slack channel whenever a PR is opened, or
-# when a draft is marked ready for review, mentioning the configured Slack user.
+# when a draft is marked ready for review, mentioning the configured user group.
 #
 # Uses `pull_request_target` rather than `pull_request` so that the Slack bot
 # token resolves for PRs from forks -- `pull_request` workflows triggered by a
@@ -27,9 +27,9 @@ on:
 
 env:
   # Destination channel for PR notifications.
-  SLACK_CHANNEL_ID: C0B89MR7YRK
-  # Slack user mentioned in each notification.
-  SLACK_USER_ID: U063M9WHWTU
+  SLACK_CHANNEL_ID: C0BHDAPNPCY
+  # Slack user group mentioned in each notification.
+  SLACK_GROUP_ID: S077U1TH43D
 
 jobs:
   notify-slack:
@@ -80,7 +80,7 @@ jobs:
           jq -n \
             --arg headline "$HEADLINE" \
             --arg channel "$SLACK_CHANNEL_ID" \
-            --arg user_id "$SLACK_USER_ID" \
+            --arg group_id "$SLACK_GROUP_ID" \
             --arg repo "$GITHUB_REPOSITORY" \
             --arg number "$PR_NUMBER" \
             --arg title "$PR_TITLE" \
@@ -97,7 +97,7 @@ jobs:
             def esc: gsub("&"; "&amp;") | gsub("<"; "&lt;") | gsub(">"; "&gt;");
             {
               channel: $channel,
-              text: "<@\($user_id)> \($headline): #\($number) \($title | esc)",
+              text: "<!subteam^\($group_id)> \($headline): #\($number) \($title | esc)",
               unfurl_links: false,
               unfurl_media: false,
               blocks: [
@@ -105,7 +105,7 @@ jobs:
                   type: "section",
                   text: {
                     type: "mrkdwn",
-                    text: "<@\($user_id)> *\($headline)* in `\($repo)`"
+                    text: "<!subteam^\($group_id)> *\($headline)* in `\($repo)`"
                   }
                 },
                 {


### PR DESCRIPTION
> 🤖 *This PR was generated by an AI Agent.*

## What

Retargets the PR notification workflow added in #1092 from the personal channel used for end-to-end verification to the intended team destination, and switches the mention from a single user to a user group.

| | Before | After |
|---|---|---|
| Channel | `C0B89MR7YRK` | `C0BHDAPNPCY` |
| Mention | `SLACK_USER_ID` | `SLACK_GROUP_ID` |
| Slack markup | `<@ID>` | `<!subteam^ID>` |

Seven lines, all in the `env:` block and the two `jq` mention strings. No change to triggers, draft gating, escaping, or failure handling.

## Verification

**The user group ID is confirmed valid.** `S077U1TH43D` appears as `<!subteam^S077U1TH43D>` in existing message history for the destination channel, so the mention will resolve rather than render as literal text. This was the one assumption flagged as unverifiable when the workflow was first designed.

**The workflow itself is already proven.** #1092 was tested end to end against the personal channel: the message was delivered, the mention resolved, the headline resolved to "New pull request opened", and PR link, author, and diff stats all rendered correctly. Only the destination changes here.

**Dry run** of the payload builder with the new values produces the expected `<!subteam^S077U1TH43D>` markup in both the fallback text and the header block, with contributor-controlled text still escaped (`<!channel>` in a PR title comes out inert).

`actionlint` passes clean.

## ⚠️ One unverified prerequisite

The Slack bot (`Airbyte Tooling Bot`) must be a member of the destination channel. It was explicitly invited to the personal channel before the successful test; whether it is already in the team channel could not be determined — it has no activity in the last 86 messages there, which is suggestive but not conclusive, since a silent long-time member would look identical.

If it is not a member, `chat.postMessage` returns `not_in_channel`. That surfaces as a red step in the Actions UI (`errors: true`) but does not block PR checks (`continue-on-error: true`), so the failure mode is visible-but-non-blocking rather than silent. Worth a quick `/invite` before or right after merge.

## Note on ping volume

This restores a user group mention on every PR, which was an explicit decision. Roughly 58% of recent PRs in this repo are authored by `devin-ai-integration`, so the group will be notified for those too. If that proves noisy, the fix is to move the mention behind a `jq` conditional on author type rather than to drop the notification.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Slack pull request notifications to mention a configured user group instead of an individual.
  * Updated notification channel and mention references for both message formats.
  * Revised related documentation to describe the new group-based notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->