### PR TITLE
chore: bump SDM base image to python-connector-base 4.1.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # A new version of source-declarative-manifest is built for every new Airbyte CDK release, and their versions are kept in sync.
 #
 
-FROM docker.io/airbyte/python-connector-base:4.1.0@sha256:1d1aa21d34e851df4e8a87b391c27724c06e2597608e7161f4d167be853bd7b6
+FROM docker.io/airbyte/python-connector-base:4.1.1@sha256:a268b44c733ae699a60f5fbc06a324945dba98945c6e2ab7f8609f2f895b0d28
 
 WORKDIR /airbyte/integration_code
 


### PR DESCRIPTION
## What

Bumps the `python-connector-base` pin in the root `Dockerfile` from `4.1.0` to `4.1.1`.

```diff
-FROM docker.io/airbyte/python-connector-base:4.1.0@sha256:1d1aa21d34e851df4e8a87b391c27724c06e2597608e7161f4d167be853bd7b6
+FROM docker.io/airbyte/python-connector-base:4.1.1@sha256:a268b44c733ae699a60f5fbc06a324945dba98945c6e2ab7f8609f2f895b0d28
```

`4.1.1` was released 2026-07-22 in airbytehq/airbyte#80337 (Python `3.13.9-slim-bookworm` → `3.13.14-slim-bookworm`). The SDM pin has been on `4.1.0` since 2025-10-23 (#805), so SDM has not picked it up — `source-declarative-manifest:7.28.3`, published 2026-08-28, still carries the `4.1.0` package set.

## Why

Three critical OS CVEs are currently open against SDM-rooted connectors and are fixed by this bump. Package versions below were read out of the published images with `crane export` (`var/lib/dpkg/status`), and required versions come from the Debian security tracker.

| Oncall issue | CVE | Package | SDM 7.28.3 today | Fix requires | base 4.1.1 |
| --- | --- | --- | --- | --- | --- |
| [#11792](https://github.com/airbytehq/oncall/issues/11792) | CVE-2025-14087 | libglib2.0-0 | `2.74.6-2+deb12u7` | `deb12u8` | `2.74.6-2+deb12u9` ✅ |
| [#11793](https://github.com/airbytehq/oncall/issues/11793) | CVE-2026-2781 | libnss3 | `2:3.87.1-1+deb12u1` | `deb12u2` (DSA-6149-1) | `2:3.87.1-1+deb12u3` ✅ |
| [#12959](https://github.com/airbytehq/oncall/issues/12959) | CVE-2026-45447 | libssl3 / openssl | `3.0.17-1~deb12u3` | `3.0.20-1~deb12u2` | `3.0.20-1~deb12u2` ✅ |

Also picks up `libxml2` `deb12u4` → `deb12u6` and `poppler-utils` `deb12u1` → `deb12u2`, and drops the vulnerable `virtualenv/seed/wheels/embed/wheel-*.whl` (GHSA-8rrh-rw8j-w5fx).

Blast radius: 512 of the 655 connectors in the OSS registry are SDM-rooted, so this is the single highest-leverage change for these three CVEs.

## What this does *not* fix

- `setuptools` stays at `78.1.1` in the base image, below the `83.0.0` that CVE-2026-59890 needs ([#13315](https://github.com/airbytehq/oncall/issues/13315)). That needs a new base image release plus widening `setuptools = "^80.9.0"` in `pyproject.toml`.
- `nltk` `3.9.1` ([#11795](https://github.com/airbytehq/oncall/issues/11795), needs `3.9.3`) and `unstructured` `0.10.27` ([#11267](https://github.com/airbytehq/oncall/issues/11267), needs `0.18.18`) are CDK Python dependencies, untouched here.

## Notes for the reviewer

- Per `docs/RELEASES.md` (added in #1140), merging this publishes nothing — the new SDM image only ships with the next CDK release.
- #327 warned that a base image bump should be treated as breaking, since Cloud connections auto-update to the new base. That was written for the 3.9 → 3.11 jump; this one is a Python patch bump (`3.13.9` → `3.13.14`) plus Debian security patches, so a major CDK bump is likely unnecessary — but worth a second opinion from whoever owns the [connector base images runbook](https://internal.airbyte.ai/docs/internal-docs/teams/apis/data-replication/runbooks/connector-base-images).
- The digest is the multi-arch OCI index digest (`linux/amd64` + `linux/arm64`), matching the convention of the existing pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application’s container base image to the latest 4.1.1 release for improved maintenance and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->