### PR TITLE
fix(low-code): identify the failing response when JSON decoding fails

### DIFF
--- a/airbyte_cdk/sources/declarative/decoders/json_decoder.py
+++ b/airbyte_cdk/sources/declarative/decoders/json_decoder.py
@@ -12,6 +12,7 @@ import requests
 
 from airbyte_cdk.sources.declarative.decoders import CompositeRawDecoder, JsonParser
 from airbyte_cdk.sources.declarative.decoders.decoder import Decoder
+from airbyte_cdk.utils.airbyte_secrets_utils import filter_secrets
 
 logger = logging.getLogger("airbyte")
 
@@ -40,7 +41,18 @@ class JsonDecoder(Decoder):
             for element in self._decoder.decode(response):
                 yield element
                 has_yielded = True
-        except Exception:
+        except Exception as exc:
+            request_method = response.request.method if response.request else "<unknown>"
+            body = response.content
+            body_preview = body[:200].decode("utf-8", errors="replace")
+            logger.error(
+                filter_secrets(
+                    "Failed to decode JSON response: "
+                    f"method={request_method}, url={response.url}, status_code={response.status_code}, "
+                    f"content_type={response.headers.get('Content-Type')}, body_length={len(body)}, "
+                    f"body_preview={body_preview!r}, error={exc}"
+                )
+            )
             yield {}
 
         if not has_yielded:

--- a/airbyte_cdk/sources/declarative/decoders/json_decoder.py
+++ b/airbyte_cdk/sources/declarative/decoders/json_decoder.py
@@ -43,7 +43,7 @@ class JsonDecoder(Decoder):
                 has_yielded = True
         except Exception as exc:
             request_method = response.request.method if response.request else "<unknown>"
-            body = response.content
+            body = response.content or b""
             body_preview = body[:200].decode("utf-8", errors="replace")
             logger.error(
                 filter_secrets(

--- a/unit_tests/sources/declarative/decoders/test_json_decoder.py
+++ b/unit_tests/sources/declarative/decoders/test_json_decoder.py
@@ -3,12 +3,14 @@
 #
 import gzip
 import json
+import logging
 import os
 
 import pytest
 import requests
 
 from airbyte_cdk.sources.declarative.decoders import CompositeRawDecoder
+from airbyte_cdk.sources.declarative.decoders import json_decoder as json_decoder_module
 from airbyte_cdk.sources.declarative.decoders.composite_raw_decoder import JsonLineParser
 from airbyte_cdk.sources.declarative.decoders.json_decoder import JsonDecoder
 
@@ -25,6 +27,79 @@ def test_json_decoder(requests_mock, response_body, first_element):
     requests_mock.register_uri("GET", "https://airbyte.io/", text=response_body)
     response = requests.get("https://airbyte.io/")
     assert next(JsonDecoder(parameters={}).decode(response)) == first_element
+
+
+@pytest.mark.parametrize(
+    ("response_body", "content_type"),
+    [
+        ("", "application/json"),
+        ("<html>error</html>", "text/html"),
+    ],
+    ids=["empty_body", "html_body"],
+)
+def test_json_decoder_logs_response_details_for_invalid_json(
+    requests_mock, caplog, response_body, content_type
+):
+    url = "https://airbyte.io/orders?api_key=secret"
+    requests_mock.register_uri(
+        "GET",
+        url,
+        text=response_body,
+        status_code=200,
+        headers={"Content-Type": content_type},
+    )
+    response = requests.get(url)
+
+    with caplog.at_level(logging.ERROR, logger="airbyte"):
+        assert all(element == {} for element in JsonDecoder(parameters={}).decode(response))
+
+    messages = [record.message for record in caplog.records]
+    message = next(message for message in messages if "Failed to decode JSON response" in message)
+    assert "method=GET" in message
+    assert f"url={url}" in message
+    assert "status_code=200" in message
+    assert f"content_type={content_type}" in message
+    assert f"body_length={len(response_body.encode())}" in message
+    assert f"body_preview={response_body!r}" in message
+    assert "Response JSON data failed to be parsed" in message
+
+
+def test_json_decoder_does_not_log_for_empty_json_array(requests_mock, caplog):
+    requests_mock.register_uri(
+        "GET",
+        "https://airbyte.io/",
+        text="[]",
+        status_code=200,
+        headers={"Content-Type": "application/json"},
+    )
+    response = requests.get("https://airbyte.io/")
+
+    with caplog.at_level(logging.ERROR, logger="airbyte"):
+        assert list(JsonDecoder(parameters={}).decode(response)) == [{}]
+
+    assert not caplog.records
+
+
+def test_json_decoder_filters_secrets_before_logging(requests_mock, caplog, monkeypatch):
+    url = "https://airbyte.io/orders?api_key=secret"
+    requests_mock.register_uri("GET", url, text="<secret>error</secret>", status_code=200)
+    response = requests.get(url)
+    monkeypatch.setattr(
+        json_decoder_module,
+        "filter_secrets",
+        lambda message: message.replace("secret", "****"),
+    )
+
+    with caplog.at_level(logging.ERROR, logger="airbyte"):
+        list(JsonDecoder(parameters={}).decode(response))
+
+    message = next(
+        record.message
+        for record in caplog.records
+        if "Failed to decode JSON response" in record.message
+    )
+    assert "secret" not in message
+    assert "****" in message
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

`JsonDecoder.decode` deliberately swallows every decode exception and yields `{}` so that a bad body looks like "no records". That is fine as a resilience choice, but the only trace left behind is `JsonParser`'s terse line:

```
Failed to parse JSON data using json library. Expecting value: line 1 column 1 (char 0)
```

No URL, no status code, no content type, no body. When a store or API intermittently answers `HTTP 200` with an empty or HTML body, a Cloud sync reports success with 0 records and nothing in the log says which request went wrong.

This adds that context at the `JsonDecoder` boundary, where the `requests.Response` is still in hand:

```python
except Exception as exc:
    logger.error(filter_secrets(
        "Failed to decode JSON response: "
        f"method={...}, url={response.url}, status_code={response.status_code}, "
        f"content_type={...}, body_length={...}, body_preview={...!r}, error={exc}"
    ))
    yield {}
```

Sample output for a 200 with an empty body:

```
Failed to decode JSON response: method=GET, url=https://example.com/wp-json/wc/v3/orders?modified_after=2026-08-06T05%3A00%3A00&modified_before=2026-08-07T05%3A07%3A45, status_code=200, content_type=application/json, body_length=0, body_preview='', error=Response JSON data failed to be parsed. See logs for more information.
```

Notes on the choices:

- **Failure semantics are unchanged.** It still yields `{}`, so no connector starts failing on bodies it used to tolerate.
- **`filter_secrets` is required, not cosmetic.** Some connectors put API keys in query params, so `response.url` and echoed bodies can carry credentials. The body preview is capped at 200 bytes.
- **Legitimately empty responses stay silent.** `[]` and `{}` reach the `if not has_yielded: yield {}` path without raising, so they produce no log line. Covered by a test that asserts zero log records.
- `JsonParser._parse_json`'s existing `logger.error` is left at error level: `CompositeRawDecoder` uses that parser directly, without going through `JsonDecoder`, so lowering it would blind those paths.

Found while diagnosing a WooCommerce Cloud connection whose `orders` stream reported 0 records on every incremental sync. The store was answering some `/orders` requests with a non-JSON 200; the terse log gave no way to tell which window was affected.

Follow-up worth a separate look, not addressed here: each failed response emits the parse error three times, i.e. the response body appears to be decoded three times per read.

## Test plan

- New unit tests in `unit_tests/sources/declarative/decoders/test_json_decoder.py` cover an empty 200 body, an HTML 200 body, secret filtering of URL and body, and the empty-JSON-array case asserting no log output.
- `pytest unit_tests/sources/declarative/decoders/test_json_decoder.py` → 10 passed; `ruff check`, `ruff format --check`, and `mypy airbyte_cdk` all clean.
- Verified end to end by running the real `source-woocommerce` manifest through `source-declarative-manifest read` against a local mock serving `HTTP 200` with an empty body and with `<html>error</html>`: both produce the new line, both still exit 0 with 0 records and an unchanged cursor.


Link to Devin session: https://app.devin.ai/sessions/d3561474f87e49e782f680f809784497
Requested by: @Airbyte-Support