### PR TITLE
fix(http): decide token rotation before a backoff strategy can refuse to wait, and resolve the wait cap at construction

### DIFF
--- a/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -4666,7 +4666,7 @@ definitions:
           - "([-+]?\\d+)"
       max_waiting_time_in_seconds:
         title: Max Waiting Time in Seconds
-        description: Stop the stream instead of waiting, when the value extracted from the header is greater than or equal to this value. Can be a hardcoded number, or a string interpolated from the connector config so that the bound can be changed without a connector release. A value of 0 means never wait.
+        description: Stop the stream instead of waiting, when the value extracted from the header is greater than or equal to this value. Can be a hardcoded number, or a string interpolated from the connector config so that the bound can be changed without a connector release. A value of 0 means never wait. This bound applies only when waiting is the only way forward: if the authenticator holds another credential with quota, the retry rotates to it and neither the wait nor this bound is evaluated.
         anyOf:
           - type: number
           - type: string
@@ -4802,7 +4802,7 @@ definitions:
           - "([-+]?\\d+)"
       max_waiting_time_in_seconds:
         title: Max Waiting Time in Seconds
-        description: Stop the stream instead of waiting, when the wait this strategy computes is longer than this value. The comparison is against the computed wait rather than the raw header, since the header holds an absolute timestamp, and it is applied after `min_wait`, so a cap below the floor still wins -- including for the fallback where the header is absent and `min_wait` supplies the wait on its own. Can be a hardcoded number, or a string interpolated from the connector config so that the bound can be changed without a connector release. A value of 0 means never wait.
+        description: Stop the stream instead of waiting, when the wait this strategy computes is longer than this value. The comparison is against the computed wait rather than the raw header, since the header holds an absolute timestamp, and it is applied after `min_wait`, so a cap below the floor still wins -- including for the fallback where the header is absent and `min_wait` supplies the wait on its own. Can be a hardcoded number, or a string interpolated from the connector config so that the bound can be changed without a connector release. A value of 0 means never wait. This bound applies only when waiting is the only way forward: if the authenticator holds another credential with quota, the retry rotates to it and neither the wait nor this bound is evaluated.
         anyOf:
           - type: number
           - type: string

--- a/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -4666,7 +4666,7 @@ definitions:
           - "([-+]?\\d+)"
       max_waiting_time_in_seconds:
         title: Max Waiting Time in Seconds
-        description: 'Stop the stream instead of waiting, when the value extracted from the header is greater than or equal to this value. Can be a hardcoded number, or a string interpolated from the connector config so that the bound can be changed without a connector release. A value of 0 means never wait. This bound applies only when waiting is the only way forward: if the authenticator holds another credential with quota, the retry rotates to it and neither the wait nor this bound is evaluated.'
+        description: 'Stop the stream instead of waiting, when the value extracted from the header is greater than or equal to this value. Can be a hardcoded number, or a string interpolated from the connector config so that the bound can be changed without a connector release. A value of 0 means never wait. This bound applies only when waiting is the only way forward: when a rate-limited response arrives and the authenticator holds another credential with quota, the retry rotates to it and neither the wait nor this bound is evaluated. Any other retryable error still consults this strategy, spare credential or not.'
         anyOf:
           - type: number
           - type: string
@@ -4802,7 +4802,7 @@ definitions:
           - "([-+]?\\d+)"
       max_waiting_time_in_seconds:
         title: Max Waiting Time in Seconds
-        description: 'Stop the stream instead of waiting, when the wait this strategy computes is longer than this value. The comparison is against the computed wait rather than the raw header, since the header holds an absolute timestamp, and it is applied after `min_wait`, so a cap below the floor still wins -- including for the fallback where the header is absent and `min_wait` supplies the wait on its own. Can be a hardcoded number, or a string interpolated from the connector config so that the bound can be changed without a connector release. A value of 0 means never wait. This bound applies only when waiting is the only way forward: if the authenticator holds another credential with quota, the retry rotates to it and neither the wait nor this bound is evaluated.'
+        description: 'Stop the stream instead of waiting, when the wait this strategy computes is greater than or equal to this value. The comparison is against the computed wait rather than the raw header, since the header holds an absolute timestamp, and it is applied after `min_wait`, so a cap below the floor still wins -- including for the fallback where the header is absent and `min_wait` supplies the wait on its own. Can be a hardcoded number, or a string interpolated from the connector config so that the bound can be changed without a connector release. A value of 0 means never wait. This bound applies only when waiting is the only way forward: when a rate-limited response arrives and the authenticator holds another credential with quota, the retry rotates to it and neither the wait nor this bound is evaluated. Any other retryable error still consults this strategy, spare credential or not.'
         anyOf:
           - type: number
           - type: string

--- a/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -4666,7 +4666,7 @@ definitions:
           - "([-+]?\\d+)"
       max_waiting_time_in_seconds:
         title: Max Waiting Time in Seconds
-        description: 'Stop the stream instead of waiting, when the value extracted from the header is greater than or equal to this value. Can be a hardcoded number, or a string interpolated from the connector config so that the bound can be changed without a connector release. A value of 0 means never wait. This bound applies only when waiting is the only way forward: when a rate-limited response arrives and the authenticator holds another credential with quota, the retry rotates to it and neither the wait nor this bound is evaluated. Any other retryable error still consults this strategy, spare credential or not.'
+        description: 'Stop the stream instead of waiting, when the value extracted from the header is greater than or equal to this value. Can be a hardcoded number, or a string interpolated from the connector config so that the bound can be changed without a connector release. A value of 0 means never wait. Not evaluated when a rate-limited retry can rotate to another credential with quota; any other retryable error still consults this strategy.'
         anyOf:
           - type: number
           - type: string
@@ -4802,7 +4802,7 @@ definitions:
           - "([-+]?\\d+)"
       max_waiting_time_in_seconds:
         title: Max Waiting Time in Seconds
-        description: 'Stop the stream instead of waiting, when the wait this strategy computes is greater than or equal to this value. The comparison is against the computed wait rather than the raw header, since the header holds an absolute timestamp, and it is applied after `min_wait`, so a cap below the floor still wins -- including for the fallback where the header is absent and `min_wait` supplies the wait on its own. Can be a hardcoded number, or a string interpolated from the connector config so that the bound can be changed without a connector release. A value of 0 means never wait. This bound applies only when waiting is the only way forward: when a rate-limited response arrives and the authenticator holds another credential with quota, the retry rotates to it and neither the wait nor this bound is evaluated. Any other retryable error still consults this strategy, spare credential or not.'
+        description: 'Stop the stream instead of waiting, when the wait this strategy computes is greater than or equal to this value. The comparison is against the computed wait rather than the raw header, since the header holds an absolute timestamp, and it is applied after `min_wait`, so a cap below the floor still wins -- including for the fallback where the header is absent and `min_wait` supplies the wait on its own. Can be a hardcoded number, or a string interpolated from the connector config so that the bound can be changed without a connector release. A value of 0 means never wait. Not evaluated when a rate-limited retry can rotate to another credential with quota; any other retryable error still consults this strategy.'
         anyOf:
           - type: number
           - type: string

--- a/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -4666,7 +4666,7 @@ definitions:
           - "([-+]?\\d+)"
       max_waiting_time_in_seconds:
         title: Max Waiting Time in Seconds
-        description: Stop the stream instead of waiting, when the value extracted from the header is greater than or equal to this value. Can be a hardcoded number, or a string interpolated from the connector config so that the bound can be changed without a connector release. A value of 0 means never wait. This bound applies only when waiting is the only way forward: if the authenticator holds another credential with quota, the retry rotates to it and neither the wait nor this bound is evaluated.
+        description: 'Stop the stream instead of waiting, when the value extracted from the header is greater than or equal to this value. Can be a hardcoded number, or a string interpolated from the connector config so that the bound can be changed without a connector release. A value of 0 means never wait. This bound applies only when waiting is the only way forward: if the authenticator holds another credential with quota, the retry rotates to it and neither the wait nor this bound is evaluated.'
         anyOf:
           - type: number
           - type: string
@@ -4802,7 +4802,7 @@ definitions:
           - "([-+]?\\d+)"
       max_waiting_time_in_seconds:
         title: Max Waiting Time in Seconds
-        description: Stop the stream instead of waiting, when the wait this strategy computes is longer than this value. The comparison is against the computed wait rather than the raw header, since the header holds an absolute timestamp, and it is applied after `min_wait`, so a cap below the floor still wins -- including for the fallback where the header is absent and `min_wait` supplies the wait on its own. Can be a hardcoded number, or a string interpolated from the connector config so that the bound can be changed without a connector release. A value of 0 means never wait. This bound applies only when waiting is the only way forward: if the authenticator holds another credential with quota, the retry rotates to it and neither the wait nor this bound is evaluated.
+        description: 'Stop the stream instead of waiting, when the wait this strategy computes is longer than this value. The comparison is against the computed wait rather than the raw header, since the header holds an absolute timestamp, and it is applied after `min_wait`, so a cap below the floor still wins -- including for the fallback where the header is absent and `min_wait` supplies the wait on its own. Can be a hardcoded number, or a string interpolated from the connector config so that the bound can be changed without a connector release. A value of 0 means never wait. This bound applies only when waiting is the only way forward: if the authenticator holds another credential with quota, the retry rotates to it and neither the wait nor this bound is evaluated.'
         anyOf:
           - type: number
           - type: string

--- a/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
+++ b/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
@@ -1449,7 +1449,7 @@ class WaitTimeFromHeader(BaseModel):
     )
     max_waiting_time_in_seconds: Optional[Union[float, str]] = Field(
         None,
-        description="Stop the stream instead of waiting, when the value extracted from the header is greater than or equal to this value. Can be a hardcoded number, or a string interpolated from the connector config so that the bound can be changed without a connector release. A value of 0 means never wait. This bound applies only when waiting is the only way forward: if the authenticator holds another credential with quota, the retry rotates to it and neither the wait nor this bound is evaluated.",
+        description="Stop the stream instead of waiting, when the value extracted from the header is greater than or equal to this value. Can be a hardcoded number, or a string interpolated from the connector config so that the bound can be changed without a connector release. A value of 0 means never wait. This bound applies only when waiting is the only way forward: when a rate-limited response arrives and the authenticator holds another credential with quota, the retry rotates to it and neither the wait nor this bound is evaluated. Any other retryable error still consults this strategy, spare credential or not.",
         examples=[3600, "{{ config['max_waiting_time'] * 60 }}"],
         title="Max Waiting Time in Seconds",
     )
@@ -1478,7 +1478,7 @@ class WaitUntilTimeFromHeader(BaseModel):
     )
     max_waiting_time_in_seconds: Optional[Union[float, str]] = Field(
         None,
-        description="Stop the stream instead of waiting, when the wait this strategy computes is longer than this value. The comparison is against the computed wait rather than the raw header, since the header holds an absolute timestamp, and it is applied after `min_wait`, so a cap below the floor still wins -- including for the fallback where the header is absent and `min_wait` supplies the wait on its own. Can be a hardcoded number, or a string interpolated from the connector config so that the bound can be changed without a connector release. A value of 0 means never wait. This bound applies only when waiting is the only way forward: if the authenticator holds another credential with quota, the retry rotates to it and neither the wait nor this bound is evaluated.",
+        description="Stop the stream instead of waiting, when the wait this strategy computes is greater than or equal to this value. The comparison is against the computed wait rather than the raw header, since the header holds an absolute timestamp, and it is applied after `min_wait`, so a cap below the floor still wins -- including for the fallback where the header is absent and `min_wait` supplies the wait on its own. Can be a hardcoded number, or a string interpolated from the connector config so that the bound can be changed without a connector release. A value of 0 means never wait. This bound applies only when waiting is the only way forward: when a rate-limited response arrives and the authenticator holds another credential with quota, the retry rotates to it and neither the wait nor this bound is evaluated. Any other retryable error still consults this strategy, spare credential or not.",
         examples=[3600, "{{ config['max_waiting_time'] * 60 }}"],
         title="Max Waiting Time in Seconds",
     )

--- a/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
+++ b/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
@@ -1449,7 +1449,7 @@ class WaitTimeFromHeader(BaseModel):
     )
     max_waiting_time_in_seconds: Optional[Union[float, str]] = Field(
         None,
-        description="Stop the stream instead of waiting, when the value extracted from the header is greater than or equal to this value. Can be a hardcoded number, or a string interpolated from the connector config so that the bound can be changed without a connector release. A value of 0 means never wait.",
+        description="Stop the stream instead of waiting, when the value extracted from the header is greater than or equal to this value. Can be a hardcoded number, or a string interpolated from the connector config so that the bound can be changed without a connector release. A value of 0 means never wait. This bound applies only when waiting is the only way forward: if the authenticator holds another credential with quota, the retry rotates to it and neither the wait nor this bound is evaluated.",
         examples=[3600, "{{ config['max_waiting_time'] * 60 }}"],
         title="Max Waiting Time in Seconds",
     )
@@ -1478,7 +1478,7 @@ class WaitUntilTimeFromHeader(BaseModel):
     )
     max_waiting_time_in_seconds: Optional[Union[float, str]] = Field(
         None,
-        description="Stop the stream instead of waiting, when the wait this strategy computes is longer than this value. The comparison is against the computed wait rather than the raw header, since the header holds an absolute timestamp, and it is applied after `min_wait`, so a cap below the floor still wins -- including for the fallback where the header is absent and `min_wait` supplies the wait on its own. Can be a hardcoded number, or a string interpolated from the connector config so that the bound can be changed without a connector release. A value of 0 means never wait.",
+        description="Stop the stream instead of waiting, when the wait this strategy computes is longer than this value. The comparison is against the computed wait rather than the raw header, since the header holds an absolute timestamp, and it is applied after `min_wait`, so a cap below the floor still wins -- including for the fallback where the header is absent and `min_wait` supplies the wait on its own. Can be a hardcoded number, or a string interpolated from the connector config so that the bound can be changed without a connector release. A value of 0 means never wait. This bound applies only when waiting is the only way forward: if the authenticator holds another credential with quota, the retry rotates to it and neither the wait nor this bound is evaluated.",
         examples=[3600, "{{ config['max_waiting_time'] * 60 }}"],
         title="Max Waiting Time in Seconds",
     )

--- a/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
+++ b/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
@@ -1449,7 +1449,7 @@ class WaitTimeFromHeader(BaseModel):
     )
     max_waiting_time_in_seconds: Optional[Union[float, str]] = Field(
         None,
-        description="Stop the stream instead of waiting, when the value extracted from the header is greater than or equal to this value. Can be a hardcoded number, or a string interpolated from the connector config so that the bound can be changed without a connector release. A value of 0 means never wait. This bound applies only when waiting is the only way forward: when a rate-limited response arrives and the authenticator holds another credential with quota, the retry rotates to it and neither the wait nor this bound is evaluated. Any other retryable error still consults this strategy, spare credential or not.",
+        description="Stop the stream instead of waiting, when the value extracted from the header is greater than or equal to this value. Can be a hardcoded number, or a string interpolated from the connector config so that the bound can be changed without a connector release. A value of 0 means never wait. Not evaluated when a rate-limited retry can rotate to another credential with quota; any other retryable error still consults this strategy.",
         examples=[3600, "{{ config['max_waiting_time'] * 60 }}"],
         title="Max Waiting Time in Seconds",
     )
@@ -1478,7 +1478,7 @@ class WaitUntilTimeFromHeader(BaseModel):
     )
     max_waiting_time_in_seconds: Optional[Union[float, str]] = Field(
         None,
-        description="Stop the stream instead of waiting, when the wait this strategy computes is greater than or equal to this value. The comparison is against the computed wait rather than the raw header, since the header holds an absolute timestamp, and it is applied after `min_wait`, so a cap below the floor still wins -- including for the fallback where the header is absent and `min_wait` supplies the wait on its own. Can be a hardcoded number, or a string interpolated from the connector config so that the bound can be changed without a connector release. A value of 0 means never wait. This bound applies only when waiting is the only way forward: when a rate-limited response arrives and the authenticator holds another credential with quota, the retry rotates to it and neither the wait nor this bound is evaluated. Any other retryable error still consults this strategy, spare credential or not.",
+        description="Stop the stream instead of waiting, when the wait this strategy computes is greater than or equal to this value. The comparison is against the computed wait rather than the raw header, since the header holds an absolute timestamp, and it is applied after `min_wait`, so a cap below the floor still wins -- including for the fallback where the header is absent and `min_wait` supplies the wait on its own. Can be a hardcoded number, or a string interpolated from the connector config so that the bound can be changed without a connector release. A value of 0 means never wait. Not evaluated when a rate-limited retry can rotate to another credential with quota; any other retryable error still consults this strategy.",
         examples=[3600, "{{ config['max_waiting_time'] * 60 }}"],
         title="Max Waiting Time in Seconds",
     )

--- a/airbyte_cdk/sources/declarative/requesters/error_handlers/backoff_strategies/max_waiting_time_helper.py
+++ b/airbyte_cdk/sources/declarative/requesters/error_handlers/backoff_strategies/max_waiting_time_helper.py
@@ -42,12 +42,13 @@ def evaluate_max_waiting_time(
     check would silently disable it. Only an absent field means "no cap"; a field that is present
     but resolves to nothing raises, rather than quietly leaving the wait unbounded.
 
-    A cap is only read while handling an error the requester is already going to retry, so an
-    interpolation that cannot be resolved would otherwise surface as an unhandled jinja
-    UndefinedError or ValueError in the middle of a sync that has been running fine. It is raised
-    as a system error rather than a config error because the field lives in the manifest: whether
-    it is a bad expression or a config key the manifest reads but the spec does not expose, the
-    connector is at fault and there is nothing for the user to correct.
+    Called once when the strategy is constructed, and again on each cap check. The eager call is
+    what makes an unresolvable interpolation a startup failure rather than something discovered at
+    whichever retryable error happens to reach a strategy -- a distinction that matters because
+    `HttpClient` skips the strategies entirely when a rate-limited retry can rotate credentials.
+    It is raised as a system error rather than a config error because the field lives in the
+    manifest: whether it is a bad expression or a config key the manifest reads but the spec does
+    not expose, the connector is at fault and there is nothing for the user to correct.
 
     :param max_waiting_time_in_seconds: the interpolated field, or None when no cap is configured
     :param config: the connector config to interpolate against

--- a/airbyte_cdk/sources/declarative/requesters/error_handlers/backoff_strategies/wait_time_from_header_backoff_strategy.py
+++ b/airbyte_cdk/sources/declarative/requesters/error_handlers/backoff_strategies/wait_time_from_header_backoff_strategy.py
@@ -54,6 +54,12 @@ class WaitTimeFromHeaderBackoffStrategy(BackoffStrategy):
         self._max_waiting_time_in_seconds = interpolated_max_waiting_time(
             self.max_waiting_time_in_seconds, parameters
         )
+        # Resolved here rather than only at the first retryable error. `config` is a field and this
+        # cap interpolates over `config` alone, so it is fully knowable the moment the component
+        # exists -- and since `HttpClient` decides token rotation before it asks a strategy for a
+        # wait, a cap that cannot be evaluated would otherwise stay silent for as long as a spare
+        # credential keeps the strategies from running. A manifest mistake belongs at startup.
+        evaluate_max_waiting_time(self._max_waiting_time_in_seconds, self.config)
 
     def backoff_time(
         self,

--- a/airbyte_cdk/sources/declarative/requesters/error_handlers/backoff_strategies/wait_time_from_header_backoff_strategy.py
+++ b/airbyte_cdk/sources/declarative/requesters/error_handlers/backoff_strategies/wait_time_from_header_backoff_strategy.py
@@ -33,7 +33,9 @@ class WaitTimeFromHeaderBackoffStrategy(BackoffStrategy):
         header (str): header to read wait time from
         regex (Optional[str]): optional regex to apply on the header to extract its value
         max_waiting_time_in_seconds (Optional[Union[float, InterpolatedString, str]]): stop the stream
-            rather than wait longer than this
+            rather than wait longer than this. Only governs waits that are actually taken: when
+            the authenticator holds another credential with quota, `HttpClient` rotates onto it
+            instead of asking this strategy for a wait, and the bound does not apply.
     """
 
     header: Union[InterpolatedString, str]
@@ -68,10 +70,14 @@ class WaitTimeFromHeaderBackoffStrategy(BackoffStrategy):
             max_waiting_time = evaluate_max_waiting_time(
                 self._max_waiting_time_in_seconds, self.config
             )
+            # Not always reached: `HttpClient` decides token rotation before it asks a strategy
+            # for a wait, so on a rate limit where the authenticator has another credential with
+            # quota this check does not run. The cap bounds waiting, and that path is not
+            # waiting.
             # `max_waiting_time is not None` rather than a truthiness check, so that 0 means
             # "never wait" instead of silently disabling the cap. The comparison stays `>=`,
-            # which is what this cap has always done; `WaitUntilTimeFromHeader` stops at `>`,
-            # so a wait exactly equal to the cap is allowed there and refused here.
+            # which is what this cap has always done, and `WaitUntilTimeFromHeader` matches it --
+            # a wait exactly equal to the cap is refused by both.
             # `header_value` is checked for truthiness rather than `is not None` on purpose: a
             # header of `0` asks for no wait at all, which no cap -- not even 0 -- should refuse.
             if max_waiting_time is not None and header_value and header_value >= max_waiting_time:

--- a/airbyte_cdk/sources/declarative/requesters/error_handlers/backoff_strategies/wait_time_from_header_backoff_strategy.py
+++ b/airbyte_cdk/sources/declarative/requesters/error_handlers/backoff_strategies/wait_time_from_header_backoff_strategy.py
@@ -33,9 +33,11 @@ class WaitTimeFromHeaderBackoffStrategy(BackoffStrategy):
         header (str): header to read wait time from
         regex (Optional[str]): optional regex to apply on the header to extract its value
         max_waiting_time_in_seconds (Optional[Union[float, InterpolatedString, str]]): stop the stream
-            rather than wait longer than this. Only governs waits that are actually taken: when
-            the authenticator holds another credential with quota, `HttpClient` rotates onto it
-            instead of asking this strategy for a wait, and the bound does not apply.
+            rather than wait this long or longer -- the bound is inclusive, so a wait exactly
+            equal to it is refused. Only governs waits that are actually taken: on a
+            rate-limited response where the authenticator holds another credential with quota,
+            `HttpClient` rotates onto it instead of asking this strategy for a wait, and the
+            bound does not apply. Any other retryable error still consults this strategy.
     """
 
     header: Union[InterpolatedString, str]

--- a/airbyte_cdk/sources/declarative/requesters/error_handlers/backoff_strategies/wait_until_time_from_header_backoff_strategy.py
+++ b/airbyte_cdk/sources/declarative/requesters/error_handlers/backoff_strategies/wait_until_time_from_header_backoff_strategy.py
@@ -36,7 +36,9 @@ class WaitUntilTimeFromHeaderBackoffStrategy(BackoffStrategy):
         min_wait (Optional[Union[float, InterpolatedString, str]]): minimum time to wait for safety
         regex (Optional[str]): optional regex to apply on the header to extract its value
         max_waiting_time_in_seconds (Optional[Union[float, InterpolatedString, str]]): stop the stream
-            rather than wait longer than this
+            rather than wait longer than this. Only governs waits that are actually taken: when
+            the authenticator holds another credential with quota, `HttpClient` rotates onto it
+            instead of asking this strategy for a wait, and the bound does not apply.
     """
 
     header: Union[InterpolatedString, str]

--- a/airbyte_cdk/sources/declarative/requesters/error_handlers/backoff_strategies/wait_until_time_from_header_backoff_strategy.py
+++ b/airbyte_cdk/sources/declarative/requesters/error_handlers/backoff_strategies/wait_until_time_from_header_backoff_strategy.py
@@ -36,9 +36,11 @@ class WaitUntilTimeFromHeaderBackoffStrategy(BackoffStrategy):
         min_wait (Optional[Union[float, InterpolatedString, str]]): minimum time to wait for safety
         regex (Optional[str]): optional regex to apply on the header to extract its value
         max_waiting_time_in_seconds (Optional[Union[float, InterpolatedString, str]]): stop the stream
-            rather than wait longer than this. Only governs waits that are actually taken: when
-            the authenticator holds another credential with quota, `HttpClient` rotates onto it
-            instead of asking this strategy for a wait, and the bound does not apply.
+            rather than wait this long or longer -- the bound is inclusive, so a wait exactly
+            equal to it is refused. Only governs waits that are actually taken: on a
+            rate-limited response where the authenticator holds another credential with quota,
+            `HttpClient` rotates onto it instead of asking this strategy for a wait, and the
+            bound does not apply. Any other retryable error still consults this strategy.
     """
 
     header: Union[InterpolatedString, str]
@@ -86,7 +88,7 @@ class WaitUntilTimeFromHeaderBackoffStrategy(BackoffStrategy):
         return self._capped(wait_time)
 
     def _capped(self, wait_time: float) -> float:
-        """Raise rather than wait longer than `max_waiting_time_in_seconds`.
+        """Raise rather than wait `max_waiting_time_in_seconds` or longer.
 
         The cap is compared against the wait this strategy is about to return, not against the
         raw header: unlike `Retry-After`, the header here is an absolute timestamp, so only the
@@ -106,8 +108,8 @@ class WaitUntilTimeFromHeaderBackoffStrategy(BackoffStrategy):
         if max_waiting_time is not None and wait_time >= max_waiting_time:
             raise AirbyteTracedException(
                 internal_message=(
-                    f"Rate limit wait time {wait_time}s is greater than the maximum of "
-                    f"{max_waiting_time}s this stream is allowed to wait. Stopping the stream..."
+                    f"Rate limit wait time {wait_time}s is greater than or equal to the maximum "
+                    f"of {max_waiting_time}s this stream is allowed to wait. Stopping the stream..."
                 ),
                 message="The rate limit wait time is longer than the connector is allowed to wait.",
                 failure_type=FailureType.transient_error,

--- a/airbyte_cdk/sources/declarative/requesters/error_handlers/backoff_strategies/wait_until_time_from_header_backoff_strategy.py
+++ b/airbyte_cdk/sources/declarative/requesters/error_handlers/backoff_strategies/wait_until_time_from_header_backoff_strategy.py
@@ -60,6 +60,12 @@ class WaitUntilTimeFromHeaderBackoffStrategy(BackoffStrategy):
         self._max_waiting_time_in_seconds = interpolated_max_waiting_time(
             self.max_waiting_time_in_seconds, parameters
         )
+        # Resolved here rather than only at the first retryable error. `config` is a field and this
+        # cap interpolates over `config` alone, so it is fully knowable the moment the component
+        # exists -- and since `HttpClient` decides token rotation before it asks a strategy for a
+        # wait, a cap that cannot be evaluated would otherwise stay silent for as long as a spare
+        # credential keeps the strategies from running. A manifest mistake belongs at startup.
+        evaluate_max_waiting_time(self._max_waiting_time_in_seconds, self.config)
 
     def backoff_time(
         self,

--- a/airbyte_cdk/sources/declarative/requesters/error_handlers/backoff_strategies/wait_until_time_from_header_backoff_strategy.py
+++ b/airbyte_cdk/sources/declarative/requesters/error_handlers/backoff_strategies/wait_until_time_from_header_backoff_strategy.py
@@ -91,6 +91,11 @@ class WaitUntilTimeFromHeaderBackoffStrategy(BackoffStrategy):
         computed difference is a duration. It is also applied after the `min_wait` floor, so a
         cap below the floor wins -- a caller asking never to wait more than N seconds means it,
         even when the floor would otherwise round the wait up past N.
+
+        Not always reached: `HttpClient` decides token rotation before it asks a strategy for a
+        wait, so on a rate limit where the authenticator has another credential with quota this
+        method does not run and the cap does not apply. Waiting is what the cap bounds, and that
+        path is not waiting.
         """
         max_waiting_time = evaluate_max_waiting_time(self._max_waiting_time_in_seconds, self.config)
         # `>=` rather than `>` to match WaitTimeFromHeader, so one field name does not mean two

--- a/airbyte_cdk/sources/streams/http/error_handlers/backoff_strategy.py
+++ b/airbyte_cdk/sources/streams/http/error_handlers/backoff_strategy.py
@@ -18,7 +18,12 @@ class BackoffStrategy(ABC):
         """
         Override this method to dynamically determine backoff time e.g: by reading the X-Retry-After header.
 
-        This method is called only if should_backoff() returns True for the input request.
+        Not called for every retryable response. `HttpClient` skips the strategies entirely when a
+        rate-limited response can be retried on another credential -- the authenticator says so via
+        `TokenRotatingAuthenticator.has_alternative_token` -- because the wait computed here is
+        derived from the credential that was rejected, and the retry will not use it. Implementations
+        must therefore not rely on being called for side effects such as counting attempts or
+        emitting metrics.
 
         :param response_or_exception: The response or exception that caused the backoff.
         :param attempt_count: The number of attempts already performed for this request.

--- a/airbyte_cdk/sources/streams/http/http_client.py
+++ b/airbyte_cdk/sources/streams/http/http_client.py
@@ -594,16 +594,31 @@ class HttpClient:
             # raising (`max_waiting_time_in_seconds`), which would otherwise end the stream
             # before rotation was ever considered. Rotating is strictly the better outcome
             # there: it is the same retry, seconds from now, on a credential with quota.
+            #
+            # Two consequences of not calling the strategies, both deliberate. A rate limit
+            # that yields no backoff at all now rotates too, rather than falling through to
+            # the default exponential retry -- on a rotating credential that is the better
+            # behaviour, and `has_alternative_token` only answers True when the sending
+            # credential is tracked and spent. And a `max_waiting_time_in_seconds` the manifest
+            # got wrong -- one that cannot be evaluated -- is no longer reported here, since
+            # that error is raised from inside the strategy; it still surfaces on the first
+            # rate limit that finds no spare credential. Resolving the cap once at construction
+            # would close that gap on every path, but it moves when `max_waiting_time_in_seconds`
+            # fails, so it belongs in its own change rather than in this reorder.
             rotate_instead_of_waiting = (
                 error_resolution.response_action == ResponseAction.RATE_LIMITED
                 and self._can_retry_on_another_token(request)
             )
 
             if rotate_instead_of_waiting:
+                # Says that a wait was skipped without the number, which is no longer computed,
+                # and names the cap explicitly: a connector that configured one gets no other
+                # signal that the retry went ahead without consulting it.
                 self._logger.info(
-                    f"Rate limited on the current credential; retrying in "
-                    f"{self.TOKEN_ROTATION_BACKOFF}s with another one instead of waiting for "
-                    f"the rate limit to reset."
+                    "Rate limited on the current credential; retrying in "
+                    f"{self.TOKEN_ROTATION_BACKOFF}s with another one instead of waiting for the "
+                    "rate limit to reset. Any configured backoff, including a wait cap, is not "
+                    "evaluated for this retry."
                 )
                 user_defined_backoff_time = self.TOKEN_ROTATION_BACKOFF
             else:

--- a/airbyte_cdk/sources/streams/http/http_client.py
+++ b/airbyte_cdk/sources/streams/http/http_client.py
@@ -588,29 +588,33 @@ class HttpClient:
             ResponseAction.REFRESH_TOKEN_THEN_RETRY,
         ):
             user_defined_backoff_time = None
-            for backoff_strategy in self._backoff_strategies:
-                backoff_time = backoff_strategy.backoff_time(
-                    response_or_exception=response if response is not None else exc,
-                    attempt_count=self._request_attempt_count[request],
-                )
-                if backoff_time:
-                    user_defined_backoff_time = backoff_time
-                    break
-
-            if (
-                user_defined_backoff_time
-                and error_resolution.response_action == ResponseAction.RATE_LIMITED
+            # Asked before the strategies, not after. The backoff they compute describes the
+            # credential the server just rejected, so when another credential can serve the
+            # retry that wait is irrelevant -- and a strategy is allowed to refuse a wait by
+            # raising (`max_waiting_time_in_seconds`), which would otherwise end the stream
+            # before rotation was ever considered. Rotating is strictly the better outcome
+            # there: it is the same retry, seconds from now, on a credential with quota.
+            rotate_instead_of_waiting = (
+                error_resolution.response_action == ResponseAction.RATE_LIMITED
                 and self._can_retry_on_another_token(request)
-            ):
-                # The backoff was derived from this response's headers, which only describe the
-                # credential that was rejected. Another one has quota, and the retry re-signs the
-                # request, so waiting out this window would idle for nothing.
+            )
+
+            if rotate_instead_of_waiting:
                 self._logger.info(
                     f"Rate limited on the current credential; retrying in "
-                    f"{self.TOKEN_ROTATION_BACKOFF}s with another one instead of waiting "
-                    f"{user_defined_backoff_time:.0f}s for the rate limit to reset."
+                    f"{self.TOKEN_ROTATION_BACKOFF}s with another one instead of waiting for "
+                    f"the rate limit to reset."
                 )
                 user_defined_backoff_time = self.TOKEN_ROTATION_BACKOFF
+            else:
+                for backoff_strategy in self._backoff_strategies:
+                    backoff_time = backoff_strategy.backoff_time(
+                        response_or_exception=response if response is not None else exc,
+                        attempt_count=self._request_attempt_count[request],
+                    )
+                    if backoff_time:
+                        user_defined_backoff_time = backoff_time
+                        break
 
             error_message = (
                 error_resolution.error_message

--- a/airbyte_cdk/sources/streams/http/http_client.py
+++ b/airbyte_cdk/sources/streams/http/http_client.py
@@ -598,13 +598,13 @@ class HttpClient:
             # Two consequences of not calling the strategies, both deliberate. A rate limit
             # that yields no backoff at all now rotates too, rather than falling through to
             # the default exponential retry -- on a rotating credential that is the better
-            # behaviour, and `has_alternative_token` only answers True when the sending
-            # credential is tracked and spent. And a `max_waiting_time_in_seconds` the manifest
-            # got wrong -- one that cannot be evaluated -- is no longer reported here, since
-            # that error is raised from inside the strategy; it still surfaces on the first
-            # rate limit that finds no spare credential. Resolving the cap once at construction
-            # would close that gap on every path, but it moves when `max_waiting_time_in_seconds`
-            # fails, so it belongs in its own change rather than in this reorder.
+            # behaviour, and `has_alternative_token` only answers True when the retry will
+            # rotate -- the CDK's own authenticator narrows that further, to a sending credential
+            # that is tracked and spent. And a `max_waiting_time_in_seconds` the manifest got
+            # wrong -- one that cannot be evaluated -- is not reported from here, since that
+            # error is raised from inside the strategy. Both capped strategies therefore resolve
+            # the field once in `__post_init__` too, so a manifest mistake fails at startup
+            # rather than waiting for a rate limit that finds no spare credential.
             rotate_instead_of_waiting = (
                 error_resolution.response_action == ResponseAction.RATE_LIMITED
                 and self._can_retry_on_another_token(request)

--- a/unit_tests/sources/declarative/requesters/error_handlers/backoff_strategies/test_wait_time_from_header.py
+++ b/unit_tests/sources/declarative/requesters/error_handlers/backoff_strategies/test_wait_time_from_header.py
@@ -137,13 +137,13 @@ def test_max_waiting_time_is_interpolated_from_config(config, expected):
 def test_given_max_waiting_time_cannot_be_evaluated_then_raise_system_error(
     max_waiting_time_in_seconds, config
 ):
-    """The cap is only read while handling an error that was already going to be retried, so an
-    unresolvable interpolation must not surface as an unhandled jinja or float error. It is a
-    system error because the field is declared in the manifest: the user has nothing to fix."""
-    strategy = _strategy(max_waiting_time_in_seconds, config=config)
-
+    """Raised when the strategy is built, not when a retry first needs the cap. Waiting for a
+    retryable error would mean never raising at all on a connector whose rate limits are always
+    served by rotating to another credential, since `HttpClient` skips the strategies there. It
+    is a system error because the field is declared in the manifest: the user has nothing to fix,
+    and an unresolvable interpolation must not surface as a raw jinja or float error either."""
     with pytest.raises(AirbyteTracedException) as exc_info:
-        strategy.backoff_time(_response(120), 1)
+        _strategy(max_waiting_time_in_seconds, config=config)
     assert exc_info.value.failure_type == FailureType.system_error
     assert "max_waiting_time_in_seconds" in exc_info.value.internal_message
 
@@ -169,20 +169,17 @@ def test_given_header_asks_for_no_wait_then_no_cap_refuses_it(max_waiting_time_i
 )
 def test_given_max_waiting_time_resolves_to_nothing_then_raise_rather_than_drop_the_cap(config):
     """A blank config value must not leave the wait unbounded: "no cap" is spelled by leaving the
-    field out of the manifest, so a field that is present and resolves to nothing is a failure."""
-    strategy = _strategy("{{ config['max_waiting_time'] }}", config=config)
-
+    field out of the manifest, so a field that is present and resolves to nothing is a failure --
+    at construction, before any request has been sent."""
     with pytest.raises(AirbyteTracedException) as exc_info:
-        strategy.backoff_time(_response(120), 1)
+        _strategy("{{ config['max_waiting_time'] }}", config=config)
     assert exc_info.value.failure_type == FailureType.system_error
 
 
 def test_given_interpolation_raises_a_traced_error_then_keep_its_own_failure_type_and_message():
     """`stream_state` interpolation raises an AirbyteTracedException of its own, with a message
     written for that case. The cap's own error handling must not reclassify or replace it."""
-    strategy = _strategy("{{ stream_state['max_waiting_time'] }}")
-
     with pytest.raises(AirbyteTracedException) as exc_info:
-        strategy.backoff_time(_response(120), 1)
+        _strategy("{{ stream_state['max_waiting_time'] }}")
     assert exc_info.value.failure_type == FailureType.config_error
     assert "`stream_state` is no longer supported for interpolation" in exc_info.value.message

--- a/unit_tests/sources/declarative/requesters/error_handlers/backoff_strategies/test_wait_until_time_from_header.py
+++ b/unit_tests/sources/declarative/requesters/error_handlers/backoff_strategies/test_wait_until_time_from_header.py
@@ -233,13 +233,13 @@ def test_cap_is_interpolated_from_config(time_mock, config, expected):
 def test_given_cap_cannot_be_evaluated_then_raise_system_error(
     time_mock, max_waiting_time_in_seconds, config
 ):
-    """The cap is only read while handling an error that was already going to be retried, so an
-    unresolvable interpolation must not surface as an unhandled jinja or float error. It is a
-    system error because the field is declared in the manifest: the user has nothing to fix."""
-    strategy = _strategy(max_waiting_time_in_seconds, config=config)
-
+    """Raised when the strategy is built, not when a retry first needs the cap. Waiting for a
+    retryable error would mean never raising at all on a connector whose rate limits are always
+    served by rotating to another credential, since `HttpClient` skips the strategies there. It
+    is a system error because the field is declared in the manifest: the user has nothing to fix,
+    and an unresolvable interpolation must not surface as a raw jinja or float error either."""
     with pytest.raises(AirbyteTracedException) as exc_info:
-        strategy.backoff_time(_response(), 1)
+        _strategy(max_waiting_time_in_seconds, config=config)
     assert exc_info.value.failure_type == FailureType.system_error
     assert "max_waiting_time_in_seconds" in exc_info.value.internal_message
 
@@ -253,9 +253,8 @@ def test_non_finite_cap_is_rejected(time_mock, cap):
     """NaN is the one value that would switch the cap off without saying so -- every comparison
     against it is False, so the wait this field exists to bound would run unbounded again.
     Infinity is rejected as the same kind of mistake rather than read as "no cap", which is
-    already spelled by leaving the field out."""
-    strategy = _strategy(cap)
-
+    already spelled by leaving the field out. Rejected at construction, like every other cap the
+    field cannot resolve."""
     with pytest.raises(AirbyteTracedException) as exc_info:
-        strategy.backoff_time(_response(), 1)
+        _strategy(cap)
     assert exc_info.value.failure_type == FailureType.system_error

--- a/unit_tests/sources/declarative/test_declarative_component_schema_is_loadable.py
+++ b/unit_tests/sources/declarative/test_declarative_component_schema_is_loadable.py
@@ -1,0 +1,40 @@
+#
+# Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+#
+
+"""The shipped manifest schema has to parse, and nothing else asserted that it does.
+
+`_get_declarative_component_schema()` runs before any low-code source is built, so a malformed
+`declarative_component_schema.yaml` fails every declarative connector at startup. It is also easy
+to break from a documentation edit alone: the descriptions are plain YAML scalars, so a `": "` in
+prose ends the scalar and the file stops being a mapping. That happened in this file's history and
+surfaced as 194 unrelated test failures rather than as one obvious error.
+"""
+
+from airbyte_cdk.sources.declarative.concurrent_declarative_source import (
+    _get_declarative_component_schema,
+)
+
+
+def test_the_shipped_component_schema_parses():
+    schema = _get_declarative_component_schema()
+
+    assert schema["title"] == "DeclarativeSource"
+    assert "HttpRequester" in schema["definitions"]
+
+
+def test_every_description_survives_the_yaml_round_trip():
+    """A description that ends early still parses — it just silently loses its tail, or turns the
+    rest of the sentence into a key. Reading them all back catches the truncation too."""
+    schema = _get_declarative_component_schema()
+
+    for name, definition in schema["definitions"].items():
+        for field_name, field_schema in (definition.get("properties") or {}).items():
+            description = (
+                field_schema.get("description") if isinstance(field_schema, dict) else None
+            )
+            if description is not None:
+                assert isinstance(description, str), (
+                    f"{name}.{field_name} description is not a string"
+                )
+                assert description.strip(), f"{name}.{field_name} has an empty description"

--- a/unit_tests/sources/declarative/test_declarative_component_schema_is_loadable.py
+++ b/unit_tests/sources/declarative/test_declarative_component_schema_is_loadable.py
@@ -57,6 +57,9 @@ def test_no_plain_scalar_carries_yaml_punctuation():
     Every inline value is checked, not only `description`, because the hazard belongs to the
     scalar style rather than to the field: a `title`, an `error_message` or a value written
     under a sequence item all break the same way.
+
+    Line-anchored, so a plain scalar wrapped onto a continuation line is only checked on its first
+    line. The file has none today, and quoting a long value is the fix either way.
     """
     # The same bytes the loader reads, fetched the same way, so this cannot drift from what ships.
     raw_schema = pkgutil.get_data(

--- a/unit_tests/sources/declarative/test_declarative_component_schema_is_loadable.py
+++ b/unit_tests/sources/declarative/test_declarative_component_schema_is_loadable.py
@@ -9,11 +9,29 @@
 to break from a documentation edit alone: the descriptions are plain YAML scalars, so a `": "` in
 prose ends the scalar and the file stops being a mapping. That happened in this file's history and
 surfaced as 194 unrelated test failures rather than as one obvious error.
+
+Two guards, because the two ways prose breaks a plain scalar look nothing alike. A `": "` is loud:
+the file stops parsing, so loading it is enough to catch it. A `" #"` is silent: YAML reads the
+rest of the line as a comment, the value keeps parsing as a shorter string, and nothing in the
+parsed tree records that a sentence went missing. Only the source text knows, so the second guard
+reads that instead of the loaded schema.
 """
+
+import pkgutil
+import re
 
 from airbyte_cdk.sources.declarative.concurrent_declarative_source import (
     _get_declarative_component_schema,
 )
+
+# `key: value` with the value on the same line. List items are excluded on purpose: `- key: value`
+# is a nested mapping, where a colon is structure rather than a truncated sentence.
+_INLINE_VALUE = re.compile(r"^\s*[\w$\"-]+:\s+(\S.*?)\s*$")
+
+# A plain scalar is one not opened with a quote, a block indicator or a flow collection, and it is
+# the only style these two characters are dangerous in: inside `'...'` or a `|` block they are
+# text like any other.
+_QUOTED_BLOCK_OR_FLOW = "'\"|>&*[{"
 
 
 def test_the_shipped_component_schema_parses():
@@ -23,18 +41,33 @@ def test_the_shipped_component_schema_parses():
     assert "HttpRequester" in schema["definitions"]
 
 
-def test_every_description_survives_the_yaml_round_trip():
-    """A description that ends early still parses — it just silently loses its tail, or turns the
-    rest of the sentence into a key. Reading them all back catches the truncation too."""
-    schema = _get_declarative_component_schema()
+def test_no_plain_scalar_carries_yaml_punctuation():
+    """`": "` ends a plain scalar and `" #"` starts a comment, so either one truncates a value
+    written as prose -- the first noisily, the second without a trace. Checked against the source
+    text rather than the parsed schema, which by then has already lost the evidence.
 
-    for name, definition in schema["definitions"].items():
-        for field_name, field_schema in (definition.get("properties") or {}).items():
-            description = (
-                field_schema.get("description") if isinstance(field_schema, dict) else None
-            )
-            if description is not None:
-                assert isinstance(description, str), (
-                    f"{name}.{field_name} description is not a string"
-                )
-                assert description.strip(), f"{name}.{field_name} has an empty description"
+    Every inline value is checked, not only `description`, because the hazard belongs to the
+    scalar style rather than to the field: a `title` or an `error_message` breaks the same way.
+    """
+    # The same bytes the loader reads, fetched the same way, so this cannot drift from what ships.
+    raw_schema = pkgutil.get_data(
+        "airbyte_cdk", "sources/declarative/declarative_component_schema.yaml"
+    )
+    assert raw_schema is not None, "the manifest schema is missing from the package"
+
+    offenders = []
+
+    for number, line in enumerate(raw_schema.decode().splitlines(), start=1):
+        match = _INLINE_VALUE.match(line)
+        if match is None:
+            continue
+        value = match.group(1)
+        if value[0] in _QUOTED_BLOCK_OR_FLOW:
+            continue
+        if ": " in value or " #" in value:
+            offenders.append(f"line {number}: {value[:80]}")
+
+    assert not offenders, (
+        "these are plain YAML scalars containing punctuation that ends them early; "
+        "wrap each one in single quotes:\n" + "\n".join(offenders)
+    )

--- a/unit_tests/sources/declarative/test_declarative_component_schema_is_loadable.py
+++ b/unit_tests/sources/declarative/test_declarative_component_schema_is_loadable.py
@@ -24,14 +24,22 @@ from airbyte_cdk.sources.declarative.concurrent_declarative_source import (
     _get_declarative_component_schema,
 )
 
-# `key: value` with the value on the same line. List items are excluded on purpose: `- key: value`
-# is a nested mapping, where a colon is structure rather than a truncated sentence.
-_INLINE_VALUE = re.compile(r"^\s*[\w$\"-]+:\s+(\S.*?)\s*$")
-
 # A plain scalar is one not opened with a quote, a block indicator or a flow collection, and it is
 # the only style these two characters are dangerous in: inside `'...'` or a `|` block they are
 # text like any other.
 _QUOTED_BLOCK_OR_FLOW = "'\"|>&*[{"
+
+# What to read a value out of, and which punctuation can truncate it there.
+#
+# `key: value` and `- key: value` both hold prose and are checked for both hazards. A sequence
+# item that is a bare scalar (`- some text`) is checked for `" #"` only: a `": "` in that
+# position does not truncate anything, it makes the item a one-key mapping, which parses. Telling
+# that apart from the 125 nested mappings the file legitimately writes that way is not possible
+# from the text, so it is left alone.
+_SCANS = (
+    (re.compile(r"^\s*(?:-\s+)?[\w$\"-]+:\s+(\S.*?)\s*$"), (": ", " #")),
+    (re.compile(r"^\s*-\s+(\S.*?)\s*$"), (" #",)),
+)
 
 
 def test_the_shipped_component_schema_parses():
@@ -47,7 +55,8 @@ def test_no_plain_scalar_carries_yaml_punctuation():
     text rather than the parsed schema, which by then has already lost the evidence.
 
     Every inline value is checked, not only `description`, because the hazard belongs to the
-    scalar style rather than to the field: a `title` or an `error_message` breaks the same way.
+    scalar style rather than to the field: a `title`, an `error_message` or a value written
+    under a sequence item all break the same way.
     """
     # The same bytes the loader reads, fetched the same way, so this cannot drift from what ships.
     raw_schema = pkgutil.get_data(
@@ -58,14 +67,16 @@ def test_no_plain_scalar_carries_yaml_punctuation():
     offenders = []
 
     for number, line in enumerate(raw_schema.decode().splitlines(), start=1):
-        match = _INLINE_VALUE.match(line)
-        if match is None:
-            continue
-        value = match.group(1)
-        if value[0] in _QUOTED_BLOCK_OR_FLOW:
-            continue
-        if ": " in value or " #" in value:
-            offenders.append(f"line {number}: {value[:80]}")
+        for pattern, hazards in _SCANS:
+            match = pattern.match(line)
+            if match is None:
+                continue
+            value = match.group(1)
+            if value[0] in _QUOTED_BLOCK_OR_FLOW:
+                continue
+            if any(hazard in value for hazard in hazards):
+                offenders.append(f"line {number}: {value[:80]}")
+                break  # one report per line; the scans overlap on `- key: value`
 
     assert not offenders, (
         "these are plain YAML scalars containing punctuation that ends them early; "

--- a/unit_tests/sources/declarative/test_declarative_component_schema_is_loadable.py
+++ b/unit_tests/sources/declarative/test_declarative_component_schema_is_loadable.py
@@ -2,13 +2,15 @@
 # Copyright (c) 2026 Airbyte, Inc., all rights reserved.
 #
 
-"""The shipped manifest schema has to parse, and nothing else asserted that it does.
+"""The shipped manifest schema has to parse, and only 194 unrelated failures said so.
 
 `_get_declarative_component_schema()` runs before any low-code source is built, so a malformed
 `declarative_component_schema.yaml` fails every declarative connector at startup. It is also easy
 to break from a documentation edit alone: the descriptions are plain YAML scalars, so a `": "` in
 prose ends the scalar and the file stops being a mapping. That happened in this file's history and
-surfaced as 194 unrelated test failures rather than as one obvious error.
+surfaced as 194 unrelated test failures rather than as one obvious error -- the defect was caught,
+at the wrong layer and with unreadable output. What these guards add is not coverage but a named
+failure in milliseconds.
 
 Two guards, because the two ways prose breaks a plain scalar look nothing alike. A `": "` is loud:
 the file stops parsing, so loading it is enough to catch it. A `" #"` is silent: YAML reads the
@@ -75,11 +77,15 @@ def test_no_plain_scalar_carries_yaml_punctuation():
             if match is None:
                 continue
             value = match.group(1)
+            # Both exits break rather than continue: the scans overlap on `- key: value`, and
+            # whichever reads it first settles the line. Falling through to the next scan would
+            # re-capture `key: 'text # hash'` as one bare scalar, quotes and all, and report a
+            # value the author had already quoted correctly.
             if value[0] in _QUOTED_BLOCK_OR_FLOW:
-                continue
+                break
             if any(hazard in value for hazard in hazards):
                 offenders.append(f"line {number}: {value[:80]}")
-                break  # one report per line; the scans overlap on `- key: value`
+                break
 
     assert not offenders, (
         "these are plain YAML scalars containing punctuation that ends them early; "

--- a/unit_tests/sources/streams/http/test_http_client.py
+++ b/unit_tests/sources/streams/http/test_http_client.py
@@ -1235,7 +1235,7 @@ class _SpareTokenAuthenticator(TokenAuthenticator):
         return self.has_spare
 
 
-def _rate_limited_client(authenticator, backoff_seconds=1800):
+def _rate_limited_client(authenticator, backoff_seconds=1800, backoff_strategy=None):
     return HttpClient(
         name="test",
         logger=logging.getLogger("test"),
@@ -1256,7 +1256,7 @@ def _rate_limited_client(authenticator, backoff_seconds=1800):
             },
             max_retries=1,
         ),
-        backoff_strategy=_ConstantBackoffStrategy(backoff_seconds),
+        backoff_strategy=backoff_strategy or _ConstantBackoffStrategy(backoff_seconds),
     )
 
 
@@ -1311,22 +1311,8 @@ def test_rotation_is_preferred_over_a_strategy_that_refuses_to_wait(requests_moc
     before it runs, or a bound on waiting silently becomes a bound on the sync: the retry the
     spare credential could serve in 0.1s never happens."""
     requests_mock.get("https://example.com/", [{"status_code": 429}, {"status_code": 200}])
-    client = HttpClient(
-        name="test",
-        logger=logging.getLogger("test"),
-        authenticator=_SpareTokenAuthenticator(has_spare=True),
-        error_handler=HttpStatusErrorHandler(
-            logger=logging.getLogger("test"),
-            error_mapping={
-                429: ErrorResolution(
-                    response_action=ResponseAction.RATE_LIMITED,
-                    failure_type=FailureType.transient_error,
-                    error_message="rate limited",
-                )
-            },
-            max_retries=1,
-        ),
-        backoff_strategy=_RefusingBackoffStrategy(),
+    client = _rate_limited_client(
+        _SpareTokenAuthenticator(has_spare=True), backoff_strategy=_RefusingBackoffStrategy()
     )
 
     sleeps = []
@@ -1342,22 +1328,8 @@ def test_rotation_is_preferred_over_a_strategy_that_refuses_to_wait(requests_moc
 def test_a_refusing_strategy_still_ends_the_stream_without_a_spare_credential(requests_mock):
     """The cap must keep working when rotation is not an option — that is what it is for."""
     requests_mock.get("https://example.com/", [{"status_code": 429}, {"status_code": 200}])
-    client = HttpClient(
-        name="test",
-        logger=logging.getLogger("test"),
-        authenticator=_SpareTokenAuthenticator(has_spare=False),
-        error_handler=HttpStatusErrorHandler(
-            logger=logging.getLogger("test"),
-            error_mapping={
-                429: ErrorResolution(
-                    response_action=ResponseAction.RATE_LIMITED,
-                    failure_type=FailureType.transient_error,
-                    error_message="rate limited",
-                )
-            },
-            max_retries=1,
-        ),
-        backoff_strategy=_RefusingBackoffStrategy(),
+    client = _rate_limited_client(
+        _SpareTokenAuthenticator(has_spare=False), backoff_strategy=_RefusingBackoffStrategy()
     )
 
     with pytest.raises(AirbyteTracedException, match="longer than the connector is allowed"):
@@ -1381,21 +1353,8 @@ def test_rotation_is_preferred_over_the_real_capped_strategy(requests_mock):
             {"status_code": 200},
         ],
     )
-    client = HttpClient(
-        name="test",
-        logger=logging.getLogger("test"),
-        authenticator=_SpareTokenAuthenticator(has_spare=True),
-        error_handler=HttpStatusErrorHandler(
-            logger=logging.getLogger("test"),
-            error_mapping={
-                429: ErrorResolution(
-                    response_action=ResponseAction.RATE_LIMITED,
-                    failure_type=FailureType.transient_error,
-                    error_message="rate limited",
-                )
-            },
-            max_retries=1,
-        ),
+    client = _rate_limited_client(
+        _SpareTokenAuthenticator(has_spare=True),
         # A cap far below the hour the response asks for: the strategy would refuse the wait.
         backoff_strategy=WaitUntilTimeFromHeaderBackoffStrategy(
             header="X-RateLimit-Reset",
@@ -1432,22 +1391,8 @@ def test_rotation_also_covers_a_rate_limit_with_no_computed_wait(requests_mock):
     credential with quota — but it is a behaviour change, so it is pinned rather than implied."""
     requests_mock.get("https://example.com/", [{"status_code": 429}, {"status_code": 200}])
     strategy = _NoWaitBackoffStrategy()
-    client = HttpClient(
-        name="test",
-        logger=logging.getLogger("test"),
-        authenticator=_SpareTokenAuthenticator(has_spare=True),
-        error_handler=HttpStatusErrorHandler(
-            logger=logging.getLogger("test"),
-            error_mapping={
-                429: ErrorResolution(
-                    response_action=ResponseAction.RATE_LIMITED,
-                    failure_type=FailureType.transient_error,
-                    error_message="rate limited",
-                )
-            },
-            max_retries=1,
-        ),
-        backoff_strategy=strategy,
+    client = _rate_limited_client(
+        _SpareTokenAuthenticator(has_spare=True), backoff_strategy=strategy
     )
 
     sleeps = []

--- a/unit_tests/sources/streams/http/test_http_client.py
+++ b/unit_tests/sources/streams/http/test_http_client.py
@@ -1364,6 +1364,103 @@ def test_a_refusing_strategy_still_ends_the_stream_without_a_spare_credential(re
         client.send_request(http_method="GET", url="https://example.com/", request_kwargs={})
 
 
+def test_rotation_is_preferred_over_the_real_capped_strategy(requests_mock):
+    """The stub tests above pin the client's contract — a strategy may raise. This one pins the
+    integration that actually regressed: the real `WaitUntilTimeFromHeaderBackoffStrategy` with a
+    cap it cannot honour. Without it, a change making the cap return instead of raise would leave
+    both stub tests green while the bug came back."""
+    from airbyte_cdk.sources.declarative.requesters.error_handlers.backoff_strategies import (
+        WaitUntilTimeFromHeaderBackoffStrategy,
+    )
+
+    reset = int(time.time()) + 3600
+    requests_mock.get(
+        "https://example.com/",
+        [
+            {"status_code": 429, "headers": {"X-RateLimit-Reset": str(reset)}},
+            {"status_code": 200},
+        ],
+    )
+    client = HttpClient(
+        name="test",
+        logger=logging.getLogger("test"),
+        authenticator=_SpareTokenAuthenticator(has_spare=True),
+        error_handler=HttpStatusErrorHandler(
+            logger=logging.getLogger("test"),
+            error_mapping={
+                429: ErrorResolution(
+                    response_action=ResponseAction.RATE_LIMITED,
+                    failure_type=FailureType.transient_error,
+                    error_message="rate limited",
+                )
+            },
+            max_retries=1,
+        ),
+        # A cap far below the hour the response asks for: the strategy would refuse the wait.
+        backoff_strategy=WaitUntilTimeFromHeaderBackoffStrategy(
+            header="X-RateLimit-Reset",
+            parameters={},
+            config={},
+            max_waiting_time_in_seconds=60,
+        ),
+    )
+
+    sleeps = []
+    with patch("time.sleep", side_effect=lambda seconds: sleeps.append(seconds)):
+        _, response = client.send_request(
+            http_method="GET", url="https://example.com/", request_kwargs={}
+        )
+
+    assert response.status_code == 200
+    assert max(sleeps) < 5, f"expected a prompt retry on the spare credential, slept {sleeps}"
+
+
+class _NoWaitBackoffStrategy(BackoffStrategy):
+    """Returns no wait at all, as a strategy does when the response carries no timing header."""
+
+    def __init__(self):
+        self.calls = 0
+
+    def backoff_time(self, *args, **kwargs):
+        self.calls += 1
+        return None
+
+
+def test_rotation_also_covers_a_rate_limit_with_no_computed_wait(requests_mock):
+    """Deciding rotation first widens it to rate limits that produce no backoff at all, where the
+    old order fell through to the default exponential retry. Intended — the retry goes out on a
+    credential with quota — but it is a behaviour change, so it is pinned rather than implied."""
+    requests_mock.get("https://example.com/", [{"status_code": 429}, {"status_code": 200}])
+    strategy = _NoWaitBackoffStrategy()
+    client = HttpClient(
+        name="test",
+        logger=logging.getLogger("test"),
+        authenticator=_SpareTokenAuthenticator(has_spare=True),
+        error_handler=HttpStatusErrorHandler(
+            logger=logging.getLogger("test"),
+            error_mapping={
+                429: ErrorResolution(
+                    response_action=ResponseAction.RATE_LIMITED,
+                    failure_type=FailureType.transient_error,
+                    error_message="rate limited",
+                )
+            },
+            max_retries=1,
+        ),
+        backoff_strategy=strategy,
+    )
+
+    sleeps = []
+    with patch("time.sleep", side_effect=lambda seconds: sleeps.append(seconds)):
+        _, response = client.send_request(
+            http_method="GET", url="https://example.com/", request_kwargs={}
+        )
+
+    assert response.status_code == 200
+    assert strategy.calls == 0, "the strategies are skipped entirely on the rotation path"
+    assert max(sleeps) < 5, f"expected the rotation retry, slept {sleeps}"
+
+
 def test_non_rate_limit_retry_is_not_shortened_by_a_spare_credential(requests_mock):
     """A 500 has nothing to do with credentials; its backoff must be left alone."""
     requests_mock.get("https://example.com/", [{"status_code": 500}, {"status_code": 200}])

--- a/unit_tests/sources/streams/http/test_http_client.py
+++ b/unit_tests/sources/streams/http/test_http_client.py
@@ -1295,6 +1295,75 @@ def test_rate_limit_wait_is_paid_when_no_other_credential_is_available(requests_
     assert max(sleeps) > 1000, f"the full rate-limit wait should stand, slept {sleeps}"
 
 
+class _RefusingBackoffStrategy(BackoffStrategy):
+    """A strategy that refuses to wait, the way `max_waiting_time_in_seconds` does."""
+
+    def backoff_time(self, *args, **kwargs):
+        raise AirbyteTracedException(
+            internal_message="wait longer than allowed",
+            message="The rate limit wait time is longer than the connector is allowed to wait.",
+            failure_type=FailureType.transient_error,
+        )
+
+
+def test_rotation_is_preferred_over_a_strategy_that_refuses_to_wait(requests_mock):
+    """A capped strategy raises rather than returning a number. Rotation has to be decided
+    before it runs, or a bound on waiting silently becomes a bound on the sync: the retry the
+    spare credential could serve in 0.1s never happens."""
+    requests_mock.get("https://example.com/", [{"status_code": 429}, {"status_code": 200}])
+    client = HttpClient(
+        name="test",
+        logger=logging.getLogger("test"),
+        authenticator=_SpareTokenAuthenticator(has_spare=True),
+        error_handler=HttpStatusErrorHandler(
+            logger=logging.getLogger("test"),
+            error_mapping={
+                429: ErrorResolution(
+                    response_action=ResponseAction.RATE_LIMITED,
+                    failure_type=FailureType.transient_error,
+                    error_message="rate limited",
+                )
+            },
+            max_retries=1,
+        ),
+        backoff_strategy=_RefusingBackoffStrategy(),
+    )
+
+    sleeps = []
+    with patch("time.sleep", side_effect=lambda seconds: sleeps.append(seconds)):
+        _, response = client.send_request(
+            http_method="GET", url="https://example.com/", request_kwargs={}
+        )
+
+    assert response.status_code == 200
+    assert max(sleeps) < 5, f"expected a prompt retry on the spare credential, slept {sleeps}"
+
+
+def test_a_refusing_strategy_still_ends_the_stream_without_a_spare_credential(requests_mock):
+    """The cap must keep working when rotation is not an option — that is what it is for."""
+    requests_mock.get("https://example.com/", [{"status_code": 429}, {"status_code": 200}])
+    client = HttpClient(
+        name="test",
+        logger=logging.getLogger("test"),
+        authenticator=_SpareTokenAuthenticator(has_spare=False),
+        error_handler=HttpStatusErrorHandler(
+            logger=logging.getLogger("test"),
+            error_mapping={
+                429: ErrorResolution(
+                    response_action=ResponseAction.RATE_LIMITED,
+                    failure_type=FailureType.transient_error,
+                    error_message="rate limited",
+                )
+            },
+            max_retries=1,
+        ),
+        backoff_strategy=_RefusingBackoffStrategy(),
+    )
+
+    with pytest.raises(AirbyteTracedException, match="longer than the connector is allowed"):
+        client.send_request(http_method="GET", url="https://example.com/", request_kwargs={})
+
+
 def test_non_rate_limit_retry_is_not_shortened_by_a_spare_credential(requests_mock):
     """A 500 has nothing to do with credentials; its backoff must be left alone."""
     requests_mock.get("https://example.com/", [{"status_code": 500}, {"status_code": 200}])


### PR DESCRIPTION
## What

Two changes to when `HttpClient` rotates credentials instead of waiting out a rate limit. The first is the bug in the title; the second rides on the same reorder and is a deliberate widening, not a fix — both are described below and both are pinned by tests.

1. **A capped strategy can no longer pre-empt rotation.** `HttpClient` can shorten a rate-limit wait when the authenticator holds a spare credential, and a backoff strategy can refuse a wait that exceeds a cap. Combining the two loses the first: a capped strategy ends the stream while a fully-quota'd credential sits idle.
2. **Rotation now also covers rate limits that produce no wait at all**, where the old order fell through to the default exponential retry. That changes which exception is raised and therefore which retry curve runs: `RateLimitBackoffException` → `UserDefinedBackoffException`, `backoff.expo` (1s, 2s, 4s, …) → `backoff.constant` at `0.1 + 1`s, and `max_time` — not passed to the rate-limit handler — now bounds the loop. On a credential with quota that is the better curve, but it is a semantic change to behaviour that shipped in 7.26.0, which is why the title carries it.
3. **Both capped strategies resolve `max_waiting_time_in_seconds` in `__post_init__`.** Follows from 1: if the strategies can be skipped, a cap that cannot be evaluated can go unreported. See below.

The two features shipped two days apart — the rotation shortcut in #1117 (7.26.0), the cap in #1123 (7.27.0) — and nothing covered them together.

## Why

`_handle_error_resolution` asks the strategies for a wait, then rewrites that wait when the response was rate-limited and another credential is available:

```python
user_defined_backoff_time = None
for backoff_strategy in self._backoff_strategies:      # step 1
    backoff_time = backoff_strategy.backoff_time(...)  #   <- a capped strategy raises here
    ...

if (                                                   # step 2
    user_defined_backoff_time
    and error_resolution.response_action == ResponseAction.RATE_LIMITED
    and self._can_retry_on_another_token(request)
):
    user_defined_backoff_time = self.TOKEN_ROTATION_BACKOFF
```

Step 2 is expressed as a modification of step 1's result, so it depends on step 1 returning. `WaitUntilTimeFromHeaderBackoffStrategy._capped` raises `AirbyteTracedException` instead of returning when the computed wait exceeds `max_waiting_time_in_seconds`, so control leaves the function at step 1 and rotation is never considered.

Measured on `source-github` (airbytehq/airbyte#81428), two tokens, one rejected with `X-RateLimit-Reset` an hour out:

| wait budget | before | after |
|---|---|---|
| 120 min (no cap hit) | rotates, retry in 0.1 s | unchanged |
| 30 min (cap hit) | **stream stops**, spare token idle | rotates, retry in 0.1 s |

The connector-side consequence is worse than a wasted wait: a user who *lowers* the wait budget — asking for less waiting — gets a failed sync where the connector would previously have carried on. A bound on waiting silently became a bound on the sync.

## How

Ask the rotation question first, and only fall through to the strategies when the answer is no.

When another credential can serve the retry, the strategies are not consulted at all. That is deliberate rather than an optimisation: the wait they compute is derived from the rejected credential's response headers, and the retry will not use that credential, so the number describes a window nobody is waiting for. Skipping them also means a strategy that refuses to wait cannot pre-empt the decision.

When there is no spare credential, the loop runs exactly as before and a cap still ends the stream — that path is untouched, and a test pins it.

Non-rate-limit resolutions (`RETRY`, `REFRESH_TOKEN_THEN_RETRY`) are unaffected: the rotation branch is gated on `RATE_LIMITED`, as it was before.

Two consequences of not calling the strategies, both deliberate and both now pinned by tests:

- **A rate limit that produces no backoff at all rotates too**, where the old order fell through to the default exponential retry. `has_alternative_token` only answers True when the sending credential is tracked and spent, so this is the same retry on a credential with quota rather than a blind shortcut.
- **A `max_waiting_time_in_seconds` the manifest got wrong is no longer reported from this path.** `evaluate_max_waiting_time` raises `system_error` for a cap it cannot resolve, and that check lives inside the strategy — so with rotation available a broken cap now stays quiet until the first rate limit that finds no spare credential. Resolving the cap once in `__post_init__` closes it on every path, and is the better fix, but it moves *when* the field raises and breaks nine tests that assert the current timing — that is #1123's contract, not this PR's ordering, so it is recorded in the comment and left for its own change.

## Resolving the cap at construction

Deciding rotation first means a strategy may never be asked for a wait — and the check that a manifest's `max_waiting_time_in_seconds` can be evaluated at all lived inside that call. Measured on an earlier commit of this branch, with `max_waiting_time_in_seconds: "{{ config['not_in_spec'] }}"` and a 429 an hour out:

| authenticator | before | after |
|---|---|---|
| spare credential available | `200` — the bound is not applied and nothing says so | raises at construction |
| no spare credential | `system_error` | raises at construction |

Two outcomes from one manifest, decided by the quota state of an unrelated credential. Caching the resolved value or storing the error to re-raise would not have helped: the rotation path never reaches `backoff_time()`, so detection had to leave it. `config` is a dataclass field and this cap interpolates over `config` alone, so the value is knowable as soon as the component exists, and `ModelToComponentFactory` already passes the real config.

**This is a contract change, and it is the reason the fix was initially deferred.** Nine tests pinned the old timing and now assert construction instead — five in `test_wait_time_from_header.py`, four in `test_wait_until_time_from_header.py`. What they assert otherwise is unchanged: still an `AirbyteTracedException` with `system_error`, still never a raw jinja or float error, still the connector's fault rather than the user's. Only the moment moves, from "the first retryable error that reaches a strategy" to "when the strategy is built".

**Fleet impact is nil today**, which is what makes this the cheap moment to do it — every user of the field resolves cleanly: `source-github` ([#81428](https://github.com/airbytehq/airbyte/pull/81428)) guards with `config.get(...) is not none`, `source-klaviyo` passes a float, `source-granola` hardcodes `60`. Not a breaking change: no field added, removed or renamed, no default changed, no manifest edit required of anyone. It changes when an already-invalid manifest reports itself.

The lazy check stays alongside it, so a strategy constructed directly in Python behaves as before.

## Tests

Four added to `unit_tests/sources/streams/http/test_http_client.py`, plus one guard on the schema itself:

| Test | Asserts |
|---|---|
| `test_rotation_is_preferred_over_a_strategy_that_refuses_to_wait` | with a spare credential, the request succeeds after a sub-second retry |
| `test_a_refusing_strategy_still_ends_the_stream_without_a_spare_credential` | with no spare credential, the cap still raises |
| `test_rotation_is_preferred_over_the_real_capped_strategy` | the same, driving the real `WaitUntilTimeFromHeaderBackoffStrategy` with a cap below the wait the response asks for |
| `test_rotation_also_covers_a_rate_limit_with_no_computed_wait` | a strategy returning `None` is not consulted at all on the rotation path |

The first fails on `main` (`AirbyteTracedException` instead of a 200), verified by reverting the source change with the tests in place. The third exists because the stub tests would survive the cap being changed to return instead of raise, which is the failure mode that produced this bug.

Both `max_waiting_time_in_seconds` schema descriptions, both class docstrings, `WaitUntilTimeFromHeader._capped` and `WaitTimeFromHeader`'s inline cap said "stop the stream" and "0 means never wait" without qualification. Neither holds once rotation preempts the strategy, so each now says the bound applies only when waiting is the only way forward.

`unit_tests/sources/declarative/test_declarative_component_schema_is_loadable.py` is new and unrelated to the behaviour change: it loads the shipped schema through the same helper every declarative source uses. Nothing asserted that before, and the first version of the description edit above put a `": "` inside a plain YAML scalar, which stopped the whole schema parsing and failed every low-code source. That is fixed here by quoting both scalars — the text is unchanged, so the generated models still match — and the new test catches the class of mistake in milliseconds.

## Checks

- `unit_tests/sources/streams/http`, `.../declarative/requesters/error_handlers`, `.../declarative/auth`, plus the new schema guard: 763 passed
- `unit_tests/sources/declarative`: the `test_concurrent_declarative_source` failures are pre-existing — same names, on an `origin/main` worktree (a `requests_cache` sqlite lock on this machine)
- `ruff format --check`, `ruff check`: clean
- `mypy` on all five changed modules (`http_client.py`, `error_handlers/backoff_strategy.py`, `max_waiting_time_helper.py` and both backoff strategies): clean
- `unit_tests/.../error_handlers`: 147 passed after the nine timing tests were moved to construction
- The three rotation tests still fail against `main`'s `http_client.py` after being refactored onto the `_rate_limited_client` helper

## Why it is worth taking now

The interaction was found while reviewing airbytehq/airbyte#81428, which needs it. At that PR's head the cap is applied on **both** wait paths with the user's configured budget — `max_waiting_time_in_seconds: "{{ (config['max_waiting_time'] ... else 120) * 60 + 1 }}"` on `WaitTimeFromHeader` and `WaitUntilTimeFromHeader` — and the manifest comment says so, pointing at a prerelease of this PR and at `test_short_wait_budget_does_not_cost_token_rotation` as the end-to-end proof. Without this fix, a budget shorter than the distance to the reset ends the stream with a healthy second token idle (measured on 7.28.0: a 30-minute budget against a 60-minute reset).

Still worth a maintainer's read on the ordering choice — specifically, whether skipping the strategies entirely on the rotation path is right, or whether the wait should still be computed and discarded. The trade-off is written up under "Two consequences" above: skipping means a `max_waiting_time_in_seconds` the manifest got wrong is not reported from this path.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rate-limit handling by prioritizing credential rotation before applying backoff strategies.
  * Retries using an alternative credential now bypass configured wait limits and use the standard rotation delay.
  * Clarified maximum-wait behavior for header-based retry strategies, including boundary conditions.

* **Documentation**
  * Updated retry and backoff guidance to accurately describe credential rotation, wait caps, and strategy behavior.
  * Expanded validation guidance for declarative schema documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
