### PR TITLE
ci: label issues from outside the org as community

### DIFF
--- a/.github/workflows/label-community-issues.yml
+++ b/.github/workflows/label-community-issues.yml
@@ -9,14 +9,25 @@ name: Label Community Issues
 #   MEMBER / OWNER  -> inside the org  -> no label
 #   anything else   -> outside the org -> "community"
 #
-# Bots are excluded via `user.type`. This matters more than it looks: 29 of the 83
-# issues in this repo were opened by bots (Devin, CodeRabbit), and every one of them
-# reports `author_association: CONTRIBUTOR`. Without the bot check they would all be
-# mislabeled as community contributions.
+# Automation accounts are excluded by an explicit allowlist rather than by
+# `user.type != 'Bot'`, which is wrong in both directions:
 #
-# `author_association` reflects org membership at the moment the event fires, so the
-# label is a snapshot. Someone who files an issue and later leaves the org keeps
-# whatever label they had, which is the intended behavior.
+#   - Too broad.  It would exclude ANY app bot, including one that files issues on
+#     behalf of community members. No such relay bot exists today, but if one is
+#     ever installed, a type check would silently drop the label. An allowlist
+#     instead labels the unknown bot's issues `community` — wrong, but visible, and
+#     fixed by adding one line here.
+#   - Too narrow. `airbyteio` and `octavia-squidington-iii` are Airbyte machine
+#     accounts of type User, not Bot. A type check would label their issues
+#     `community`.
+#
+# The list below mirrors the denylist in airbytehq/workflow-actions -> src/community.ts
+# (which drives the same labeling in airbytehq/airbyte), plus `coderabbitai[bot]`,
+# which files issues here and is absent from that list.
+#
+# Bots that have actually opened issues in this repo: devin-ai-integration (21) and
+# coderabbitai (8), out of 83 total. Both are Airbyte-installed tooling producing
+# internal engineering issues.
 
 on:
   issues:
@@ -27,9 +38,11 @@ on:
 jobs:
   label-community-issue:
     name: Add "community" Label to Issue
-    # Skip bots, and skip anyone inside the airbytehq organization.
+    # Skip known Airbyte automation, and skip anyone inside the airbytehq org.
+    # An automation account not listed here is treated as a community author on
+    # purpose, so the gap shows up in triage rather than disappearing.
     if: >
-      github.event.issue.user.type != 'Bot' &&
+      !contains(fromJSON('["devin-ai-integration[bot]", "coderabbitai[bot]", "github-actions[bot]", "dependabot[bot]", "octavia-bot[bot]", "octavia-bot-admin[bot]", "octavia-bot-hoard[bot]", "speakeasybot[bot]", "airbyte-slash-dispatch-bot[bot]", "octavia-squidington-iii", "airbyteio"]'), github.event.issue.user.login) &&
       !contains(fromJSON('["MEMBER", "OWNER"]'), github.event.issue.author_association)
     runs-on: ubuntu-24.04
     permissions:

--- a/.github/workflows/label-community-issues.yml
+++ b/.github/workflows/label-community-issues.yml
@@ -1,33 +1,37 @@
 name: Label Community Issues
 
-# This workflow adds the "community" label to issues opened by people outside the
-# airbytehq organization. It is the issue-side counterpart to
-# label-community-prs.yml, which does the same for PRs from forks.
+# This workflow adds the "community" label to issues opened by anyone outside
+# Airbyte. It is the issue-side counterpart to label-community-prs.yml, which does
+# the same for PRs from forks.
 #
-# The signal is `author_association`, which GitHub computes per event against live
-# org membership:
-#   MEMBER / OWNER  -> inside the org  -> no label
-#   anything else   -> outside the org -> "community"
+# The rule:
+#   airbytehq org member        -> no label
+#   bot installed by airbytehq  -> no label
+#   everyone else               -> "community"
 #
-# Automation accounts are excluded by an explicit allowlist rather than by
-# `user.type != 'Bot'`, which is wrong in both directions:
+# Both exclusions are exact, and neither needs a maintained list:
 #
-#   - Too broad.  It would exclude ANY app bot, including one that files issues on
-#     behalf of community members. No such relay bot exists today, but if one is
-#     ever installed, a type check would silently drop the label. An allowlist
-#     instead labels the unknown bot's issues `community` — wrong, but visible, and
-#     fixed by adding one line here.
-#   - Too narrow. `airbyteio` and `octavia-squidington-iii` are Airbyte machine
-#     accounts of type User, not Bot. A type check would label their issues
-#     `community`.
+# 1. Org membership. `author_association` is computed by GitHub per event against
+#    live org membership, including private memberships, and arrives in the webhook
+#    payload — no API call, no token scope. MEMBER and OWNER mean the author is
+#    inside the org. This also covers Airbyte's machine *user* accounts
+#    (`airbyteio`, `octavia-squidington-iii`), which are org members and whose
+#    issues report MEMBER.
 #
-# The list below mirrors the denylist in airbytehq/workflow-actions -> src/community.ts
-# (which drives the same labeling in airbytehq/airbyte), plus `coderabbitai[bot]`,
-# which files issues here and is absent from that list.
+# 2. Installed apps. A `type: Bot` account is a GitHub App identity, and a GitHub
+#    App can only act on repositories where it is installed. Installing an app on an
+#    airbytehq repo requires an airbytehq admin. So every Bot-authored issue in this
+#    repo is, by construction, from an app Airbyte installed — there is no way for an
+#    outside app to open one. An allowlist would be both unnecessary and unreliable:
+#    airbytehq has 78 apps installed org-wide, and any hand-maintained subset would
+#    drift.
 #
-# Bots that have actually opened issues in this repo: devin-ai-integration (21) and
-# coderabbitai (8), out of 83 total. Both are Airbyte-installed tooling producing
-# internal engineering issues.
+# `author_association` is evaluated when the event fires, so the label is a snapshot.
+# Someone who files an issue and later leaves the org keeps the label they had.
+#
+# Note on COLLABORATOR: an outside collaborator is someone granted direct access to
+# this repo without being an org member. They are outside the org, so by the rule
+# above they get the label. This repo currently has zero outside collaborators.
 
 on:
   issues:
@@ -38,11 +42,9 @@ on:
 jobs:
   label-community-issue:
     name: Add "community" Label to Issue
-    # Skip known Airbyte automation, and skip anyone inside the airbytehq org.
-    # An automation account not listed here is treated as a community author on
-    # purpose, so the gap shows up in triage rather than disappearing.
+    # Skip airbytehq org members, and skip apps installed by airbytehq.
     if: >
-      !contains(fromJSON('["devin-ai-integration[bot]", "coderabbitai[bot]", "github-actions[bot]", "dependabot[bot]", "octavia-bot[bot]", "octavia-bot-admin[bot]", "octavia-bot-hoard[bot]", "speakeasybot[bot]", "airbyte-slash-dispatch-bot[bot]", "octavia-squidington-iii", "airbyteio"]'), github.event.issue.user.login) &&
+      github.event.issue.user.type != 'Bot' &&
       !contains(fromJSON('["MEMBER", "OWNER"]'), github.event.issue.author_association)
     runs-on: ubuntu-24.04
     permissions:

--- a/.github/workflows/label-community-issues.yml
+++ b/.github/workflows/label-community-issues.yml
@@ -1,0 +1,44 @@
+name: Label Community Issues
+
+# This workflow adds the "community" label to issues opened by people outside the
+# airbytehq organization. It is the issue-side counterpart to
+# label-community-prs.yml, which does the same for PRs from forks.
+#
+# The signal is `author_association`, which GitHub computes per event against live
+# org membership:
+#   MEMBER / OWNER  -> inside the org  -> no label
+#   anything else   -> outside the org -> "community"
+#
+# Bots are excluded via `user.type`. This matters more than it looks: 29 of the 83
+# issues in this repo were opened by bots (Devin, CodeRabbit), and every one of them
+# reports `author_association: CONTRIBUTOR`. Without the bot check they would all be
+# mislabeled as community contributions.
+#
+# `author_association` reflects org membership at the moment the event fires, so the
+# label is a snapshot. Someone who files an issue and later leaves the org keeps
+# whatever label they had, which is the intended behavior.
+
+on:
+  issues:
+    types:
+      - opened
+      - reopened
+
+jobs:
+  label-community-issue:
+    name: Add "community" Label to Issue
+    # Skip bots, and skip anyone inside the airbytehq organization.
+    if: >
+      github.event.issue.user.type != 'Bot' &&
+      !contains(fromJSON('["MEMBER", "OWNER"]'), github.event.issue.author_association)
+    runs-on: ubuntu-24.04
+    permissions:
+      issues: write
+    steps:
+      - name: Add community label
+        # This action uses GitHub's addLabels API, which is idempotent.
+        # If the label already exists, the API call succeeds without error.
+        uses: actions-ecosystem/action-add-labels@bd52874380e3909a1ac983768df6976535ece7f8 # v1.1.3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          labels: community


### PR DESCRIPTION
> 🤖 *This PR was generated by an AI Agent.*

## What

Adds `label-community-issues.yml` — the issue-side counterpart to `label-community-prs.yml`.

```
airbytehq org member        -> no label
bot installed by airbytehq  -> no label
everyone else               -> "community"
```

```yaml
if: >
  github.event.issue.user.type != 'Bot' &&
  !contains(fromJSON('["MEMBER", "OWNER"]'), github.event.issue.author_association)
```

Both exclusions are exact, and neither needs a maintained list.

## 1. Org membership — `author_association`

GitHub computes it per event against **live** org membership, including private memberships, and it arrives in the webhook payload: no API call, no token scope.

Verified: four issue authors here report `CONTRIBUTOR` despite being recognizable Airbyte names — `brianjlai`, `natikgadzhi`, `marcosmarxm`, `arr-ee`. All four have since left the org (`orgs/airbytehq/members/{user}` → 404), while current members `tolik0` and `pnilan` report `MEMBER` and resolve. The signal tracks reality, not a stale roster.

This also covers Airbyte's machine **user** accounts. `airbyteio` and `octavia-squidington-iii` are `type=User`, not `Bot` — but both are org members, and their issues report `MEMBER`:

```console
$ gh api orgs/airbytehq/members/octavia-squidington-iii --silent && echo "ORG MEMBER"
ORG MEMBER
$ gh api -X GET search/issues -f q='repo:airbytehq/airbyte is:issue author:octavia-squidington-iii' ...
  #11646  assoc=MEMBER
```

## 2. Installed apps — `user.type != 'Bot'`

A `type: Bot` account is a GitHub App identity, and **a GitHub App can only act on repositories where it is installed.** Installing an app on an airbytehq repo requires an airbytehq admin.

So every Bot-authored issue in this repo is, by construction, from an app Airbyte installed. There is no path for an outside app to open one — which makes the type check an exact expression of "bot installed by airbytehq," not an approximation.

An allowlist would be strictly worse here: **airbytehq has 78 apps installed org-wide**, so any hand-maintained subset drifts. (An earlier revision of this PR used an 11-entry list mirroring `workflow-actions/src/community.ts`; it was replaced for this reason.)

## Who is a COLLABORATOR

An *outside collaborator* — someone granted direct access to a repository without being an org member. They are outside the org, so under the rule above they get the label.

In practice this is close to empty:

```console
$ gh api "repos/airbytehq/airbyte-python-cdk/collaborators?affiliation=outside"
(none)

$ gh api "repos/airbytehq/airbyte/collaborators?affiliation=outside"
airbyte-oss-build-runner   admin
```

Zero on this repo. One on `airbyte`, and it's a machine account that has never opened an issue. No `COLLABORATOR`-authored issue exists in either repo.

Worth noting the other two Airbyte implementations treat `COLLABORATOR` as internal — `community-api-source-pr-board.yml` uses `['MEMBER', 'OWNER', 'COLLABORATOR']`, and `workflow-actions/src/community.ts` counts only `CONTRIBUTOR` / `NONE` / `FIRST_TIME_CONTRIBUTOR` / `FIRST_TIMER` as community. This PR intentionally follows the org-membership rule instead.

## Which bots actually file issues here

| Author | Count | Treatment |
|---|---|---|
| `devin-ai-integration[bot]` | 21 | excluded |
| `coderabbitai[bot]` | 8 | excluded |
| humans outside the org | 32 | **community** |
| org members | 22 | excluded |

Both bots are Airbyte-installed tooling producing internal engineering issues — CodeRabbit's are code-review follow-ups (*"Refactor Dockerfile when airbyte-ci no longer requires rigid file structure"*). Neither relays community reports. `devin-ai-integration[bot]` is the only bot to have filed an issue in `airbytehq/airbyte` this year (39).

Every bot issue reports `author_association: CONTRIBUTOR`, so without the type check **35% of this repo's issues would be mislabeled** as community contributions.

## Verification

Replayed against **412 issues** across both repos (all 83 here, plus everything in `airbytehq/airbyte` since 2026-01-01):

| Repo | author_association | type | Count | Result |
|---|---|---|---|---|
| cdk | `NONE` | User | 22 | **community** |
| cdk | `CONTRIBUTOR` | User | 10 | **community** |
| cdk | `CONTRIBUTOR` | Bot | 29 | no label |
| cdk | `MEMBER` | User | 22 | no label |
| airbyte | `NONE` | User | 260 | **community** |
| airbyte | `CONTRIBUTOR` | User | 41 | **community** |
| airbyte | `CONTRIBUTOR` | Bot | 39 | no label |
| airbyte | `MEMBER` | User | 18 | no label |

No misclassifications.

## Label housekeeping

The `community` label already exists here (`#2D7D67`) but is described as **"PRs from community contributors"**. Worth widening to cover issues — a repo-settings change, not included here.

## Relationship to the triage workflow

Independent of #1097. That gates on **repo write permission** via the collaborators API; this keys on **org membership** via `author_association`. They agree in practice but are not the same test — an org member holding only `read` on this repo would be triaged as community while receiving no label.

## Testing notes

Not exercised end to end — the next issue opened here is the real test. The condition was replayed offline against 412 existing issues, as above.

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._