### PR TITLE
chore(do not merge): CDK #1079 on current main for OC-13084 prerelease SDM

### DIFF
--- a/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -634,6 +634,7 @@ from airbyte_cdk.sources.message import (
     NoopMessageRepository,
 )
 from airbyte_cdk.sources.message.repository import StateFilteringMessageRepository
+from airbyte_cdk.sources.streams import NO_CURSOR_STATE_KEY
 from airbyte_cdk.sources.streams.call_rate import (
     APIBudget,
     FixedWindowCallRatePolicy,
@@ -4138,6 +4139,14 @@ class ModelToComponentFactory:
         self, model: ParentStreamConfigModel, config: Config, *, stream_name: str, **kwargs: Any
     ) -> Any:
         child_state = self._connector_state_manager.get_stream_state(stream_name, None)
+        if NO_CURSOR_STATE_KEY in child_state:
+            # Full refresh streams checkpoint a `{NO_CURSOR_STATE_KEY: true}` sentinel. When such a
+            # stream is later converted to incremental with an incremental_dependency parent,
+            # `_instantiate_parent_stream_state_manager` would treat the sentinel's boolean as a legacy
+            # cursor value and re-key it under the parent's cursor field, crashing cursor initialization.
+            child_state = {
+                key: value for key, value in child_state.items() if key != NO_CURSOR_STATE_KEY
+            }
 
         parent_state: Optional[Mapping[str, Any]] = (
             child_state if model.incremental_dependency and child_state else None

--- a/unit_tests/sources/declarative/parsers/test_model_to_component_factory.py
+++ b/unit_tests/sources/declarative/parsers/test_model_to_component_factory.py
@@ -4020,6 +4020,108 @@ def test_create_concurrent_cursor_from_perpartition_cursor_runs_state_migrations
     )
 
 
+def test_create_concurrent_cursor_from_perpartition_cursor_ignores_full_refresh_sentinel_state():
+    """
+    A stream that synced as full refresh checkpoints `{"__ab_no_cursor_state_message": true}`. If a later
+    connector version converts that stream to incremental with an `incremental_dependency` parent, the
+    sentinel must not be re-keyed under the parent's cursor field as if it were a legacy cursor value —
+    doing so crashed cursor initialization with `ValueError: No format in [...] matching True`.
+    """
+    content = """
+    type: DeclarativeStream
+    primary_key: "id"
+    name: test
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        $schema: "http://json-schema.org/draft-07/schema"
+        type: object
+        properties:
+          id:
+            type: string
+    incremental_sync:
+      type: "DatetimeBasedCursor"
+      cursor_field: "updated_at"
+      datetime_format: "%Y-%m-%dT%H:%M:%S.%f%z"
+      start_datetime: "{{ config['start_time'] }}"
+    retriever:
+      type: SimpleRetriever
+      name: test
+      requester:
+        type: HttpRequester
+        name: "test"
+        url_base: "https://api.test.com/v3/"
+        http_method: "GET"
+        authenticator:
+          type: NoAuth
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: []
+      partition_router:
+        type: SubstreamPartitionRouter
+        parent_stream_configs:
+          - type: ParentStreamConfig
+            parent_key: id
+            partition_field: id
+            incremental_dependency: true
+            stream:
+              type: DeclarativeStream
+              primary_key: id
+              name: parent_stream
+              schema_loader:
+                type: InlineSchemaLoader
+                schema:
+                  $schema: "http://json-schema.org/draft-07/schema"
+                  type: object
+                  properties:
+                    id:
+                      type: string
+              incremental_sync:
+                type: "DatetimeBasedCursor"
+                cursor_field: "updated_at"
+                datetime_format: "%Y-%m-%dT%H:%M:%S.%f%z"
+                start_datetime: "{{ config['start_time'] }}"
+              retriever:
+                type: SimpleRetriever
+                requester:
+                  type: HttpRequester
+                  url_base: "https://api.test.com/v3/parent"
+                  http_method: "GET"
+                record_selector:
+                  type: RecordSelector
+                  extractor:
+                    type: DpathExtractor
+                    field_path: []
+      """
+
+    connector_state_manager = ConnectorStateManager(
+        state=[
+            AirbyteStateMessage(
+                type=AirbyteStateType.STREAM,
+                stream=AirbyteStreamState(
+                    stream_descriptor=StreamDescriptor(name="test"),
+                    stream_state=AirbyteStateBlob({"__ab_no_cursor_state_message": True}),
+                ),
+            )
+        ]
+    )
+    factory = ModelToComponentFactory(
+        emit_connector_builder_messages=True, connector_state_manager=connector_state_manager
+    )
+    stream = factory.create_component(
+        model_type=DeclarativeStreamModel,
+        component_definition=YamlDeclarativeSource._parse(content),
+        config=input_config,
+    )
+
+    parent_cursor_state = stream.cursor._partition_router.parent_stream_configs[
+        0
+    ].stream.cursor.state
+    assert all(value is not True for value in parent_cursor_state.values())
+
+
 def test_incrementing_count_cursor_with_partition_router_raises_error():
     content = """
     type: DeclarativeStream


### PR DESCRIPTION
## Summary

**DO NOT MERGE.** This is a temporary build artifact, requested by Zane Hyatt. It exists only to produce a prerelease `source-declarative-manifest` image that contains both the sentinel fix and the provenance-aware custom-code gate. All review of the actual fix belongs on airbytehq/airbyte-python-cdk#1079 — not here.

Contents: current `main` plus a clean cherry-pick of `df07154ba1e777bd08a2fad89da42065304c7461`, the sole commit of airbytehq/airbyte-python-cdk#1079 ("fix(declarative): ignore full-refresh sentinel in parent state seeding"). No other changes: no logic edits, no version bumps, no changelog.

Why this branch is needed: #1079's branch forked from `main` before airbytehq/airbyte-python-cdk#1083 (`6ce33eaf7`, released in v7.23.8) landed, so a prerelease built from it hits `AirbyteCustomCodeNotPermittedError` for any manifest-only connector bundling a `components.py` (see airbytehq/airbyte-python-cdk#1082). source-hubspot is such a connector. No published image has both changes; this branch does.

Related:
- Fix PR (review here): airbytehq/airbyte-python-cdk#1079
- Custom-code gate fix: airbytehq/airbyte-python-cdk#1083
- Gate regression: airbytehq/airbyte-python-cdk#1082
- Oncall issue: https://github.com/airbytehq/oncall/issues/13084

Verified on this branch, in `model_to_component_factory.py`:
- `if NO_CURSOR_STATE_KEY in child_state:` sentinel strip before parent state seeding (from #1079)
- `manifest_is_untrusted = not self._custom_components_trusted or ...` / `if manifest_is_untrusted and not custom_code_execution_permitted():` (from #1083)

Tests: `poetry run pytest unit_tests/sources/declarative/parsers/ unit_tests/sources/declarative/partition_routers/` → 239 passed, 0 failed, including `test_create_concurrent_cursor_from_perpartition_cursor_ignores_full_refresh_sentinel_state`.


Link to Devin session: https://app.devin.ai/sessions/1bce0e0ed6044627b8ef34dd6482c6af
Requested by: @ZaneHyattAB