### PR TITLE
chore: test retargeted Slack PR notification

### DIFF
--- a/.github/workflows/slack-pr-notification.yml
+++ b/.github/workflows/slack-pr-notification.yml
@@ -149,3 +149,6 @@ jobs:
           # re-expanded as a GitHub expression.
           payload-file-path: ${{ steps.payload.outputs.file }}
           errors: true
+
+# Temporary scaffolding for verifying the retargeted notification end to end.
+# Remove before merging -- this PR exists only to trigger a notification.


### PR DESCRIPTION
> 🤖 *This PR was generated by an AI Agent.*

> [!WARNING]
> **Test PR — not intended to merge.** Opened solely to verify that the retargeted Slack notification from #1094 reaches the team channel and resolves the user group mention. Closing as soon as delivery is confirmed. Apologies for the ping.

## Purpose

`.github/workflows/slack-pr-notification.yml` runs on `pull_request_target`, which executes the base-branch version of the workflow. #1094 changed the destination channel and swapped the single-user mention for a user group mention, so this is the first PR opened after that merge and therefore the first live exercise of the new target.

## What to check

- The message arrives in the team channel rather than the previous personal one.
- `<!subteam^…>` renders as a real group mention, not literal text.
- Headline reads "New pull request opened".
- PR link, author, and diff stats render correctly.
- Context line shows `:lock: internal branch` (this branch is not a fork).

## Diff

A comment appended to the workflow file. Functionally irrelevant — the workflow that runs is the one on `main`, not the one in this diff.
