### PR TITLE
fix(oauth): preserve provider error detail on refresh token failure

### DIFF
--- a/airbyte_cdk/sources/streams/http/requests_native_auth/abstract_oauth.py
+++ b/airbyte_cdk/sources/streams/http/requests_native_auth/abstract_oauth.py
@@ -27,8 +27,10 @@ _NOOP_MESSAGE_REPOSITORY = NoopMessageRepository()
 
 # How much of the provider's error detail is appended to the user-facing message. Long enough to
 # keep a provider error code and the start of its description (e.g. Microsoft Entra puts the
-# `AADSTS<code>` at the front of `error_description`), short enough to keep the message readable.
-_PROVIDER_ERROR_DETAIL_MAX_LENGTH = 200
+# `AADSTS<code>` at the front of `error_description`), short enough to keep the message readable
+# and to stop before the per-request values (issue dates, trace ids) that some providers embed
+# further into the description, so the same failure produces the same message on every attempt.
+_PROVIDER_ERROR_DETAIL_MAX_LENGTH = 120
 # How much of the raw provider response is kept in the internal message, which is logged and is not
 # shown to the user.
 _PROVIDER_ERROR_RESPONSE_MAX_LENGTH = 1000
@@ -295,24 +297,27 @@ class AbstractOauth2Authenticator(AuthBase):
         """
         Build a short, single-line provider error detail suitable for the user-facing message.
 
-        Only the standard OAuth 2.0 error fields (`error` and `error_description`) are used: they
-        are where providers put the actionable diagnostic, and they are not expected to carry
-        credentials. For Microsoft Entra this is what distinguishes a revoked grant
-        (`AADSTS50173`) from a client-type or secret misconfiguration (`AADSTS7000218`,
-        `AADSTS700025`) from Conditional Access requiring interactive sign-in (`AADSTS50076`,
-        `AADSTS50078`, `AADSTS700082`) - all of which otherwise collapse into the same message.
+        Only the standard OAuth 2.0 `error` and `error_description` fields (RFC 6749 section 5.2)
+        are used, and only the first line of the description: providers put the actionable code
+        there (Microsoft Entra leads with `AADSTS<code>`, which tells a revoked or expired grant
+        such as `AADSTS50173` / `AADSTS700082` apart from a client misconfiguration such as
+        `AADSTS7000218`), while per-request trace ids and timestamps follow on later lines. Which
+        provider errors reach this path at all is set by the authenticator's `refresh_token_error_*`
+        configuration.
         """
         if not response_content:
             return None
         parts = [
-            str(response_content[key])
+            response_content[key].strip()
             for key in ("error", "error_description")
-            if response_content.get(key)
+            if isinstance(response_content.get(key), str) and response_content[key].strip()
         ]
         if not parts:
             return None
-        # Collapse newlines and repeated whitespace so the detail stays on a single line.
-        detail = " ".join(": ".join(parts).split())
+        # Keep the first line only and collapse its whitespace: the actionable code leads the
+        # description, while trace ids and timestamps that differ on every attempt follow on later
+        # lines and would make the same failure read differently each time.
+        detail = " ".join(": ".join(parts).splitlines()[0].split())
         return self._truncate(self._redact_credentials(detail), _PROVIDER_ERROR_DETAIL_MAX_LENGTH)
 
     def _build_provider_response_info(self, exception: requests.exceptions.RequestException) -> str:

--- a/airbyte_cdk/sources/streams/http/requests_native_auth/abstract_oauth.py
+++ b/airbyte_cdk/sources/streams/http/requests_native_auth/abstract_oauth.py
@@ -17,13 +17,21 @@ from airbyte_cdk.models import FailureType, Level
 from airbyte_cdk.sources.http_logger import format_http_message
 from airbyte_cdk.sources.message import MessageRepository, NoopMessageRepository
 from airbyte_cdk.utils import AirbyteTracedException
-from airbyte_cdk.utils.airbyte_secrets_utils import add_to_secrets
+from airbyte_cdk.utils.airbyte_secrets_utils import add_to_secrets, filter_secrets
 from airbyte_cdk.utils.datetime_helpers import AirbyteDateTime, ab_datetime_now, ab_datetime_parse
 
 from ..exceptions import DefaultBackoffException
 
 logger = logging.getLogger("airbyte")
 _NOOP_MESSAGE_REPOSITORY = NoopMessageRepository()
+
+# How much of the provider's error detail is appended to the user-facing message. Long enough to
+# keep a provider error code and the start of its description (e.g. Microsoft Entra puts the
+# `AADSTS<code>` at the front of `error_description`), short enough to keep the message readable.
+_PROVIDER_ERROR_DETAIL_MAX_LENGTH = 200
+# How much of the raw provider response is kept in the internal message, which is logged and is not
+# shown to the user.
+_PROVIDER_ERROR_RESPONSE_MAX_LENGTH = 1000
 
 
 class ResponseKeysMaxRecurtionReached(AirbyteTracedException):
@@ -238,8 +246,91 @@ class AbstractOauth2Authenticator(AuthBase):
         default_token_expiry_duration_hours = 1  # 1 hour
         return ab_datetime_now() + timedelta(hours=default_token_expiry_duration_hours)
 
+    @staticmethod
+    def _parse_error_response_content(
+        response: Optional[requests.Response],
+    ) -> Optional[Mapping[str, Any]]:
+        """
+        Best-effort parse of an error response body as a JSON object.
+
+        Returns `None` when the response is missing, empty, not valid JSON, or not a JSON object,
+        so that callers can degrade gracefully instead of raising a new exception while they are
+        already handling an error.
+        """
+        if response is None:
+            return None
+        try:
+            content = response.json()
+        except (JSONDecodeError, ValueError):
+            return None
+        return content if isinstance(content, Mapping) else None
+
+    def _redact_credentials(self, value: str) -> str:
+        """
+        Redact credential material from a string before it is logged or surfaced to the user.
+
+        Only response bodies are passed here, so request headers (including `Authorization`) are
+        never echoed. On top of the config secrets already tracked by the CDK, the authenticator's
+        own refresh token and client secret are redacted explicitly, in case a provider echoes the
+        submitted credentials back in its error payload.
+        """
+        redacted = filter_secrets(value)
+        for get_credential in (self.get_refresh_token, self.get_client_secret):
+            try:
+                credential = get_credential()
+            except Exception:
+                # Never let redaction itself fail the error path we are already in.
+                continue
+            if credential and isinstance(credential, str):
+                redacted = redacted.replace(credential, "****")
+        return redacted
+
+    @staticmethod
+    def _truncate(value: str, max_length: int) -> str:
+        return value if len(value) <= max_length else value[:max_length] + "..."
+
+    def _build_provider_error_detail(
+        self, response_content: Optional[Mapping[str, Any]]
+    ) -> Optional[str]:
+        """
+        Build a short, single-line provider error detail suitable for the user-facing message.
+
+        Only the standard OAuth 2.0 error fields (`error` and `error_description`) are used: they
+        are where providers put the actionable diagnostic, and they are not expected to carry
+        credentials. For Microsoft Entra this is what distinguishes a revoked grant
+        (`AADSTS50173`) from a client-type or secret misconfiguration (`AADSTS7000218`,
+        `AADSTS700025`) from Conditional Access requiring interactive sign-in (`AADSTS50076`,
+        `AADSTS50078`, `AADSTS700082`) - all of which otherwise collapse into the same message.
+        """
+        if not response_content:
+            return None
+        parts = [
+            str(response_content[key])
+            for key in ("error", "error_description")
+            if response_content.get(key)
+        ]
+        if not parts:
+            return None
+        # Collapse newlines and repeated whitespace so the detail stays on a single line.
+        detail = " ".join(": ".join(parts).split())
+        return self._truncate(self._redact_credentials(detail), _PROVIDER_ERROR_DETAIL_MAX_LENGTH)
+
+    def _build_provider_response_info(self, exception: requests.exceptions.RequestException) -> str:
+        """
+        Build the full provider response detail for the internal message, which goes to the logs.
+        """
+        if exception.response is None:
+            return self._redact_credentials(str(exception))
+        body = self._truncate(
+            self._redact_credentials(exception.response.text),
+            _PROVIDER_ERROR_RESPONSE_MAX_LENGTH,
+        )
+        return f"HTTP {exception.response.status_code}: {body}"
+
     def _wrap_refresh_token_exception(
-        self, exception: requests.exceptions.RequestException
+        self,
+        exception: requests.exceptions.RequestException,
+        response_content: Optional[Mapping[str, Any]] = None,
     ) -> bool:
         """
         Wraps and handles exceptions that occur during the refresh token process.
@@ -249,16 +340,20 @@ class AbstractOauth2Authenticator(AuthBase):
 
         Args:
             exception (requests.exceptions.RequestException): The exception raised during the request.
+            response_content (Optional[Mapping[str, Any]]): The already-parsed response body, when
+                the caller has one, so the body is not parsed twice. Parsed on demand otherwise.
 
         Returns:
             bool: True if the exception is related to a refresh token error, False otherwise.
         """
-        try:
-            if exception.response is not None:
-                exception_content = exception.response.json()
-            else:
-                return False
-        except JSONDecodeError:
+        if exception.response is None:
+            return False
+        exception_content = (
+            response_content
+            if response_content is not None
+            else self._parse_error_response_content(exception.response)
+        )
+        if exception_content is None:
             return False
         return (
             exception.response.status_code in self._refresh_token_error_status_codes
@@ -333,15 +428,25 @@ class AbstractOauth2Authenticator(AuthBase):
                         response=e.response,
                         failure_type=FailureType.transient_error,
                     )
-            if self._wrap_refresh_token_exception(e):
-                response_info = (
-                    f"HTTP {e.response.status_code}: {e.response.text[:1000]}"
-                    if e.response is not None
-                    else str(e)
+            error_content = self._parse_error_response_content(e.response)
+            if self._wrap_refresh_token_exception(e, response_content=error_content):
+                message = (
+                    "Refresh token was rejected by the OAuth provider (invalid, expired, or "
+                    "already used). Re-authenticate this source's credentials in its connection "
+                    "settings."
                 )
+                provider_error_detail = self._build_provider_error_detail(error_content)
+                if provider_error_detail:
+                    # The provider's own diagnostic is what tells apart otherwise identical-looking
+                    # failures (revoked grant vs. misconfigured client vs. Conditional Access), so
+                    # a short form of it is appended after the actionable guidance.
+                    message = f"{message} Provider error: {provider_error_detail}"
                 raise AirbyteTracedException(
-                    internal_message=f"Refresh token rejected by the OAuth token endpoint. {response_info}",
-                    message="Refresh token was rejected by the OAuth provider (invalid, expired, or already used). Re-authenticate this source's credentials in its connection settings.",
+                    internal_message=(
+                        "Refresh token rejected by the OAuth token endpoint. "
+                        f"{self._build_provider_response_info(e)}"
+                    ),
+                    message=message,
                     failure_type=FailureType.config_error,
                 ) from e
             raise

--- a/airbyte_cdk/sources/streams/http/requests_native_auth/abstract_oauth.py
+++ b/airbyte_cdk/sources/streams/http/requests_native_auth/abstract_oauth.py
@@ -3,6 +3,7 @@
 #
 
 import logging
+import re
 import threading
 from abc import abstractmethod
 from datetime import timedelta
@@ -25,12 +26,15 @@ from ..exceptions import DefaultBackoffException
 logger = logging.getLogger("airbyte")
 _NOOP_MESSAGE_REPOSITORY = NoopMessageRepository()
 
-# How much of the provider's error detail is appended to the user-facing message. Long enough to
-# keep a provider error code and the start of its description (e.g. Microsoft Entra puts the
-# `AADSTS<code>` at the front of `error_description`), short enough to keep the message readable
-# and to stop before the per-request values (issue dates, trace ids) that some providers embed
-# further into the description, so the same failure produces the same message on every attempt.
-_PROVIDER_ERROR_DETAIL_MAX_LENGTH = 120
+# Provider error codes that lead `error_description`, e.g. Microsoft Entra's `AADSTS50173`.
+# Only the code is appended to the user-facing message: it is the entire grouping key, and unlike
+# the surrounding prose it is identical on every attempt at the same failure.
+_PROVIDER_ERROR_CODE_PATTERN = re.compile(r"^[A-Za-z]{3,}\d{4,}\b")
+# Upper bound on the provider-controlled text appended to the user-facing message. Both the
+# RFC 6749 `error` token and the extracted code come from the provider, so both are still capped.
+# The longest standard token (`unsupported_grant_type`, 22) plus a 7-digit Entra code is 37
+# characters, so this leaves roughly 2x headroom while still bounding a misbehaving provider.
+_PROVIDER_ERROR_DETAIL_MAX_LENGTH = 64
 # How much of the raw provider response is kept in the internal message, which is logged and is not
 # shown to the user.
 _PROVIDER_ERROR_RESPONSE_MAX_LENGTH = 1000
@@ -295,30 +299,36 @@ class AbstractOauth2Authenticator(AuthBase):
         self, response_content: Optional[Mapping[str, Any]]
     ) -> Optional[str]:
         """
-        Build a short, single-line provider error detail suitable for the user-facing message.
+        Build a short, deterministic provider error detail for the user-facing message.
 
-        Only the standard OAuth 2.0 `error` and `error_description` fields (RFC 6749 section 5.2)
-        are used, and only the first line of the description: providers put the actionable code
-        there (Microsoft Entra leads with `AADSTS<code>`, which tells a revoked or expired grant
-        such as `AADSTS50173` / `AADSTS700082` apart from a client misconfiguration such as
-        `AADSTS7000218`), while per-request trace ids and timestamps follow on later lines. Which
-        provider errors reach this path at all is set by the authenticator's `refresh_token_error_*`
-        configuration.
+        Only the standard OAuth 2.0 `error` field (RFC 6749 section 5.2) and the provider error
+        code leading `error_description` are used. Both are stable for a given failure, so the same
+        failure produces a byte-identical message on every attempt and the platform groups them
+        into a single failure summary. The description prose is deliberately excluded: it is
+        free-form, and providers embed per-request values in it -- Microsoft Entra's
+        `AADSTS700082` carries the token issue timestamp in its first sentence -- which would make
+        the grouping key unbounded. The code alone is what distinguishes a revoked grant
+        (`AADSTS50173`) from a misconfigured client (`AADSTS7000218`) or a Conditional Access
+        requirement (`AADSTS50076`). The full response body is preserved in the internal message,
+        which is logged. Which provider errors reach this path at all is set by the
+        authenticator's `refresh_token_error_*` configuration.
         """
         if not response_content:
             return None
-        parts = [
-            response_content[key].strip()
-            for key in ("error", "error_description")
-            if isinstance(response_content.get(key), str) and response_content[key].strip()
-        ]
+        parts = []
+        error = response_content.get("error")
+        if isinstance(error, str) and error.strip():
+            parts.append(" ".join(error.split()))
+        description = response_content.get("error_description")
+        if isinstance(description, str):
+            code_match = _PROVIDER_ERROR_CODE_PATTERN.match(description.strip())
+            if code_match:
+                parts.append(code_match.group())
         if not parts:
             return None
-        # Keep the first line only and collapse its whitespace: the actionable code leads the
-        # description, while trace ids and timestamps that differ on every attempt follow on later
-        # lines and would make the same failure read differently each time.
-        detail = " ".join(": ".join(parts).splitlines()[0].split())
-        return self._truncate(self._redact_credentials(detail), _PROVIDER_ERROR_DETAIL_MAX_LENGTH)
+        return self._truncate(
+            self._redact_credentials(": ".join(parts)), _PROVIDER_ERROR_DETAIL_MAX_LENGTH
+        )
 
     def _build_provider_response_info(self, exception: requests.exceptions.RequestException) -> str:
         """

--- a/unit_tests/sources/declarative/auth/test_oauth.py
+++ b/unit_tests/sources/declarative/auth/test_oauth.py
@@ -19,7 +19,7 @@ from airbyte_cdk.sources.declarative.auth import DeclarativeOauth2Authenticator
 from airbyte_cdk.sources.declarative.auth.jwt import JwtAuthenticator
 from airbyte_cdk.test.mock_http import HttpMocker, HttpRequest, HttpResponse
 from airbyte_cdk.utils import AirbyteTracedException
-from airbyte_cdk.utils.airbyte_secrets_utils import filter_secrets
+from airbyte_cdk.utils.airbyte_secrets_utils import filter_secrets, update_secrets
 from airbyte_cdk.utils.datetime_helpers import AirbyteDateTime, ab_datetime_now, ab_datetime_parse
 
 LOGGER = logging.getLogger(__name__)
@@ -686,6 +686,50 @@ class TestOauth2Authenticator:
         with pytest.raises(requests.exceptions.HTTPError) as e:
             oauth.refresh_access_token()
             assert e.value.errno == 400
+
+    def test_refresh_access_token_rejected_surfaces_provider_error_and_redacts(self, requests_mock):
+        """The declarative authenticator (what manifest connectors use) carries the provider's own
+        error code into the user-facing message and never the interpolated credentials."""
+        update_secrets([])
+        oauth = DeclarativeOauth2Authenticator(
+            token_refresh_endpoint="{{ config['refresh_endpoint'] }}",
+            client_id="{{ config['client_id'] }}",
+            client_secret="{{ config['client_secret'] }}",
+            refresh_token="{{ parameters['refresh_token'] }}",
+            config=config,
+            parameters=parameters,
+            # The defaults the component factory applies when a manifest sets none of these.
+            refresh_token_error_status_codes=(400,),
+            refresh_token_error_key="error",
+            refresh_token_error_values=("invalid_grant", "invalid_permissions"),
+        )
+        requests_mock.post(
+            config["refresh_endpoint"],
+            status_code=400,
+            json={
+                "error": "invalid_grant",
+                "error_description": (
+                    f"AADSTS50173: Rejected {parameters['refresh_token']} for {config['client_secret']}. "
+                    "The provided grant has expired due to it being revoked, a fresh auth token is "
+                    "needed.\r\nTrace ID: 00000000-0000-0000-0000-000000000000"
+                ),
+            },
+        )
+
+        with pytest.raises(AirbyteTracedException) as exc_info:
+            oauth.refresh_access_token()
+
+        assert exc_info.value.failure_type == FailureType.config_error
+        assert exc_info.value.message.startswith("Refresh token was rejected by the OAuth provider")
+        assert (
+            "Provider error: invalid_grant: AADSTS50173: Rejected **** for ****."
+            in exc_info.value.message
+        )
+        assert "Trace ID" not in exc_info.value.message
+        assert "Trace ID" in exc_info.value.internal_message
+        for message in (exc_info.value.message, exc_info.value.internal_message):
+            assert parameters["refresh_token"] not in message
+            assert config["client_secret"] not in message
 
 
 def mock_request(method, url, data, headers, **kwargs):

--- a/unit_tests/sources/declarative/auth/test_oauth.py
+++ b/unit_tests/sources/declarative/auth/test_oauth.py
@@ -721,11 +721,14 @@ class TestOauth2Authenticator:
 
         assert exc_info.value.failure_type == FailureType.config_error
         assert exc_info.value.message.startswith("Refresh token was rejected by the OAuth provider")
-        assert (
-            "Provider error: invalid_grant: AADSTS50173: Rejected **** for ****."
-            in exc_info.value.message
-        )
+        # Only the provider code is surfaced, so the echoed credentials cannot reach the
+        # user-facing message at all -- they are absent by construction, not merely masked.
+        assert exc_info.value.message.endswith("Provider error: invalid_grant: AADSTS50173")
+        assert "****" not in exc_info.value.message
+        assert "Rejected" not in exc_info.value.message
         assert "Trace ID" not in exc_info.value.message
+        # The internal message keeps the full body with both credentials redacted.
+        assert exc_info.value.internal_message.count("****") == 2
         assert "Trace ID" in exc_info.value.internal_message
         for message in (exc_info.value.message, exc_info.value.internal_message):
             assert parameters["refresh_token"] not in message

--- a/unit_tests/sources/streams/http/requests_native_auth/test_requests_native_auth.py
+++ b/unit_tests/sources/streams/http/requests_native_auth/test_requests_native_auth.py
@@ -648,8 +648,170 @@ class TestOauth2Authenticator:
             )
             assert f"HTTP {response_code}" in exc_info.value.internal_message
             assert response_value in exc_info.value.internal_message
-            assert exc_info.value.message == error_message
+            assert exc_info.value.message.startswith(error_message)
             assert exc_info.value.failure_type == FailureType.config_error
+
+    def _entra_style_authenticator(self):
+        return Oauth2Authenticator(
+            f"https://{TestOauth2Authenticator.refresh_endpoint}",
+            TestOauth2Authenticator.client_id,
+            TestOauth2Authenticator.client_secret,
+            TestOauth2Authenticator.refresh_token,
+            refresh_token_error_status_codes=(400,),
+            refresh_token_error_key="error",
+            refresh_token_error_values=("invalid_grant", "invalid_client"),
+        )
+
+    # Sits at the very end of each provider payload below, past the point where the user-facing
+    # message is truncated, so it can only be found in the internal message.
+    trailing_marker = "Correlation ID: 11111111-2222-3333-4444-555555555555"
+
+    @pytest.mark.parametrize(
+        "error, error_description, expected_code",
+        (
+            (
+                # Grant revoked, e.g. the user changed their password: re-authentication is the fix.
+                "invalid_grant",
+                "AADSTS50173: The provided grant has expired due to it being revoked, a fresh auth "
+                "grant is needed. The user might have changed or reset their password.\r\n"
+                "Trace ID: 00000000-0000-0000-0000-000000000000\r\n" + trailing_marker,
+                "AADSTS50173",
+            ),
+            (
+                # Client type / credential misconfiguration: re-authentication will not help.
+                "invalid_client",
+                "AADSTS7000218: The request body must contain the following parameter: "
+                "'client_assertion' or a client credential.\r\n" + trailing_marker,
+                "AADSTS7000218",
+            ),
+            (
+                # Conditional Access requires an interactive sign-in.
+                "invalid_grant",
+                "AADSTS50076: Due to a configuration change made by your administrator, or because "
+                "you moved to a new location, you must use multi-factor authentication to access "
+                "the resource.\r\n" + trailing_marker,
+                "AADSTS50076",
+            ),
+        ),
+    )
+    def test_refresh_access_token_surfaces_provider_error_code(
+        self, requests_mock, error, error_description, expected_code
+    ):
+        """The provider's own diagnostic must reach the logs and the user-facing message."""
+        oauth = self._entra_style_authenticator()
+        requests_mock.post(
+            f"https://{TestOauth2Authenticator.refresh_endpoint}",
+            status_code=400,
+            json={"error": error, "error_description": error_description},
+        )
+
+        with pytest.raises(AirbyteTracedException) as exc_info:
+            oauth.refresh_access_token()
+
+        guidance = (
+            "Refresh token was rejected by the OAuth provider (invalid, expired, or already used). "
+            "Re-authenticate this source's credentials in its connection settings."
+        )
+        # The full provider response reaches the internal message, which is logged.
+        assert expected_code in exc_info.value.internal_message
+        assert TestOauth2Authenticator.trailing_marker in exc_info.value.internal_message
+        # The actionable guidance still leads the user-facing message ...
+        assert exc_info.value.message.startswith(guidance)
+        # ... followed by a short, single-line provider detail carrying the error code.
+        assert f"Provider error: {error}: {expected_code}" in exc_info.value.message
+        assert "\n" not in exc_info.value.message and "\r" not in exc_info.value.message
+        assert exc_info.value.failure_type == FailureType.config_error
+
+    def test_refresh_access_token_truncates_long_provider_error_detail(self, requests_mock):
+        oauth = self._entra_style_authenticator()
+        error_description = "AADSTS50173: " + ("x" * 5000)
+        requests_mock.post(
+            f"https://{TestOauth2Authenticator.refresh_endpoint}",
+            status_code=400,
+            json={"error": "invalid_grant", "error_description": error_description},
+        )
+
+        with pytest.raises(AirbyteTracedException) as exc_info:
+            oauth.refresh_access_token()
+
+        provider_detail = exc_info.value.message.split("Provider error: ", 1)[1]
+        assert provider_detail.startswith("invalid_grant: AADSTS50173: ")
+        assert provider_detail.endswith("...")
+        assert len(provider_detail) < 250
+        assert len(exc_info.value.internal_message) < 1200
+
+    def test_refresh_access_token_redacts_credentials_from_provider_error(self, requests_mock):
+        """A provider that echoes the submitted credentials must not leak them into the error."""
+        oauth = self._entra_style_authenticator()
+        requests_mock.post(
+            f"https://{TestOauth2Authenticator.refresh_endpoint}",
+            status_code=400,
+            json={
+                "error": "invalid_grant",
+                "error_description": (
+                    f"AADSTS50173: rejected refresh_token={TestOauth2Authenticator.refresh_token} "
+                    f"client_secret={TestOauth2Authenticator.client_secret}"
+                ),
+            },
+        )
+
+        with pytest.raises(AirbyteTracedException) as exc_info:
+            oauth.refresh_access_token()
+
+        for message in (exc_info.value.message, exc_info.value.internal_message):
+            assert TestOauth2Authenticator.refresh_token not in message
+            assert TestOauth2Authenticator.client_secret not in message
+            assert "****" in message
+        assert "AADSTS50173" in exc_info.value.message
+
+    @pytest.mark.parametrize(
+        "response_kwargs",
+        (
+            {"text": ""},
+            {"text": "<html><body>Bad Request</body></html>"},
+            {"json": ["invalid_grant"]},
+        ),
+        ids=["empty_body", "html_body", "json_array_body"],
+    )
+    def test_refresh_access_token_non_json_body_does_not_raise_new_exception(
+        self, requests_mock, response_kwargs
+    ):
+        """A body we cannot read as a JSON object falls back to the raw RequestException."""
+        oauth = self._entra_style_authenticator()
+        requests_mock.post(
+            f"https://{TestOauth2Authenticator.refresh_endpoint}",
+            status_code=400,
+            **response_kwargs,
+        )
+
+        with pytest.raises(RequestException):
+            oauth.refresh_access_token()
+
+    def test_refresh_access_token_without_error_fields_keeps_bare_guidance(self, requests_mock):
+        """No usable provider detail means the user-facing message is left exactly as before."""
+        oauth = Oauth2Authenticator(
+            f"https://{TestOauth2Authenticator.refresh_endpoint}",
+            TestOauth2Authenticator.client_id,
+            TestOauth2Authenticator.client_secret,
+            TestOauth2Authenticator.refresh_token,
+            refresh_token_error_status_codes=(400,),
+            refresh_token_error_key="errorCode",
+            refresh_token_error_values=("invalid_grant",),
+        )
+        requests_mock.post(
+            f"https://{TestOauth2Authenticator.refresh_endpoint}",
+            status_code=400,
+            json={"errorCode": "invalid_grant", "errorSummary": "the grant was revoked"},
+        )
+
+        with pytest.raises(AirbyteTracedException) as exc_info:
+            oauth.refresh_access_token()
+
+        assert exc_info.value.message == (
+            "Refresh token was rejected by the OAuth provider (invalid, expired, or already used). "
+            "Re-authenticate this source's credentials in its connection settings."
+        )
+        assert "the grant was revoked" in exc_info.value.internal_message
 
 
 @freezegun.freeze_time("2022-12-31")

--- a/unit_tests/sources/streams/http/requests_native_auth/test_requests_native_auth.py
+++ b/unit_tests/sources/streams/http/requests_native_auth/test_requests_native_auth.py
@@ -25,9 +25,11 @@ from airbyte_cdk.sources.streams.http.requests_native_auth import (
     TokenAuthenticator,
 )
 from airbyte_cdk.sources.streams.http.requests_native_auth.abstract_oauth import (
+    _PROVIDER_ERROR_DETAIL_MAX_LENGTH,
     ResponseKeysMaxRecurtionReached,
 )
 from airbyte_cdk.utils import AirbyteTracedException
+from airbyte_cdk.utils.airbyte_secrets_utils import update_secrets
 from airbyte_cdk.utils.datetime_helpers import AirbyteDateTime, ab_datetime_now, ab_datetime_parse
 
 LOGGER = logging.getLogger(__name__)
@@ -662,8 +664,8 @@ class TestOauth2Authenticator:
             refresh_token_error_values=("invalid_grant", "invalid_client"),
         )
 
-    # Sits at the very end of each provider payload below, past the point where the user-facing
-    # message is truncated, so it can only be found in the internal message.
+    # Sits on a later line of each provider payload below, like the trace ids and timestamps
+    # Microsoft Entra appends, so it must reach the internal message and never the user-facing one.
     trailing_marker = "Correlation ID: 11111111-2222-3333-4444-555555555555"
 
     @pytest.mark.parametrize(
@@ -673,7 +675,7 @@ class TestOauth2Authenticator:
                 # Grant revoked, e.g. the user changed their password: re-authentication is the fix.
                 "invalid_grant",
                 "AADSTS50173: The provided grant has expired due to it being revoked, a fresh auth "
-                "grant is needed. The user might have changed or reset their password.\r\n"
+                "token is needed. The user might have changed or reset their password.\r\n"
                 "Trace ID: 00000000-0000-0000-0000-000000000000\r\n" + trailing_marker,
                 "AADSTS50173",
             ),
@@ -681,7 +683,7 @@ class TestOauth2Authenticator:
                 # Client type / credential misconfiguration: re-authentication will not help.
                 "invalid_client",
                 "AADSTS7000218: The request body must contain the following parameter: "
-                "'client_assertion' or a client credential.\r\n" + trailing_marker,
+                "'client_assertion' or 'client_secret'.\r\n" + trailing_marker,
                 "AADSTS7000218",
             ),
             (
@@ -720,6 +722,9 @@ class TestOauth2Authenticator:
         # ... followed by a short, single-line provider detail carrying the error code.
         assert f"Provider error: {error}: {expected_code}" in exc_info.value.message
         assert "\n" not in exc_info.value.message and "\r" not in exc_info.value.message
+        # Later lines of the description (trace ids, timestamps) stay out of the user-facing message,
+        # so the same failure produces the same message on every attempt.
+        assert TestOauth2Authenticator.trailing_marker not in exc_info.value.message
         assert exc_info.value.failure_type == FailureType.config_error
 
     def test_refresh_access_token_truncates_long_provider_error_detail(self, requests_mock):
@@ -737,21 +742,31 @@ class TestOauth2Authenticator:
         provider_detail = exc_info.value.message.split("Provider error: ", 1)[1]
         assert provider_detail.startswith("invalid_grant: AADSTS50173: ")
         assert provider_detail.endswith("...")
-        assert len(provider_detail) < 250
+        assert len(provider_detail) == _PROVIDER_ERROR_DETAIL_MAX_LENGTH + len("...")
         assert len(exc_info.value.internal_message) < 1200
 
     def test_refresh_access_token_redacts_credentials_from_provider_error(self, requests_mock):
         """A provider that echoes the submitted credentials must not leak them into the error."""
-        oauth = self._entra_style_authenticator()
+        # Start from no config-level secrets: earlier tests register values such as "token" through
+        # add_to_secrets, which would otherwise mask the credentials on their own.
+        update_secrets([])
+        refresh_token = "0.AXoA-rt-9f3ZqW7kP2"
+        client_secret = "s3cr3t~Xyz-1Qp"
+        oauth = Oauth2Authenticator(
+            f"https://{TestOauth2Authenticator.refresh_endpoint}",
+            TestOauth2Authenticator.client_id,
+            client_secret,
+            refresh_token,
+            refresh_token_error_status_codes=(400,),
+            refresh_token_error_key="error",
+            refresh_token_error_values=("invalid_grant",),
+        )
         requests_mock.post(
             f"https://{TestOauth2Authenticator.refresh_endpoint}",
             status_code=400,
             json={
                 "error": "invalid_grant",
-                "error_description": (
-                    f"AADSTS50173: rejected refresh_token={TestOauth2Authenticator.refresh_token} "
-                    f"client_secret={TestOauth2Authenticator.client_secret}"
-                ),
+                "error_description": f"AADSTS50173: rejected rt={refresh_token} cs={client_secret}",
             },
         )
 
@@ -759,9 +774,9 @@ class TestOauth2Authenticator:
             oauth.refresh_access_token()
 
         for message in (exc_info.value.message, exc_info.value.internal_message):
-            assert TestOauth2Authenticator.refresh_token not in message
-            assert TestOauth2Authenticator.client_secret not in message
-            assert "****" in message
+            assert refresh_token not in message
+            assert client_secret not in message
+            assert message.count("****") == 2
         assert "AADSTS50173" in exc_info.value.message
 
     @pytest.mark.parametrize(

--- a/unit_tests/sources/streams/http/requests_native_auth/test_requests_native_auth.py
+++ b/unit_tests/sources/streams/http/requests_native_auth/test_requests_native_auth.py
@@ -4,6 +4,7 @@
 
 import json
 import logging
+import re
 import threading
 import time
 from datetime import timedelta
@@ -727,7 +728,8 @@ class TestOauth2Authenticator:
         assert TestOauth2Authenticator.trailing_marker not in exc_info.value.message
         assert exc_info.value.failure_type == FailureType.config_error
 
-    def test_refresh_access_token_truncates_long_provider_error_detail(self, requests_mock):
+    def test_refresh_access_token_omits_description_prose(self, requests_mock):
+        """Only the provider code is surfaced; the surrounding prose never reaches the user."""
         oauth = self._entra_style_authenticator()
         error_description = "AADSTS50173: " + ("x" * 5000)
         requests_mock.post(
@@ -739,11 +741,47 @@ class TestOauth2Authenticator:
         with pytest.raises(AirbyteTracedException) as exc_info:
             oauth.refresh_access_token()
 
-        provider_detail = exc_info.value.message.split("Provider error: ", 1)[1]
-        assert provider_detail.startswith("invalid_grant: AADSTS50173: ")
-        assert provider_detail.endswith("...")
-        assert len(provider_detail) == _PROVIDER_ERROR_DETAIL_MAX_LENGTH + len("...")
+        assert exc_info.value.message.endswith("Provider error: invalid_grant: AADSTS50173")
+        assert "xxx" not in exc_info.value.message
         assert len(exc_info.value.internal_message) < 1200
+
+    def test_provider_error_detail_is_capped(self, requests_mock):
+        """The `error` field is not always the gated one, so it stays provider-controlled.
+
+        `_wrap_refresh_token_exception` gates on `refresh_token_error_key`, but the user-facing
+        detail always reads the RFC 6749 `error` field. A connector configured against a different
+        key (Okta's `errorCode`, here) therefore admits an arbitrary `error` value, which is what
+        the cap bounds.
+
+        The expected length is written as a literal rather than derived from the imported
+        constant, so raising the cap fails this test instead of silently redefining it.
+        """
+        oauth = Oauth2Authenticator(
+            f"https://{TestOauth2Authenticator.refresh_endpoint}",
+            TestOauth2Authenticator.client_id,
+            TestOauth2Authenticator.client_secret,
+            TestOauth2Authenticator.refresh_token,
+            refresh_token_error_status_codes=(400,),
+            refresh_token_error_key="errorCode",
+            refresh_token_error_values=("invalid_grant",),
+        )
+        requests_mock.post(
+            f"https://{TestOauth2Authenticator.refresh_endpoint}",
+            status_code=400,
+            json={
+                "errorCode": "invalid_grant",
+                "error": "e" * 500,
+                "error_description": "AADSTS50173: y",
+            },
+        )
+
+        with pytest.raises(AirbyteTracedException) as exc_info:
+            oauth.refresh_access_token()
+
+        provider_detail = exc_info.value.message.split("Provider error: ", 1)[1]
+        assert provider_detail.endswith("...")
+        assert len(provider_detail) == 67  # 64-char cap + the "..." marker
+        assert len(provider_detail) == _PROVIDER_ERROR_DETAIL_MAX_LENGTH + len("...")
 
     def test_refresh_access_token_redacts_credentials_from_provider_error(self, requests_mock):
         """A provider that echoes the submitted credentials must not leak them into the error."""
@@ -776,8 +814,12 @@ class TestOauth2Authenticator:
         for message in (exc_info.value.message, exc_info.value.internal_message):
             assert refresh_token not in message
             assert client_secret not in message
-            assert message.count("****") == 2
-        assert "AADSTS50173" in exc_info.value.message
+        # The internal message keeps the echoed body, with both credentials redacted.
+        assert exc_info.value.internal_message.count("****") == 2
+        # The user-facing message never carries description prose, so there is nothing to redact:
+        # credential echo-back is structurally impossible there, not merely masked.
+        assert "****" not in exc_info.value.message
+        assert exc_info.value.message.endswith("Provider error: invalid_grant: AADSTS50173")
 
     @pytest.mark.parametrize(
         "response_kwargs",
@@ -801,6 +843,134 @@ class TestOauth2Authenticator:
 
         with pytest.raises(RequestException):
             oauth.refresh_access_token()
+
+    def _message_for_description(self, requests_mock, error_description):
+        oauth = self._entra_style_authenticator()
+        requests_mock.post(
+            f"https://{TestOauth2Authenticator.refresh_endpoint}",
+            status_code=400,
+            json={"error": "invalid_grant", "error_description": error_description},
+        )
+        with pytest.raises(AirbyteTracedException) as exc_info:
+            oauth.refresh_access_token()
+        return exc_info.value.message
+
+    # AADSTS700082 embeds the token issue timestamp in the *first sentence* of the description,
+    # so no first-line rule and no character cap can separate it from the stable text.
+    _AADSTS700082 = (
+        "AADSTS700082: The refresh token has expired due to inactivity. The token was issued "
+        "on {issued} and was inactive for 90.00:00:00."
+    )
+
+    def test_same_failure_produces_identical_message_across_attempts(self, requests_mock):
+        """The grouping property: per-request values must not vary the user-facing message."""
+        first = self._message_for_description(
+            requests_mock, self._AADSTS700082.format(issued="2026-06-11T03:14:07.000Z")
+        )
+        second = self._message_for_description(
+            requests_mock, self._AADSTS700082.format(issued="2026-07-29T22:01:52.000Z")
+        )
+        assert first == second
+        assert "AADSTS700082" in first
+
+    def test_timestamp_in_first_sentence_never_reaches_message(self, requests_mock):
+        """A per-request value inside the first sentence, with no later lines to fall back on."""
+        message = self._message_for_description(
+            requests_mock, self._AADSTS700082.format(issued="2026-06-11T03:14:07.000Z")
+        )
+        assert "AADSTS700082" in message
+        assert re.search(r"\d{4}-\d{2}-\d{2}T", message) is None
+
+    def test_trace_id_under_the_cap_never_reaches_message(self, requests_mock):
+        """A short payload whose trace id sits below the cap, so the cap alone cannot remove it."""
+        message = self._message_for_description(
+            requests_mock,
+            "AADSTS50173: grant revoked.\r\nTrace ID: 00000000-0000-0000-0000-000000000000",
+        )
+        assert "AADSTS50173" in message
+        assert "Trace ID" not in message
+
+    def test_provider_code_is_only_read_from_the_start_of_the_description(self, requests_mock):
+        """The code pattern is anchored: a code mentioned mid-prose is not the failure's own code.
+
+        Kills the `match` -> `search` mutant. Matching anywhere would let a code named inside a
+        sentence (a doc reference, a nested provider error) become the grouping key.
+        """
+        message = self._message_for_description(
+            requests_mock, "Something went wrong; see AADSTS50173 in the documentation."
+        )
+        assert message.endswith("Provider error: invalid_grant")
+        assert "AADSTS50173" not in message
+
+    def test_credential_extracted_as_a_provider_code_is_redacted(self, requests_mock):
+        """A code-shaped refresh token leading the description is extracted, so it must be masked."""
+        update_secrets([])
+        refresh_token = "RTOKEN1234567890"
+        oauth = Oauth2Authenticator(
+            f"https://{TestOauth2Authenticator.refresh_endpoint}",
+            TestOauth2Authenticator.client_id,
+            TestOauth2Authenticator.client_secret,
+            refresh_token,
+            refresh_token_error_status_codes=(400,),
+            refresh_token_error_key="error",
+            refresh_token_error_values=("invalid_grant",),
+        )
+        requests_mock.post(
+            f"https://{TestOauth2Authenticator.refresh_endpoint}",
+            status_code=400,
+            json={"error": "invalid_grant", "error_description": f"{refresh_token} was rejected."},
+        )
+
+        with pytest.raises(AirbyteTracedException) as exc_info:
+            oauth.refresh_access_token()
+
+        assert refresh_token not in exc_info.value.message
+        assert exc_info.value.message.endswith("Provider error: invalid_grant: ****")
+
+    def test_provider_code_requires_a_word_boundary(self, requests_mock):
+        """`AADSTS50173abc` is a longer identifier, not the code `AADSTS50173`."""
+        message = self._message_for_description(requests_mock, "AADSTS50173abc: not a code.")
+        assert message.endswith("Provider error: invalid_grant")
+        assert "AADSTS50173" not in message
+
+    def test_credentials_echoed_in_the_error_field_are_redacted(self, requests_mock):
+        """The `error` field is ungated when the connector keys off a different field.
+
+        Kills the mutant that drops `_redact_credentials` from the user-facing detail: the code and
+        the gated error token are safe by construction, but this field is not.
+        """
+        update_secrets([])
+        refresh_token = "0.AXoA-rt-9f3ZqW7kP2"
+        oauth = Oauth2Authenticator(
+            f"https://{TestOauth2Authenticator.refresh_endpoint}",
+            TestOauth2Authenticator.client_id,
+            TestOauth2Authenticator.client_secret,
+            refresh_token,
+            refresh_token_error_status_codes=(400,),
+            refresh_token_error_key="errorCode",
+            refresh_token_error_values=("invalid_grant",),
+        )
+        requests_mock.post(
+            f"https://{TestOauth2Authenticator.refresh_endpoint}",
+            status_code=400,
+            json={
+                "errorCode": "invalid_grant",
+                "error": f"rejected {refresh_token}",
+                "error_description": "AADSTS50173: revoked.",
+            },
+        )
+
+        with pytest.raises(AirbyteTracedException) as exc_info:
+            oauth.refresh_access_token()
+
+        assert refresh_token not in exc_info.value.message
+        assert "****" in exc_info.value.message
+
+    def test_description_without_provider_code_falls_back_to_error_token(self, requests_mock):
+        """Providers that return prose with no code still get the RFC 6749 error token."""
+        message = self._message_for_description(requests_mock, "Token has been expired or revoked.")
+        assert message.endswith("Provider error: invalid_grant")
+        assert "revoked." not in message
 
     def test_refresh_access_token_without_error_fields_keeps_bare_guidance(self, requests_mock):
         """No usable provider detail means the user-facing message is left exactly as before."""


### PR DESCRIPTION
## What

When an OAuth refresh request is rejected, `AbstractOauth2Authenticator._make_handled_request` raised an `AirbyteTracedException` whose user-facing message was one fixed sentence, and it threw away the provider's own diagnostic. `_wrap_refresh_token_exception` had already parsed the error body with `exception.response.json()` in order to decide whether the failure was a refresh-token failure, and then discarded that parsed body.

That matters most for Microsoft Entra, where the body carries an AADSTS code that separates root causes needing completely different fixes:

- `AADSTS50173` — the grant was revoked, typically because the user changed or reset their password. Re-authenticating is the fix.
- `AADSTS7000218` / `AADSTS700025` — the app registration's client type or client credential is misconfigured. Re-authenticating does not help; the app registration has to change.
- `AADSTS50076` / `AADSTS50078` / `AADSTS700082` — Conditional Access requires an interactive sign-in or MFA. Again a different fix, and one the workspace admin has to make.

Today all three collapse into the same string. Across 300 sampled production failure summaries for source-bing-ads, zero contain an AADSTS code, so support has no way to tell these apart from the failure summary. See airbytehq/oncall#12835.

## How

- The error body is parsed once, in `_make_handled_request`, and passed into `_wrap_refresh_token_exception` through a new optional `response_content` argument, so the response is no longer parsed twice. The argument defaults to `None` and the method parses on demand when it is absent, so existing callers keep working.
- `internal_message` carries the full provider response (`HTTP <status>: <body>`, truncated at 1000 characters), so the whole payload lands in the logs.
- The user-facing `message` deliberately keeps the existing actionable sentence as its lead: "Refresh token was rejected by the OAuth provider (invalid, expired, or already used). Re-authenticate this source's credentials in its connection settings." Only after that is a short provider detail appended, as `Provider error: <error>: <error_description>`, built from the standard OAuth 2.0 `error` and `error_description` fields, collapsed to a single line and truncated at 200 characters. Two hundred characters is enough to keep the `AADSTS<code>` and the beginning of its description, since Entra puts the code at the front of `error_description`, while staying short enough that the failure summary is still readable. No raw provider blob becomes the primary message, and when the body has no usable `error` / `error_description` the message is byte-for-byte what it was before.
- Bodies that are empty, non-JSON, or valid JSON but not an object now resolve to "no parsed content" rather than raising. Previously a JSON array body would have hit `AttributeError` on `.get(...)` inside the already-failing error path.
- Everything surfaced, in both the user-facing and the internal message, is run through `filter_secrets`, and the authenticator's own refresh token and client secret are redacted explicitly on top of that, in case a provider echoes submitted credentials back in its payload. Only response bodies are read, so request headers, including `Authorization`, are never echoed.

No changelog entry or version bump is included: `CONTRIBUTING.md` states releases are drafted automatically by `semantic-pr-release-drafter` from the PR title, and the package version is computed by `poetry-dynamic-versioning`. `CHANGELOG.md` is frozen and points at GitHub Release Notes.

## Test plan

New tests in `unit_tests/sources/streams/http/requests_native_auth/test_requests_native_auth.py`:

- a parametrized test over the three Entra failure modes above, asserting that the AADSTS code and the full response body reach `internal_message` while `message` still starts with the re-authenticate guidance and then carries the provider code on a single line;
- truncation of an oversized `error_description`;
- redaction, using a payload that echoes the refresh token and client secret back;
- empty, HTML, and JSON-array bodies falling back to the raw `RequestException` instead of raising something new;
- a provider whose body has no `error` / `error_description`, asserting the user-facing message is exactly the unchanged sentence.

The existing `test_refresh_access_token_wrapped` assertion on `message` was relaxed from equality to `startswith`, since the wrapped case now appends `Provider error: invalid_grant`.

This repo is Poetry-managed, so `uv run pytest` cannot resolve the dev dependencies; the tests were run with the project's Poetry virtualenv:

```
$ python -m pytest unit_tests/sources/streams/http/requests_native_auth/ -q
======================== 49 passed, 3 warnings in 0.86s ========================

$ python -m pytest unit_tests/sources/declarative/auth -q
======================= 166 passed, 3 warnings in 34.80s =======================

$ ruff check airbyte_cdk/sources/streams/http/requests_native_auth/abstract_oauth.py unit_tests/sources/streams/http/requests_native_auth/test_requests_native_auth.py
All checks passed!

$ ruff format --check airbyte_cdk/sources/streams/http/requests_native_auth/abstract_oauth.py unit_tests/sources/streams/http/requests_native_auth/test_requests_native_auth.py
2 files already formatted

$ mypy --config-file mypy.ini airbyte_cdk/sources/streams/http/requests_native_auth/abstract_oauth.py
Success: no issues found in 1 source file
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Update — 2026-09-03 (added by @ZaneHyattAB on @tolik0's behalf)

@tolik0 is out, and this PR now carries commit `6d5e37c9` applying
@bazarnov's review feedback. **Everything above is @tolik0's original text,
left as written.** The points below supersede it where they conflict; the
original wording is kept for context rather than rewritten.

1. **The user-facing detail is now the first line of `error_description`
   only, capped at 120 characters** (was: single-line collapse, 200
   characters). Entra appends `Trace ID`, `Correlation ID` and `Timestamp` on
   later lines and embeds per-request issue dates in the first sentence, so
   collapsing whitespace pulled per-request GUIDs into the message. Every
   attempt then produced a distinct ~375-character string, which defeats
   grouping by failure summary — the capability this PR exists to provide.
   After the change the message is a stable ~295 characters per error code,
   with the full body still in `internal_message`.

2. **`AADSTS700082` is regrouped.** It is
   `ExpiredOrRevokedGrantInactiveToken` — refresh-token expiry after
   inactivity — so it belongs with the expired/revoked group above, not with
   Conditional Access.

3. **Reachability caveat added.** On the declarative defaults
   `source-bing-ads` runs (`(400,)` / `"error"` /
   `("invalid_grant", "invalid_permissions")`), `invalid_client`
   (`AADSTS7000218`, `AADSTS700025`) and `interaction_required`
   (`AADSTS50078`) never reach this path and surface as raw HTTP errors.

4. **Only string values are read**, so a provider nesting the error object no
   longer renders a dict repr into the message.

5. **The redaction test now actually tests the redaction.** It uses distinct
   credential values and calls `update_secrets([])` first, because secrets
   registered by earlier tests were masking the credentials on their own —
   the previous test passed even with the explicit pair redaction disabled.
   Verified by disabling that redaction and confirming the test fails.

6. **New declarative-authenticator test** at
   `unit_tests/sources/declarative/auth/test_oauth.py`, covering the path
   manifest-only connectors such as `source-bing-ads` actually run.

**Retracted:** the "300 sampled production failure summaries" figure above is
not sourced in airbytehq/oncall#12835 and should not be relied on. The
verified claim is narrower: a deliberately revoked Bing Ads token on `3.0.7`
produced a 95-line `check` log containing **zero** AADSTS codes, and the same
token on a preview build of this PR surfaced the code.

Validation on `6d5e37c9`: 216 targeted tests pass, `ruff` and `mypy` clean.
Additionally validated end to end in Airbyte Cloud on a genuinely revoked
token — see airbytehq/oncall#12835.

@tolik0, please adjust or fold this in as you see fit when you're back.


## Update — 2026-09-09: provider detail is now the code only (`1216c9d2`)

Supersedes the `<error>: <error_description>` format in "How" above (single line, 200 characters) and point 1 of the 2026-09-03 update (first line, 120 characters). Neither was deterministic for every Entra code: `AADSTS700082` carries the token issue timestamp in its *first sentence*, so no line rule or character cap can make it stable ([analysis](https://github.com/airbytehq/airbyte-python-cdk/pull/1138#discussion_r3936030689)).

What ships in `1216c9d2`:

- The user-facing detail is `Provider error: <error>[: <provider code>]`, where the code is `^[A-Za-z]{3,}\d{4,}\b` matched against the start of `error_description` (e.g. `AADSTS700082`). No description prose is ever appended, so the same failure produces a byte-identical message on every attempt ([rationale](https://github.com/airbytehq/airbyte-python-cdk/blob/1216c9d2a9ce322d52799e722790afcb01721ef0/airbyte_cdk/sources/streams/http/requests_native_auth/abstract_oauth.py#L299-L313)).
- Providers whose `error_description` is prose (Google, Salesforce, GitLab, Airtable, Harvest, ...) get `Provider error: <error>` only; the full body is still in `internal_message`, now redacted as well.
- `_PROVIDER_ERROR_DETAIL_MAX_LENGTH` is 64 (both `error` and the code are provider-controlled). The cap test asserts the literal length so the constant is pinned.
- New tests: first-sentence timestamp with no later lines, `\r\n` trace id under the cap, the same code with two different issue dates asserting equal `message`, and a word-boundary check for the code pattern.

Residual theoretical case, no change requested: a provider whose `error_description` leads with a hex/GUID-like token would surface that token as the "code"; none of the providers with fixtures in the monorepo does, and the value is still redacted and capped.


Link to Devin session: https://app.devin.ai/sessions/51216c43280840fba9342c4cec3cd435
Open in Devin Desktop: https://app.devin.ai/desktop/session/51216c43280840fba9342c4cec3cd435?variant=devin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved OAuth refresh-token error messages by showing concise provider error codes and relevant details.
  - Redacted refresh tokens, client secrets, and other credentials from both user-facing and diagnostic messages.
  - Prevented lengthy provider responses, trace IDs, and timestamps from cluttering user-facing errors.
  - Improved handling of non-JSON error responses by preserving the underlying request error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->