### PR TITLE
ci: add OSS issue triage workflow

### DIFF
--- a/.github/workflows/oss-issue-triage.yml
+++ b/.github/workflows/oss-issue-triage.yml
@@ -1,0 +1,105 @@
+name: OSS Issue Triage
+
+# This workflow automatically triggers AI triage for issues opened by community
+# members (users without write access to the repository). It provides a quick
+# initial response and escalates confirmed defects to the internal oncall team.
+#
+# CDK-specific behavior lives in the shared `oss_issue_triage` playbook:
+#   - Escalated issues are filed as P2, because a CDK defect can affect every
+#     source connector built on it.
+#   - Feature requests are NOT escalated. They stay in this repo.
+#   - A defect is only escalated when the report includes a reproducing snippet,
+#     a stack trace, or a CDK version where the behavior changed.
+#
+# Playbook source: airbytehq/ai-skills → devin/playbooks/oss_issue_triage.md
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  check-permissions:
+    name: Resolve Input Variables
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Authenticate as GitHub App
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        id: get-app-token
+        with:
+          owner: "airbytehq"
+          repositories: "airbyte-python-cdk"
+          app-id: ${{ secrets.OCTAVIA_BOT_APP_ID }}
+          private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}
+
+      - name: Check if user has write access
+        id: check-access
+        env:
+          GH_TOKEN: ${{ steps.get-app-token.outputs.token }}
+          AUTHOR: ${{ github.event.issue.user.login }}
+        run: |
+          set -euo pipefail
+
+          echo "Checking permissions for user: $AUTHOR"
+
+          PERMISSION=$(gh api repos/${{ github.repository }}/collaborators/$AUTHOR/permission \
+            --jq '.permission' 2>/dev/null || echo "none")
+
+          echo "User permission level: $PERMISSION"
+
+          # Users with write, maintain, or admin access are NOT community members
+          if [[ "$PERMISSION" == "admin" || "$PERMISSION" == "maintain" || "$PERMISSION" == "write" ]]; then
+            echo "User has write access - skipping AI triage"
+            echo "is-community-member=false" >> $GITHUB_OUTPUT
+          else
+            echo "User is a community member - triggering AI triage"
+            echo "is-community-member=true" >> $GITHUB_OUTPUT
+          fi
+    outputs:
+      is-community-member: ${{ steps.check-access.outputs.is-community-member }}
+
+  ai-triage-issue:
+    name: AI Triage for Community Issue
+    needs: check-permissions
+    if: needs.check-permissions.outputs.is-community-member == 'true'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Authenticate as GitHub App
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        id: get-app-token
+        with:
+          owner: "airbytehq"
+          repositories: "airbyte-python-cdk,oncall"
+          app-id: ${{ secrets.OCTAVIA_BOT_APP_ID }}
+          private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}
+
+      - name: Run AI Triage
+        uses: aaronsteers/devin-action@main
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          playbook-macro: "!oss_issue_triage"
+          devin-token: ${{ secrets.DEVIN_AI_API_KEY }}
+          github-token: ${{ steps.get-app-token.outputs.token }}
+          api-version: v3
+          org-id: ${{ vars.DEVIN_AI_ORG_ID }}
+          start-message: |
+            **AI Triage Starting...**
+
+            Thank you for opening this issue! I'm an AI assistant that will do an initial review and may:
+            - Ask clarifying questions if needed
+            - Suggest relevant documentation or workarounds
+            - Flag this for internal visibility
+
+            **Note:** Community issues are reviewed on a best-effort basis and do not have a guaranteed response time. To help us act on a suspected bug, please include a reproducing manifest or code snippet, the full stack trace, and the CDK version where you first saw the behavior.
+
+            For additional help:
+            - Join the [Airbyte Community Slack](https://slack.airbyte.com) to connect with other users and community members
+            - If you're an Airbyte Cloud customer, you can [open a support ticket](https://support.airbyte.com) or contact your account representative, referencing this issue URL
+
+            [View playbook](https://github.com/airbytehq/ai-skills/blob/main/devin/playbooks/oss_issue_triage.md)
+          tags: |
+            oss-issue-triage
+            community-issue
+            airbyte-python-cdk

--- a/.github/workflows/oss-issue-triage.yml
+++ b/.github/workflows/oss-issue-triage.yml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
   check-permissions:
-    name: Resolve Input Variables
+    name: Check Author Permissions
     runs-on: ubuntu-24.04
     steps:
       - name: Authenticate as GitHub App
@@ -39,23 +39,40 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.get-app-token.outputs.token }}
           AUTHOR: ${{ github.event.issue.user.login }}
+          REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
 
           echo "Checking permissions for user: $AUTHOR"
 
-          PERMISSION=$(gh api repos/${{ github.repository }}/collaborators/$AUTHOR/permission \
-            --jq '.permission' 2>/dev/null || echo "none")
+          # A 404 is the expected answer for a non-collaborator. Every other
+          # failure -- rate limit, 5xx, expired token -- must NOT be mistaken for
+          # one: that would classify a maintainer as a community member and start
+          # a Devin session that can file a P2 issue in airbytehq/oncall. Fail the
+          # job instead, so the problem is visible rather than silently wrong.
+          ERR="$RUNNER_TEMP/permission-error.txt"
+          STATUS=0
+          PERMISSION=$(gh api "repos/$REPO/collaborators/$AUTHOR/permission" --jq '.permission' 2>"$ERR") || STATUS=$?
+
+          if [[ "$STATUS" -ne 0 ]]; then
+            if grep -q "HTTP 404" "$ERR"; then
+              PERMISSION="none"
+            else
+              echo "::error::Permission lookup for $AUTHOR failed; refusing to guess."
+              cat "$ERR" >&2
+              exit 1
+            fi
+          fi
 
           echo "User permission level: $PERMISSION"
 
           # Users with write, maintain, or admin access are NOT community members
           if [[ "$PERMISSION" == "admin" || "$PERMISSION" == "maintain" || "$PERMISSION" == "write" ]]; then
             echo "User has write access - skipping AI triage"
-            echo "is-community-member=false" >> $GITHUB_OUTPUT
+            echo "is-community-member=false" >> "$GITHUB_OUTPUT"
           else
             echo "User is a community member - triggering AI triage"
-            echo "is-community-member=true" >> $GITHUB_OUTPUT
+            echo "is-community-member=true" >> "$GITHUB_OUTPUT"
           fi
     outputs:
       is-community-member: ${{ steps.check-access.outputs.is-community-member }}
@@ -92,7 +109,7 @@ jobs:
             - Suggest relevant documentation or workarounds
             - Flag this for internal visibility
 
-            **Note:** Community issues are reviewed on a best-effort basis and do not have a guaranteed response time. To help us act on a suspected bug, please include a reproducing manifest or code snippet, the full stack trace, and the CDK version where you first saw the behavior.
+            **Note:** Community issues are reviewed on a best-effort basis and do not have a guaranteed response time. To help us act on a suspected bug, please include at least one of: a reproducing manifest or code snippet, the full stack trace or error message, or the CDK version where the behavior changed. More detail is always welcome.
 
             For additional help:
             - Join the [Airbyte Community Slack](https://slack.airbyte.com) to connect with other users and community members


### PR DESCRIPTION
> 🤖 *This PR was generated by an AI Agent.*

## What

Adds `oss-issue-triage.yml` — an AI triage workflow for community issues opened in this repo, mirroring the one in `airbytehq/airbyte`.

When a user **without** write access opens an issue, the workflow starts a Devin session running the shared `!oss_issue_triage` playbook. The playbook posts an acknowledgment, asks for anything missing, and — for confirmed defects only — files a tracking issue in `airbytehq/oncall`.

## CDK-specific behavior

The rules live in the shared playbook, gated on repository. Companion PR: **airbytehq/ai-skills#689**.

| | Behavior |
|---|---|
| **Priority** | Escalated issues are **P2**, not P3 — a CDK defect can affect every source connector built on it, so the blast radius is categorically larger than any single connector's |
| **Feature requests** | **Never escalated.** Enhancements, new declarative capabilities, and manifest-only feature gaps stay here, labeled `enhancement` |
| **Evidence bar** | A defect escalates only with a reproducing snippet, a stack trace, or a CDK version where the behavior changed. Otherwise the bot asks for it and does not escalate |

The higher evidence bar is deliberate: P2 is a real priority, and it shouldn't be handed out on an unsubstantiated report.

## Merge order

**Merge airbytehq/ai-skills#689 first.** Without it, issues opened here would be triaged under the connector rules — feature requests would be escalated and priority would be P3/P4 rather than P2. Nothing breaks, but the behavior would be wrong until the playbook lands.

## Credentials

All required secrets are already available to this repo at the org level — verified via `actions/organization-secrets` and `actions/organization-variables`:

- `OCTAVIA_BOT_APP_ID` / `OCTAVIA_BOT_PRIVATE_KEY` — already used by 6 workflows here
- `DEVIN_AI_API_KEY`
- `DEVIN_AI_ORG_ID` (variable)

The app token in the triage job is scoped to `airbyte-python-cdk,oncall` so it can write the tracking issue.

## One deliberate difference from the `airbyte` version

The triage job here is gated on the permission check:

```yaml
if: needs.check-permissions.outputs.is-community-member == 'true'
```

In `airbytehq/airbyte`, `is-community-member` is computed and exposed as a job output but **never used** — both jobs gate only on `event-type`. The effect is that AI triage fires on every issue there, including issues opened by maintainers, which is not what that workflow's own description says it does.

That's a pre-existing bug in the other repo and is not fixed here. This workflow does what the description says.

## Scope

Issues only. Discussions are enabled on this repo but are not wired up — worth considering separately once the issue path has run for a few weeks.

## Testing notes

Not exercised end to end. The next community-opened issue in this repo is the real test; worth watching the first few runs to confirm the permission gate gets it right and that P2 is applied only to confirmed defects.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated triage for newly opened open-source issues.
  * Issues from contributors without write access can receive an introductory response and relevant labels.
  * Triage can reference related CDK and on-call repository information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._

> [!NOTE]
> **Auto-merge may have been disabled. Please check the PR status to confirm.**