### PR TITLE
fix(declarative): detect gzip payloads in GzipParser instead of trusting headers

### DIFF
--- a/airbyte_cdk/sources/declarative/decoders/composite_raw_decoder.py
+++ b/airbyte_cdk/sources/declarative/decoders/composite_raw_decoder.py
@@ -34,6 +34,7 @@ class _PrefixedStream(io.RawIOBase):
     """Restore consumed header bytes ahead of the remaining stream."""
 
     def __init__(self, prefix: bytes, stream: BufferedIOBase) -> None:
+        super().__init__()
         self._prefix = prefix
         self._stream = stream
 

--- a/airbyte_cdk/sources/declarative/decoders/composite_raw_decoder.py
+++ b/airbyte_cdk/sources/declarative/decoders/composite_raw_decoder.py
@@ -31,6 +31,8 @@ logger = logging.getLogger("airbyte")
 
 
 class _PrefixedStream(io.RawIOBase):
+    """Restore consumed header bytes ahead of the remaining stream."""
+
     def __init__(self, prefix: bytes, stream: BufferedIOBase) -> None:
         self._prefix = prefix
         self._stream = stream
@@ -69,7 +71,12 @@ class GzipParser(Parser):
         Yields:
             Records parsed by the inner parser.
         """
-        prefix = data.read(2)
+        prefix = b""
+        while len(prefix) < 2:
+            chunk = data.read(2 - len(prefix))
+            if not chunk:
+                break
+            prefix += chunk
         prefixed_data = io.BufferedReader(_PrefixedStream(prefix, data))
 
         if prefix == b"\x1f\x8b":

--- a/airbyte_cdk/sources/declarative/decoders/composite_raw_decoder.py
+++ b/airbyte_cdk/sources/declarative/decoders/composite_raw_decoder.py
@@ -15,6 +15,7 @@ from typing import Any, List, Optional
 import ijson
 import orjson
 import requests
+from typing_extensions import Buffer
 
 from airbyte_cdk.models import FailureType
 from airbyte_cdk.sources.declarative.decoders.decoder import DECODER_OUTPUT_TYPE, Decoder
@@ -29,23 +30,53 @@ from airbyte_cdk.utils import AirbyteTracedException
 logger = logging.getLogger("airbyte")
 
 
+class _PrefixedStream(io.RawIOBase):
+    def __init__(self, prefix: bytes, stream: BufferedIOBase) -> None:
+        self._prefix = prefix
+        self._stream = stream
+
+    def readable(self) -> bool:
+        return True
+
+    def readinto(self, buffer: Buffer) -> int:
+        buffer_view = memoryview(buffer)
+        prefix_size = min(len(self._prefix), len(buffer_view))
+        if prefix_size:
+            buffer_view[:prefix_size] = self._prefix[:prefix_size]
+            self._prefix = self._prefix[prefix_size:]
+
+        if prefix_size == len(buffer_view):
+            return prefix_size
+
+        data = self._stream.read(len(buffer_view) - prefix_size)
+        if not data:
+            return prefix_size
+
+        buffer_view[prefix_size : prefix_size + len(data)] = data
+        return prefix_size + len(data)
+
+
 @dataclass
 class GzipParser(Parser):
     inner_parser: Parser
 
     def parse(self, data: BufferedIOBase) -> PARSER_OUTPUT_TYPE:
+        """Decompress gzipped data or pass uncompressed data through unchanged.
+
+        Args:
+            data: A byte stream containing compressed or uncompressed data.
+
+        Yields:
+            Records parsed by the inner parser.
         """
-        Decompress gzipped bytes and pass decompressed data to the inner parser.
+        prefix = data.read(2)
+        prefixed_data = io.BufferedReader(_PrefixedStream(prefix, data))
 
-        IMPORTANT:
-            - If the data is not gzipped, reset the pointer and pass the data to the inner parser as is.
-
-        Note:
-            - The data is not decoded by default.
-        """
-
-        with gzip.GzipFile(fileobj=data, mode="rb") as gzipobj:
-            yield from self.inner_parser.parse(gzipobj)
+        if prefix == b"\x1f\x8b":
+            with gzip.GzipFile(fileobj=prefixed_data, mode="rb") as gzipobj:
+                yield from self.inner_parser.parse(gzipobj)
+        else:
+            yield from self.inner_parser.parse(prefixed_data)
 
 
 @dataclass

--- a/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -2783,15 +2783,12 @@ class ModelToComponentFactory:
         gzip_parser: GzipParser = ModelToComponentFactory._get_parser(model, config)  # type: ignore  # based on the model, we know this will be a GzipParser
 
         if self._emit_connector_builder_messages:
-            # This is very surprising but if the response is not streamed,
-            # CompositeRawDecoder calls response.content and the requests library actually uncompress the data as opposed to response.raw,
-            # which uses urllib3 directly and does not uncompress the data.
-            return CompositeRawDecoder(gzip_parser.inner_parser, False)
+            return CompositeRawDecoder(gzip_parser, False)
 
         return CompositeRawDecoder.by_headers(
             [({"Content-Encoding", "Content-Type"}, _compressed_response_types, gzip_parser)],
             stream_response=True,
-            fallback_parser=gzip_parser.inner_parser,
+            fallback_parser=gzip_parser,
         )
 
     @staticmethod

--- a/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -2785,8 +2785,12 @@ class ModelToComponentFactory:
         if self._emit_connector_builder_messages:
             return CompositeRawDecoder(gzip_parser, False)
 
+        transport_gzip_parser = GzipParser(inner_parser=gzip_parser)
         return CompositeRawDecoder.by_headers(
-            [({"Content-Encoding", "Content-Type"}, _compressed_response_types, gzip_parser)],
+            [
+                ({"Content-Encoding"}, {"gzip"}, transport_gzip_parser),
+                ({"Content-Type"}, _compressed_response_types, gzip_parser),
+            ],
             stream_response=True,
             fallback_parser=gzip_parser,
         )

--- a/unit_tests/sources/declarative/decoders/test_composite_decoder.py
+++ b/unit_tests/sources/declarative/decoders/test_composite_decoder.py
@@ -73,6 +73,42 @@ def generate_csv(
     return csv_data.encode(encoding)
 
 
+class NonSeekableBytesIO(BytesIO):
+    def seekable(self) -> bool:
+        return False
+
+
+def test_gzip_parser_decompresses_gzip_payload():
+    parser = GzipParser(inner_parser=CsvParser())
+
+    assert list(parser.parse(BytesIO(compress_with_gzip("date,units\n2026-08-01,42\n")))) == [
+        {"date": "2026-08-01", "units": "42"}
+    ]
+
+
+@pytest.mark.parametrize("stream_class", [BytesIO, NonSeekableBytesIO])
+def test_gzip_parser_passes_through_non_gzip_payload(stream_class):
+    parser = GzipParser(inner_parser=CsvParser())
+
+    assert list(parser.parse(stream_class(b"date,units\n2026-08-01,42\n"))) == [
+        {"date": "2026-08-01", "units": "42"}
+    ]
+
+
+def test_gzip_parser_handles_empty_payload():
+    parser = GzipParser(inner_parser=CsvParser())
+
+    assert list(parser.parse(BytesIO())) == []
+
+
+def test_nested_gzip_parser_decompresses_single_gzip_payload():
+    parser = GzipParser(inner_parser=GzipParser(inner_parser=CsvParser()))
+
+    assert list(parser.parse(BytesIO(compress_with_gzip("date,units\n2026-08-01,42\n")))) == [
+        {"date": "2026-08-01", "units": "42"}
+    ]
+
+
 @pytest.mark.parametrize("encoding", ["utf-8", "utf", "iso-8859-1"])
 def test_composite_raw_decoder_gzip_csv_parser(requests_mock, encoding: str):
     requests_mock.register_uri(

--- a/unit_tests/sources/declarative/decoders/test_composite_decoder.py
+++ b/unit_tests/sources/declarative/decoders/test_composite_decoder.py
@@ -78,12 +78,27 @@ class NonSeekableBytesIO(BytesIO):
         return False
 
 
+class OneByteAtATimeBytesIO(BytesIO):
+    def read(self, size: int = -1) -> bytes:
+        if size > 0:
+            size = 1
+        return super().read(size)
+
+
 def test_gzip_parser_decompresses_gzip_payload():
     parser = GzipParser(inner_parser=CsvParser())
 
     assert list(parser.parse(BytesIO(compress_with_gzip("date,units\n2026-08-01,42\n")))) == [
         {"date": "2026-08-01", "units": "42"}
     ]
+
+
+def test_gzip_parser_handles_short_reads():
+    parser = GzipParser(inner_parser=CsvParser())
+
+    assert list(
+        parser.parse(OneByteAtATimeBytesIO(compress_with_gzip("date,units\n2026-08-01,42\n")))
+    ) == [{"date": "2026-08-01", "units": "42"}]
 
 
 @pytest.mark.parametrize("stream_class", [BytesIO, NonSeekableBytesIO])

--- a/unit_tests/sources/declarative/decoders/test_composite_decoder.py
+++ b/unit_tests/sources/declarative/decoders/test_composite_decoder.py
@@ -3,6 +3,7 @@
 #
 import csv
 import gzip
+import io
 import json
 import socket
 from http.server import BaseHTTPRequestHandler, HTTPServer
@@ -77,6 +78,12 @@ class NonSeekableBytesIO(BytesIO):
     def seekable(self) -> bool:
         return False
 
+    def seek(self, *args, **kwargs) -> int:
+        raise io.UnsupportedOperation("seek")
+
+    def tell(self) -> int:
+        raise io.UnsupportedOperation("tell")
+
 
 class OneByteAtATimeBytesIO(BytesIO):
     def read(self, size: int = -1) -> bytes:
@@ -85,10 +92,11 @@ class OneByteAtATimeBytesIO(BytesIO):
         return super().read(size)
 
 
-def test_gzip_parser_decompresses_gzip_payload():
+@pytest.mark.parametrize("stream_class", [BytesIO, NonSeekableBytesIO])
+def test_gzip_parser_decompresses_gzip_payload(stream_class):
     parser = GzipParser(inner_parser=CsvParser())
 
-    assert list(parser.parse(BytesIO(compress_with_gzip("date,units\n2026-08-01,42\n")))) == [
+    assert list(parser.parse(stream_class(compress_with_gzip("date,units\n2026-08-01,42\n")))) == [
         {"date": "2026-08-01", "units": "42"}
     ]
 

--- a/unit_tests/sources/declarative/parsers/test_model_to_component_factory.py
+++ b/unit_tests/sources/declarative/parsers/test_model_to_component_factory.py
@@ -293,6 +293,35 @@ def test_create_gzip_decoder_handles_compressed_response(
         headers=headers,
         status=200,
         preload_content=False,
+        decode_content=False,
+    )
+
+    model = GzipDecoderModel(
+        type="GzipDecoder",
+        decoder=CsvDecoderModel(type="CsvDecoder"),
+    )
+    decoder = ModelToComponentFactory(
+        emit_connector_builder_messages=emit_connector_builder_messages
+    ).create_gzip_decoder(model, {})
+
+    assert list(decoder.decode(response)) == [{"date": "2026-08-01", "units": "42"}]
+
+
+@pytest.mark.parametrize("emit_connector_builder_messages", [False, True])
+def test_create_gzip_decoder_handles_transport_and_content_gzip(
+    emit_connector_builder_messages: bool,
+):
+    csv_data = b"date,units\n2026-08-01,42\n"
+    headers = {"Content-Encoding": "gzip", "Content-Type": "application/gzip"}
+    response = requests.Response()
+    response.status_code = 200
+    response.headers.update(headers)
+    response.raw = HTTPResponse(
+        body=io.BytesIO(gzip.compress(gzip.compress(csv_data))),
+        headers=headers,
+        status=200,
+        preload_content=False,
+        decode_content=False,
     )
 
     model = GzipDecoderModel(

--- a/unit_tests/sources/declarative/parsers/test_model_to_component_factory.py
+++ b/unit_tests/sources/declarative/parsers/test_model_to_component_factory.py
@@ -1,6 +1,8 @@
 #
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
+import gzip
+import io
 import json
 import logging
 from copy import deepcopy
@@ -22,6 +24,7 @@ from airbyte_protocol_dataclasses.models.airbyte_protocol import (
 )
 from freezegun.api import FakeDatetime
 from pydantic.v1 import ValidationError
+from urllib3 import HTTPResponse
 
 from airbyte_cdk.legacy.sources.declarative.declarative_stream import DeclarativeStream
 from airbyte_cdk.legacy.sources.declarative.incremental import DatetimeBasedCursor
@@ -97,10 +100,16 @@ from airbyte_cdk.sources.declarative.models.declarative_component_schema import 
     ConstantBackoffStrategy as ConstantBackoffStrategyModel,
 )
 from airbyte_cdk.sources.declarative.models.declarative_component_schema import (
+    CsvDecoder as CsvDecoderModel,
+)
+from airbyte_cdk.sources.declarative.models.declarative_component_schema import (
     CustomRequester as CustomRequesterModel,
 )
 from airbyte_cdk.sources.declarative.models.declarative_component_schema import (
     ExponentialBackoffStrategy as ExponentialBackoffStrategyModel,
+)
+from airbyte_cdk.sources.declarative.models.declarative_component_schema import (
+    GzipDecoder as GzipDecoderModel,
 )
 from airbyte_cdk.sources.declarative.models.declarative_component_schema import (
     OffsetIncrement as OffsetIncrementModel,
@@ -259,6 +268,42 @@ def test_create_check_stream():
 
     assert isinstance(check, CheckStream)
     assert check.stream_names == ["list_stream"]
+
+
+@pytest.mark.parametrize(
+    "headers",
+    [
+        {"Content-Type": "application/gzip"},
+        {"Content-Type": "application/x-gzip"},
+        {"Content-Type": "text/csv"},
+        {"Content-Type": "binary/octet-stream"},
+        {"Content-Encoding": "gzip"},
+    ],
+)
+@pytest.mark.parametrize("emit_connector_builder_messages", [False, True])
+def test_create_gzip_decoder_handles_compressed_response(
+    headers: Mapping[str, str], emit_connector_builder_messages: bool
+):
+    csv_data = b"date,units\n2026-08-01,42\n"
+    response = requests.Response()
+    response.status_code = 200
+    response.headers.update(headers)
+    response.raw = HTTPResponse(
+        body=io.BytesIO(gzip.compress(csv_data)),
+        headers=headers,
+        status=200,
+        preload_content=False,
+    )
+
+    model = GzipDecoderModel(
+        type="GzipDecoder",
+        decoder=CsvDecoderModel(type="CsvDecoder"),
+    )
+    decoder = ModelToComponentFactory(
+        emit_connector_builder_messages=emit_connector_builder_messages
+    ).create_gzip_decoder(model, {})
+
+    assert list(decoder.decode(response)) == [{"date": "2026-08-01", "units": "42"}]
 
 
 def test_create_component_type_mismatch():


### PR DESCRIPTION
## Summary

Requested by Syed Khadeer (Airbyte support) off Zendesk ticket 18622: a customer's Connector Builder **Test** read of a stream that downloads a gzipped CSV fails with `UnicodeDecodeError: 'utf-8' codec can't decode byte 0x8b in position 1` while a real sync of the same stream succeeds. `0x1f 0x8b` is the gzip magic — compressed bytes are reaching the UTF-8 CSV parser.

Resolves https://github.com/airbytehq/oncall/issues/13362:
- https://github.com/airbytehq/oncall/issues/13362

Cause: `create_gzip_decoder` builds two *different* decoders depending on mode, and neither actually looks at the payload.

```python
if self._emit_connector_builder_messages:      # Builder test read
    return CompositeRawDecoder(gzip_parser.inner_parser, False)   # gunzip step dropped entirely
return CompositeRawDecoder.by_headers(          # real sync
    [({"Content-Encoding", "Content-Type"}, _compressed_response_types, gzip_parser)],
    stream_response=True,
    fallback_parser=gzip_parser.inner_parser,   # no gunzip unless a header matched
)
```

The Builder branch assumed `requests` had already decompressed `response.content`, which only holds for *transport-level* `Content-Encoding: gzip`. When the body is a gzip *payload* (e.g. an S3 `*.csv.gz` download served as `application/gzip` or `binary/octet-stream`, as Apple App Store Connect analytics report segments are), nothing gunzips it in Builder mode. Measured on `main` with a single `GzipDecoder(CsvDecoder)`, against an undecoded raw stream (`decode_content=False`, matching how `requests` constructs `response.raw` in production sync mode):

| payload / headers | sync | Builder test read |
| --- | --- | --- |
| gzip, `Content-Type: application/gzip` | OK | `UnicodeDecodeError` 0x8b |
| gzip, `Content-Type: binary/octet-stream` | `UnicodeDecodeError` 0x8b | `UnicodeDecodeError` 0x8b |
| gzip, `Content-Encoding: gzip` | OK | OK |
| gzip×2, `Content-Encoding: gzip` + `Content-Type: application/gzip` | `UnicodeDecodeError` 0x8b (only one layer stripped) | `UnicodeDecodeError` 0x8b |

(An earlier revision of this table claimed the `Content-Encoding: gzip` sync path raised `BadGzipFile`; that measurement was taken with `decode_content=True`, which pre-decompressed the fixture body — the production raw path succeeded. Corrected per review.)

That asymmetry is why manifests in the wild carry double-nested `GzipDecoder(GzipDecoder(CsvDecoder))` workarounds (`source-amazon-ads` ships one next to a `# TODO Fix me`) — and why the single- vs. double-nesting workarounds are mutually exclusive depending on which header the server returns. Previously reported in airbytehq/oncall#7739, #11173, #11809 and airbytehq/airbyte#56988.

Fix, in two parts:

1. Make `GzipParser` self-detecting — the behavior its own docstring already promised (*"If the data is not gzipped, reset the pointer and pass the data to the inner parser as is"*) but never implemented. `GzipParser.parse` reads the 2-byte header (looping, since `response.raw.read(2)` may short-read), gunzips when it is `\x1f\x8b`, and otherwise hands the inner parser the untouched stream. Because the stream may be non-seekable (`response.raw` in sync mode), the consumed header is restored by wrapping it in a private `_PrefixedStream` (`io.RawIOBase`) inside an `io.BufferedReader`, which keeps it usable by both `gzip.GzipFile` and `CsvParser`'s `TextIOWrapper`.
2. Use it in both modes of `create_gzip_decoder`, treating the HTTP transport layer and the gzip representation as separate layers — a response can validly carry *both* `Content-Encoding: gzip` and `Content-Type: application/gzip`, in which case the sync raw stream holds two gzip layers:

```python
if self._emit_connector_builder_messages:   # requests strips the transport layer via response.content
    return CompositeRawDecoder(gzip_parser, False)

transport_gzip_parser = GzipParser(inner_parser=gzip_parser)   # strips the Content-Encoding layer, then the payload layer
return CompositeRawDecoder.by_headers(
    [
        ({"Content-Encoding"}, {"gzip"}, transport_gzip_parser),
        ({"Content-Type"}, _compressed_response_types, gzip_parser),
    ],
    stream_response=True,
    fallback_parser=gzip_parser,
)
```

A single `GzipDecoder` now works for every combination in the table above, in both modes (pass-through makes the nested parser safe when only one layer is present). Existing double-nested manifests keep working: the inner `GzipParser` sees already-decompressed data and passes it through instead of raising `BadGzipFile`.

## Test plan

- New `GzipParser` unit tests in `unit_tests/sources/declarative/decoders/test_composite_decoder.py`: gzipped payload and non-gzip pass-through, each over both a seekable and a truly non-seekable stream (`seek()`/`tell()` raise `io.UnsupportedOperation`), a stream that returns one byte per `read()`, empty payload, and nested `GzipParser(GzipParser(CsvParser))` over a singly-gzipped body.
- New `create_gzip_decoder` tests in `unit_tests/sources/declarative/parsers/test_model_to_component_factory.py` covering `emit_connector_builder_messages` `True` and `False` against each header shape above, with `preload_content=False, decode_content=False` fixtures matching the production raw path — including the double-layer `Content-Encoding` + `Content-Type` regression case. Builder mode had no coverage at all before.
- `poetry run pytest unit_tests/sources/declarative/decoders/ unit_tests/sources/declarative/parsers/test_model_to_component_factory.py`, `poetry run ruff format --check . && poetry run ruff check .`, `poetry run mypy --config-file mypy.ini airbyte_cdk`.


Link to Devin session: https://app.devin.ai/sessions/3b5024f8f9bf4de88ec1abad6fb688fb

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._