### PR TITLE
fix(low-code): make Spec.generate_spec idempotent and non-mutating

### DIFF
--- a/airbyte_cdk/sources/declarative/spec/spec.py
+++ b/airbyte_cdk/sources/declarative/spec/spec.py
@@ -3,6 +3,7 @@
 #
 
 from dataclasses import InitVar, dataclass, field
+from enum import Enum
 from typing import Any, List, Mapping, MutableMapping, Optional
 
 from airbyte_cdk.models import (
@@ -54,19 +55,17 @@ class Spec:
         if self.documentation_url:
             obj["documentationUrl"] = self.documentation_url
         if self.advanced_auth:
-            self.advanced_auth.auth_flow_type = self.advanced_auth.auth_flow_type.value  # type: ignore # We know this is always assigned to an AuthFlow which has the auth_flow_type field
-            # Convert scopes_join_strategy enum to its string value (same pattern as auth_flow_type above)
-            oauth_spec = getattr(self.advanced_auth, "oauth_config_specification", None)
-            if oauth_spec:
-                oauth_input = getattr(oauth_spec, "oauth_connector_input_specification", None)
-                if (
-                    oauth_input
-                    and hasattr(oauth_input, "scopes_join_strategy")
-                    and oauth_input.scopes_join_strategy is not None
-                ):
-                    oauth_input.scopes_join_strategy = oauth_input.scopes_join_strategy.value  # type: ignore
+            # Serialize to a dict and normalize enum values there so the typed model is
+            # never mutated and repeated calls produce the same result
+            advanced_auth = self.advanced_auth.dict()
+            if isinstance(advanced_auth.get("auth_flow_type"), Enum):
+                advanced_auth["auth_flow_type"] = advanced_auth["auth_flow_type"].value
+            oauth_spec = advanced_auth.get("oauth_config_specification") or {}
+            oauth_input = oauth_spec.get("oauth_connector_input_specification") or {}
+            if isinstance(oauth_input.get("scopes_join_strategy"), Enum):
+                oauth_input["scopes_join_strategy"] = oauth_input["scopes_join_strategy"].value
             # Map CDK AuthFlow model to protocol AdvancedAuth model
-            obj["advanced_auth"] = self.advanced_auth.dict()
+            obj["advanced_auth"] = advanced_auth
 
         # We remap these keys to camel case because that's the existing format expected by the rest of the platform
         return ConnectorSpecificationSerializer.load(obj)

--- a/airbyte_cdk/sources/declarative/spec/spec.py
+++ b/airbyte_cdk/sources/declarative/spec/spec.py
@@ -2,8 +2,8 @@
 # Copyright (c) 2025 Airbyte, Inc., all rights reserved.
 #
 
+import json
 from dataclasses import InitVar, dataclass, field
-from enum import Enum
 from typing import Any, List, Mapping, MutableMapping, Optional
 
 from airbyte_cdk.models import (
@@ -55,17 +55,13 @@ class Spec:
         if self.documentation_url:
             obj["documentationUrl"] = self.documentation_url
         if self.advanced_auth:
-            # Serialize to a dict and normalize enum values there so the typed model is
-            # never mutated and repeated calls produce the same result
-            advanced_auth = self.advanced_auth.dict()
-            if isinstance(advanced_auth.get("auth_flow_type"), Enum):
-                advanced_auth["auth_flow_type"] = advanced_auth["auth_flow_type"].value
-            oauth_spec = advanced_auth.get("oauth_config_specification") or {}
-            oauth_input = oauth_spec.get("oauth_connector_input_specification") or {}
-            if isinstance(oauth_input.get("scopes_join_strategy"), Enum):
-                oauth_input["scopes_join_strategy"] = oauth_input["scopes_join_strategy"].value
+            # Serialize through JSON so enum values are normalized at any depth and the typed
+            # model is never mutated — repeated calls produce the same result.
+            # Note: an AuthFlow without an auth_flow_type (e.g. only a predicate) is passed
+            # through as auth_flow_type=None, which the protocol AdvancedAuth allows.
+            advanced_auth_dict = json.loads(self.advanced_auth.json())
             # Map CDK AuthFlow model to protocol AdvancedAuth model
-            obj["advanced_auth"] = advanced_auth
+            obj["advanced_auth"] = advanced_auth_dict
 
         # We remap these keys to camel case because that's the existing format expected by the rest of the platform
         return ConnectorSpecificationSerializer.load(obj)

--- a/unit_tests/sources/declarative/spec/test_spec.py
+++ b/unit_tests/sources/declarative/spec/test_spec.py
@@ -162,6 +162,24 @@ def test_spec(spec, expected_connection_specification) -> None:
     assert spec.generate_spec() == expected_connection_specification
 
 
+def test_generate_spec_is_idempotent_and_does_not_mutate_the_model() -> None:
+    spec = component_spec(
+        connection_specification={"client_id": "my_client_id"},
+        parameters={},
+        advanced_auth=component_auth_flow(
+            auth_flow_type=component_auth_flow_type.oauth2_0,
+            predicate_key=None,
+            predicate_value=None,
+        ),
+    )
+
+    first = spec.generate_spec()
+    second = spec.generate_spec()
+
+    assert first == second
+    assert spec.advanced_auth.auth_flow_type is component_auth_flow_type.oauth2_0
+
+
 def test_given_list_of_transformations_when_transform_config_then_config_is_transformed() -> None:
     input_config = {"planet_code": "CRSC"}
     expected_config = {

--- a/unit_tests/sources/declarative/spec/test_spec.py
+++ b/unit_tests/sources/declarative/spec/test_spec.py
@@ -37,6 +37,9 @@ from airbyte_cdk.sources.declarative.models.declarative_component_schema import 
     OauthConnectorInputSpecification as component_declarative_oauth_connector_input_spec,
 )
 from airbyte_cdk.sources.declarative.models.declarative_component_schema import (
+    ScopesJoinStrategy as component_declarative_oauth_scopes_join_strategy,
+)
+from airbyte_cdk.sources.declarative.models.declarative_component_schema import (
     State as component_declarative_oauth_state,
 )
 from airbyte_cdk.sources.declarative.spec.spec import ConfigMigration
@@ -162,22 +165,90 @@ def test_spec(spec, expected_connection_specification) -> None:
     assert spec.generate_spec() == expected_connection_specification
 
 
-def test_generate_spec_is_idempotent_and_does_not_mutate_the_model() -> None:
+@pytest.mark.parametrize(
+    "advanced_auth",
+    [
+        pytest.param(
+            component_auth_flow(
+                auth_flow_type=component_auth_flow_type.oauth2_0,
+                predicate_key=None,
+                predicate_value=None,
+            ),
+            id="top_level_auth_flow_type_enum",
+        ),
+        pytest.param(
+            component_auth_flow(
+                auth_flow_type=component_auth_flow_type.oauth2_0,
+                predicate_key=None,
+                predicate_value=None,
+                oauth_config_specification=component_declarative_oauth_config_spec(
+                    oauth_connector_input_specification=component_declarative_oauth_connector_input_spec(
+                        consent_url="https://domain.host.com/endpoint/oauth",
+                        access_token_url="https://domain.host.com/endpoint/v1/oauth2/access_token/",
+                        scope="reports:read campaigns:read",
+                        scopes_join_strategy=component_declarative_oauth_scopes_join_strategy.comma,
+                        extract_output=["data.access_token"],
+                    ),
+                ),
+            ),
+            id="nested_scopes_join_strategy_enum",
+        ),
+        pytest.param(
+            component_auth_flow(
+                auth_flow_type=None,
+                predicate_key=["credentials", "auth_type"],
+                predicate_value="oauth2.0",
+            ),
+            id="no_auth_flow_type",
+        ),
+    ],
+)
+def test_generate_spec_is_idempotent_and_does_not_mutate_the_model(advanced_auth) -> None:
     spec = component_spec(
         connection_specification={"client_id": "my_client_id"},
         parameters={},
-        advanced_auth=component_auth_flow(
-            auth_flow_type=component_auth_flow_type.oauth2_0,
-            predicate_key=None,
-            predicate_value=None,
-        ),
+        advanced_auth=advanced_auth,
     )
 
     first = spec.generate_spec()
     second = spec.generate_spec()
 
     assert first == second
-    assert spec.advanced_auth.auth_flow_type is component_auth_flow_type.oauth2_0
+    # identity, not equality: catches an in-place mutation to the plain string "oauth2.0"
+    assert spec.advanced_auth.auth_flow_type is advanced_auth.auth_flow_type
+
+    oauth_spec = spec.advanced_auth.oauth_config_specification
+    if oauth_spec and oauth_spec.oauth_connector_input_specification:
+        # the model keeps its enum...
+        assert (
+            oauth_spec.oauth_connector_input_specification.scopes_join_strategy
+            is component_declarative_oauth_scopes_join_strategy.comma
+        )
+        # ...while the emitted spec carries the plain string the protocol declares.
+        # `scopes_join_strategy` is typed `Optional[str]`, so an un-normalized enum would
+        # otherwise slip through both the serializer and the `first == second` check.
+        emitted = first.advanced_auth.oauth_config_specification.oauth_connector_input_specification.scopes_join_strategy
+        assert emitted == "comma" and type(emitted) is str
+
+
+def test_generate_spec_without_auth_flow_type_emits_advanced_auth_with_none() -> None:
+    """An AuthFlow carrying only a predicate is valid: both the component model and the
+    protocol AdvancedAuth declare auth_flow_type as optional, so it is passed through as None."""
+    spec = component_spec(
+        connection_specification={},
+        parameters={},
+        advanced_auth=component_auth_flow(
+            auth_flow_type=None,
+            predicate_key=["credentials", "auth_type"],
+            predicate_value="oauth2.0",
+        ),
+    )
+
+    assert spec.generate_spec().advanced_auth == model_advanced_auth(
+        auth_flow_type=None,
+        predicate_key=["credentials", "auth_type"],
+        predicate_value="oauth2.0",
+    )
 
 
 def test_given_list_of_transformations_when_transform_config_then_config_is_transformed() -> None:


### PR DESCRIPTION
## Summary

`Spec.generate_spec()` converted the `advanced_auth` enum fields (`auth_flow_type`, nested `scopes_join_strategy`) to their string values by assigning the converted values back onto the typed model. That in-place mutation meant:

- a second `generate_spec()` call in the same process raised `AttributeError` (`.value` on an already-converted `str`) — hit by any flow that generates the spec more than once (Connector Builder, tests);
- any other reader of `self.advanced_auth` afterwards saw a string where the type system promises an enum.

This change serializes the model to a dict first and normalizes enum values only in that throwaway copy, so repeated calls are idempotent and the typed model is never mutated. Normalization happens via a single JSON round-trip (`json.loads(self.advanced_auth.json())`) rather than a hand-written walk over the two known enum fields — `declarative_component_schema.py` is code-generated and already defines 12 `Enum` classes, so an explicit walk would silently pass an `Enum` through to `ConnectorSpecificationSerializer` the next time an enum field is added anywhere under the `advanced_auth` subtree.

## Behavior change: `advanced_auth` without an `auth_flow_type`

`AuthFlow` is a pydantic model, so `if self.advanced_auth:` is always truthy. A manifest that sets `advanced_auth` with only a `predicate_key` (no `auth_flow_type`) previously hard-failed with `AttributeError: 'NoneType' object has no attribute 'value'`; it now emits `AdvancedAuth(auth_flow_type=None, ...)`.

Passing `None` through is the more correct behavior — both `AuthFlow.auth_flow_type` (`declarative_component_schema.py:1618`) and the protocol `AdvancedAuth.auth_flow_type` (`airbyte_cdk/models/airbyte_protocol.py:119`) are `Optional`. This PR pins that semantic with a dedicated test rather than leaving it implicit.

## Context

Split out of #1066, where this fix was bundled with the (unrelated) `RateLimitedMultipleTokenAuthenticator` feature; review feedback there asked for it to be its own PR. The fix is being removed from #1066.

## Testing

`unit_tests/sources/declarative/spec/test_spec.py` — 15 passed. The idempotency test is parametrized over three `advanced_auth` shapes so both normalization branches and the `None` case are covered:

- `top_level_auth_flow_type_enum`
- `nested_scopes_join_strategy_enum` — asserts the emitted `scopes_join_strategy` is the plain string the protocol declares. That field is typed `Optional[str]`, so an un-normalized enum would otherwise slip past both the serializer and the `first == second` check.
- `no_auth_flow_type`

Verified the new assertions actually bite: reverting `generate_spec` to a plain `.dict()` with no normalization fails 4 tests, including both new parametrized cases.

`mypy`, `ruff check`, and `ruff format --check` are clean on both touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication specification generation for enum-based authentication flows and OAuth scope joining.
  * Ensured repeated specification generation produces consistent results without altering configured authentication settings.
  * Improved handling of authentication flows without a specified flow type.

* **Tests**
  * Added regression coverage for repeatable specification generation, plain protocol values, configuration immutability, and flow-type edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->